### PR TITLE
ci: Fix Image publish GHA WF to provide build-arg and build-context to dockerfile.

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -108,4 +108,4 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
           build-contexts: |
-            distributions=../build/distributions
+            distributions=./server/build/distributions

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -89,6 +89,12 @@ jobs:
         with:
           driver-opts: network=host
 
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(grep 'version=' gradle.properties | cut -d '=' -f2)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
       - name: Build and push image
         uses: docker/build-push-action@1ca370b3a9802c92e886402e0dd88098a2533b12 # v6.4.1
         with:
@@ -99,3 +105,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{ env.TAG }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          build-contexts: |
+            distributions=../build/distributions


### PR DESCRIPTION
**Description**:
Dockerfile needs build-context distributions and build-arg Version in order to sucessfully build and work as expected.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
