### PR TITLE
CI Test Check for Style guidelines using Spotless plugin

### DIFF
--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -1,3 +1,19 @@
+##
+# Copyright (C) 2024 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
 name: Spotless Check
 
 on: [pull_request]

--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Expand Shallow Clone for Spotless
+        run: |
+          if [ -f .git/shallow ]; then
+            git fetch --unshallow --no-recurse-submodules
+          else
+            echo "Repository is not shallow, no need to unshallow."
+          fi
+
       - name: Set up JDK 21
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
         with:

--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -1,0 +1,43 @@
+name: Spotless Check
+
+on: [pull_request]
+
+jobs:
+  spotless:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@17d0e2bd7d51742c71671bd19fa12bdc9d40a3d6 # v2.8.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Spotless Check
+        run: |
+          ./gradlew spotlessCheck
+          if [ $? -ne 0 ]; then
+            echo "Spotless found formatting issues. Please run './gradlew spotlessApply' to fix them."
+            exit 1
+          fi
+        continue-on-error: false


### PR DESCRIPTION

**Description**:
Add a CI Test that checks that the spotless check passes, otherwise it will fail and recommend to run the following command:
```
./gradlew spotlessApply
```

**Related issue(s)**:

Fixes #31 

**Notes for reviewer**:
Raised another PR with the same exact changes, but added another commit with a modification of style so to force the failure of the check.

see here:
https://github.com/hashgraph/hedera-block-node/pull/42
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
