### PR TITLE
refactor: configuration to use Platform SDK across all project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ gradle-app.setting
 .DS_Store
 # .env files
 server/docker/.env
+/server/data/

--- a/README.md
+++ b/README.md
@@ -30,19 +30,17 @@ Please do not file a public ticket mentioning the vulnerability. Refer to the se
 
 ---
 
-# Running Locally
+# Configuration
 
-1) Create a local temp directory.  For example, use `mktemp -d -t block-stream-temp-dir` to create a directory
-2) Configuration variables
-```
-export BLOCKNODE_STORAGE_ROOT_PATH=<path to the temp directory> # You can add this to your .zshrc, etc
-```
-3) Optional Configuration variables
-```
-export BLOCKNODE_SERVER_CONSUMER_TIMEOUT_THRESHOLD="<NumberInMiliseconds>" #Default is 1500
-```
+| Environment Variable            | Description                                                                                                   | Default Value |
+|---------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|
+| persistence.storage.rootPath    | The root path for the storage, if not provided will attempt to create a `data` on the working dir of the app. | ./data        |
+| consumer.timeoutThresholdMillis | Time to wait for subscribers before disconnecting in milliseconds                                             | 1500          |
 
-3) ./gradlew run  # ./gradlew run --debug-jvm to run in debug mode
+3) To run in debug mode:
+```bash
+./gradlew run  # ./gradlew run --debug-jvm to run in debug mode
+```
 
 # Running Tests
 1) ./gradlew build

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please do not file a public ticket mentioning the vulnerability. Refer to the se
 
 
 
-# Staring locally:
+# Starting locally:
 ```bash
 ./gradlew run
 ```

--- a/README.md
+++ b/README.md
@@ -30,16 +30,30 @@ Please do not file a public ticket mentioning the vulnerability. Refer to the se
 
 ---
 
-# Configuration
+# Usage
+
+## Configuration
 
 | Environment Variable            | Description                                                                                                   | Default Value |
 |---------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|
 | persistence.storage.rootPath    | The root path for the storage, if not provided will attempt to create a `data` on the working dir of the app. | ./data        |
 | consumer.timeoutThresholdMillis | Time to wait for subscribers before disconnecting in milliseconds                                             | 1500          |
 
-3) To run in debug mode:
+
+
+# Staring locally:
 ```bash
-./gradlew run  # ./gradlew run --debug-jvm to run in debug mode
+./gradlew run
+```
+
+In debug mode, you can attach a debugger to the port 5005.
+```bash
+./gradlew run --debug-jvm
+```
+
+Also you can run on docker locally:
+```bash
+./gradlew startDockerContainer
 ```
 
 # Running Tests

--- a/server/src/main/java/com/hedera/block/server/BlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/BlockStreamService.java
@@ -21,7 +21,6 @@ import static com.hedera.block.server.Constants.*;
 
 import com.google.protobuf.Descriptors;
 import com.hedera.block.server.config.BlockNodeContext;
-import com.hedera.block.server.consumer.ConsumerConfig;
 import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.StreamMediator;
@@ -139,8 +138,7 @@ public class BlockStreamService implements GrpcService {
             @NonNull
             final var streamObserver =
                     new ConsumerStreamResponseObserver(
-                            // TODO, send the context anyway.
-                            blockNodeContext.configuration().getConfigData(ConsumerConfig.class),
+                            blockNodeContext,
                             Clock.systemDefaultZone(),
                             streamMediator,
                             subscribeStreamResponseObserver);

--- a/server/src/main/java/com/hedera/block/server/BlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/BlockStreamService.java
@@ -139,6 +139,7 @@ public class BlockStreamService implements GrpcService {
             @NonNull
             final var streamObserver =
                     new ConsumerStreamResponseObserver(
+                            // TODO, send the context anyway.
                             blockNodeContext.configuration().getConfigData(ConsumerConfig.class),
                             Clock.systemDefaultZone(),
                             streamMediator,

--- a/server/src/main/java/com/hedera/block/server/Constants.java
+++ b/server/src/main/java/com/hedera/block/server/Constants.java
@@ -22,15 +22,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public final class Constants {
     private Constants() {}
 
-    /** Constant mapped to the root path config key where the block files are stored */
-    @NonNull
-    public static final String BLOCKNODE_STORAGE_ROOT_PATH_KEY = "blocknode.storage.root.path";
-
-    /** Constant mapped to the timeout for stream consumers in milliseconds */
-    @NonNull
-    public static final String BLOCKNODE_SERVER_CONSUMER_TIMEOUT_THRESHOLD_KEY =
-            "blocknode.server.consumer.timeout.threshold";
-
     /** Constant mapped to the name of the service in the .proto file */
     @NonNull public static final String SERVICE_NAME = "BlockStreamGrpcService";
 

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -54,10 +54,6 @@ public class Server {
             // init context, metrics, and configuration.
             @NonNull final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
 
-            // Set the global configuration
-            // @NonNull final Config config = Config.create();
-            // Config.global(config);
-
             @NonNull final ServiceStatus serviceStatus = new ServiceStatusImpl();
 
             @NonNull

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -17,7 +17,6 @@
 package com.hedera.block.server;
 
 import static com.hedera.block.protos.BlockStreamService.*;
-import static com.hedera.block.server.Constants.BLOCKNODE_SERVER_CONSUMER_TIMEOUT_THRESHOLD_KEY;
 import static com.hedera.block.server.Constants.BLOCKNODE_STORAGE_ROOT_PATH_KEY;
 
 import com.hedera.block.server.config.BlockNodeContext;
@@ -112,12 +111,7 @@ public class Server {
             @NonNull final ServiceStatus serviceStatus,
             @NonNull final BlockNodeContext blockNodeContext) {
 
-        // Get Timeout threshold from configuration
-        final long consumerTimeoutThreshold =
-                config.get(BLOCKNODE_SERVER_CONSUMER_TIMEOUT_THRESHOLD_KEY).asLong().orElse(1500L);
-
         return new BlockStreamService(
-                consumerTimeoutThreshold,
                 new ItemAckBuilder(),
                 streamMediator,
                 blockReader,

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -112,10 +112,6 @@ public class Server {
             @NonNull final BlockNodeContext blockNodeContext) {
 
         return new BlockStreamService(
-                new ItemAckBuilder(),
-                streamMediator,
-                blockReader,
-                serviceStatus,
-                blockNodeContext);
+                new ItemAckBuilder(), streamMediator, blockReader, serviceStatus, blockNodeContext);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -17,20 +17,19 @@
 package com.hedera.block.server;
 
 import static com.hedera.block.protos.BlockStreamService.*;
-import static com.hedera.block.server.Constants.BLOCKNODE_STORAGE_ROOT_PATH_KEY;
 
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.LiveStreamMediatorBuilder;
 import com.hedera.block.server.mediator.StreamMediator;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.read.BlockAsDirReaderBuilder;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
 import com.hedera.block.server.producer.ItemAckBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.helidon.config.Config;
 import io.helidon.webserver.WebServer;
 import io.helidon.webserver.grpc.GrpcRouting;
 import java.io.IOException;
@@ -56,16 +55,14 @@ public class Server {
             @NonNull final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
 
             // Set the global configuration
-            @NonNull final Config config = Config.create();
-            Config.global(config);
+            // @NonNull final Config config = Config.create();
+            // Config.global(config);
 
             @NonNull final ServiceStatus serviceStatus = new ServiceStatusImpl();
 
             @NonNull
             final BlockWriter<BlockItem> blockWriter =
-                    BlockAsDirWriterBuilder.newBuilder(
-                                    BLOCKNODE_STORAGE_ROOT_PATH_KEY, config, blockNodeContext)
-                            .build();
+                    BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
             @NonNull
             final StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> streamMediator =
                     LiveStreamMediatorBuilder.newBuilder(
@@ -74,13 +71,16 @@ public class Server {
 
             @NonNull
             final BlockReader<Block> blockReader =
-                    BlockAsDirReaderBuilder.newBuilder(BLOCKNODE_STORAGE_ROOT_PATH_KEY, config)
+                    BlockAsDirReaderBuilder.newBuilder(
+                                    blockNodeContext
+                                            .configuration()
+                                            .getConfigData(PersistenceStorageConfig.class))
                             .build();
 
             @NonNull
             final BlockStreamService blockStreamService =
                     buildBlockStreamService(
-                            config, streamMediator, blockReader, serviceStatus, blockNodeContext);
+                            streamMediator, blockReader, serviceStatus, blockNodeContext);
 
             @NonNull
             final GrpcRouting.Builder grpcRouting =
@@ -103,7 +103,6 @@ public class Server {
 
     @NonNull
     private static BlockStreamService buildBlockStreamService(
-            @NonNull final Config config,
             @NonNull
                     final StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>>
                             streamMediator,

--- a/server/src/main/java/com/hedera/block/server/config/BlockNodeConfigExtension.java
+++ b/server/src/main/java/com/hedera/block/server/config/BlockNodeConfigExtension.java
@@ -17,6 +17,8 @@
 package com.hedera.block.server.config;
 
 import com.google.auto.service.AutoService;
+import com.hedera.block.server.consumer.ConsumerConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.swirlds.common.config.BasicCommonConfig;
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
@@ -28,6 +30,11 @@ import java.util.Set;
 @AutoService(ConfigurationExtension.class)
 public class BlockNodeConfigExtension implements ConfigurationExtension {
 
+    /** Explicitly defined constructor. */
+    public BlockNodeConfigExtension() {
+        super();
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -36,6 +43,11 @@ public class BlockNodeConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(BasicCommonConfig.class, MetricsConfig.class, PrometheusConfig.class);
+        return Set.of(
+                BasicCommonConfig.class,
+                MetricsConfig.class,
+                PrometheusConfig.class,
+                ConsumerConfig.class,
+                PersistenceStorageConfig.class);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.block.server.consumer;
 
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 
 @ConfigData("consumer")
-public record ConsumerConfig(
-        @ConfigProperty(defaultValue = "1500") long timeoutThresholdMillis
-) {}
+public record ConsumerConfig(@ConfigProperty(defaultValue = "1500") long timeoutThresholdMillis) {}

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
@@ -1,0 +1,9 @@
+package com.hedera.block.server.consumer;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+
+@ConfigData("consumer")
+public record ConsumerConfig(
+        @ConfigProperty(defaultValue = "1500") long timeoutThresholdMillis
+) {}

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
@@ -19,5 +19,11 @@ package com.hedera.block.server.consumer;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 
+/**
+ * Use this configuration across the consumer package.
+ *
+ * @param timeoutThresholdMillis after this time of inactivity, the consumer will be considered
+ *     timed out and will be disconnected
+ */
 @ConfigData("consumer")
 public record ConsumerConfig(@ConfigProperty(defaultValue = "1500") long timeoutThresholdMillis) {}

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -19,6 +19,7 @@ package com.hedera.block.server.consumer;
 import static com.hedera.block.protos.BlockStreamService.BlockItem;
 import static com.hedera.block.protos.BlockStreamService.SubscribeStreamResponse;
 
+import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.SubscriptionHandler;
 import com.lmax.disruptor.EventHandler;
@@ -66,14 +67,14 @@ public class ConsumerStreamResponseObserver
      * SubscribeStreamResponse events from the Disruptor and passing them to the downstream consumer
      * via the subscribeStreamResponseObserver.
      *
-     * @param consumerConfig contains the Consumer configuration settings
+     * @param context contains the context with metrics and configuration for the application
      * @param producerLivenessClock the clock to use to determine the producer liveness
      * @param subscriptionHandler the subscription handler to use to manage the subscription
      *     lifecycle
      * @param subscribeStreamResponseObserver the observer to use to send responses to the consumer
      */
     public ConsumerStreamResponseObserver(
-            @NonNull final ConsumerConfig consumerConfig,
+            @NonNull final BlockNodeContext context,
             @NonNull final InstantSource producerLivenessClock,
             @NonNull
                     final SubscriptionHandler<ObjectEvent<SubscribeStreamResponse>>
@@ -81,7 +82,10 @@ public class ConsumerStreamResponseObserver
             @NonNull
                     final StreamObserver<SubscribeStreamResponse> subscribeStreamResponseObserver) {
 
-        this.timeoutThresholdMillis = consumerConfig.timeoutThresholdMillis();
+        this.timeoutThresholdMillis =
+                context.configuration()
+                        .getConfigData(ConsumerConfig.class)
+                        .timeoutThresholdMillis();
         this.subscriptionHandler = subscriptionHandler;
 
         // The ServerCallStreamObserver can be configured with Runnable handlers to

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -66,15 +66,14 @@ public class ConsumerStreamResponseObserver
      * SubscribeStreamResponse events from the Disruptor and passing them to the downstream consumer
      * via the subscribeStreamResponseObserver.
      *
-     * @param timeoutThresholdMillis the timeout threshold in milliseconds for the producer to
-     *     publish block items
+     * @param consumerConfig contains the Consumer configuration settings
      * @param producerLivenessClock the clock to use to determine the producer liveness
      * @param subscriptionHandler the subscription handler to use to manage the subscription
      *     lifecycle
      * @param subscribeStreamResponseObserver the observer to use to send responses to the consumer
      */
     public ConsumerStreamResponseObserver(
-            final long timeoutThresholdMillis,
+            @NonNull final ConsumerConfig consumerConfig,
             @NonNull final InstantSource producerLivenessClock,
             @NonNull
                     final SubscriptionHandler<ObjectEvent<SubscribeStreamResponse>>
@@ -82,7 +81,7 @@ public class ConsumerStreamResponseObserver
             @NonNull
                     final StreamObserver<SubscribeStreamResponse> subscribeStreamResponseObserver) {
 
-        this.timeoutThresholdMillis = timeoutThresholdMillis;
+        this.timeoutThresholdMillis = consumerConfig.timeoutThresholdMillis();
         this.subscriptionHandler = subscriptionHandler;
 
         // The ServerCallStreamObserver can be configured with Runnable handlers to

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
@@ -88,6 +88,7 @@ class LiveStreamMediatorImpl
         // Initialize and start the disruptor
         @NonNull
         final Disruptor<ObjectEvent<SubscribeStreamResponse>> disruptor =
+                // TODO: replace ring buffer size with a configurable value
                 new Disruptor<>(ObjectEvent::new, 1024, DaemonThreadFactory.INSTANCE);
         this.ringBuffer = disruptor.start();
         this.executor = Executors.newCachedThreadPool(DaemonThreadFactory.INSTANCE);

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
@@ -88,7 +88,7 @@ class LiveStreamMediatorImpl
         // Initialize and start the disruptor
         @NonNull
         final Disruptor<ObjectEvent<SubscribeStreamResponse>> disruptor =
-                // TODO: replace ring buffer size with a configurable value
+                // TODO: replace ring buffer size with a configurable value, create a MediatorConfig
                 new Disruptor<>(ObjectEvent::new, 1024, DaemonThreadFactory.INSTANCE);
         this.ringBuffer = disruptor.start();
         this.executor = Executors.newCachedThreadPool(DaemonThreadFactory.INSTANCE);

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/FileUtils.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/FileUtils.java
@@ -17,14 +17,20 @@
 package com.hedera.block.server.persistence.storage;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
 
-/** Util methods provide common functionality for the storage package. */
-public final class Util {
-    private Util() {}
+/** FileUtils methods provide common functionality for the storage package. */
+public final class FileUtils {
+
+    private static final System.Logger LOGGER = System.getLogger(FileUtils.class.getName());
+
+    private FileUtils() {}
 
     /**
      * Default file permissions defines the file and directory for the storage package.
@@ -42,4 +48,18 @@ public final class Util {
                             PosixFilePermission.GROUP_EXECUTE,
                             PosixFilePermission.OTHERS_READ,
                             PosixFilePermission.OTHERS_EXECUTE));
+
+    public static void createPathIfNotExists(
+            @NonNull final Path blockNodePath,
+            @NonNull final System.Logger.Level logLevel,
+            @NonNull FileAttribute<Set<PosixFilePermission>> perms)
+            throws IOException {
+        // Initialize the Block directory if it does not exist
+        if (Files.notExists(blockNodePath)) {
+            Files.createDirectory(blockNodePath, perms);
+            LOGGER.log(logLevel, "Created block node root directory: " + blockNodePath);
+        } else {
+            LOGGER.log(logLevel, "Using existing block node root directory: " + blockNodePath);
+        }
+    }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/FileUtils.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/FileUtils.java
@@ -49,6 +49,14 @@ public final class FileUtils {
                             PosixFilePermission.OTHERS_READ,
                             PosixFilePermission.OTHERS_EXECUTE));
 
+    /**
+     * Use this to create a Dir if it does not exist with the given permissions and log the result.
+     *
+     * @param blockNodePath the path to create
+     * @param logLevel the log level to use
+     * @param perms the permissions to use when creating the directory
+     * @throws IOException if the directory cannot be created
+     */
     public static void createPathIfNotExists(
             @NonNull final Path blockNodePath,
             @NonNull final System.Logger.Level logLevel,

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -26,8 +26,8 @@ import java.nio.file.Paths;
 /**
  * Use this configuration across the persistent storage package
  *
- * @param rootPath provides the root path for saving block data, if you want to override it need to set
- *     it as persistence.storage.rootPath
+ * @param rootPath provides the root path for saving block data, if you want to override it need to
+ *     set it as persistence.storage.rootPath
  */
 @ConfigData("persistence.storage")
 public record PersistenceStorageConfig(@ConfigProperty(defaultValue = "") String rootPath) {

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.persistence.storage;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Use this configuration across the persistent storage package
+ *
+ * @param rootPath provides the root path for saving block data
+ */
+@ConfigData("persistence.storage")
+public record PersistenceStorageConfig(@ConfigProperty(defaultValue = "") String rootPath) {
+    /**
+     * Constructor to set the default root path if not provided, it will be set to the data
+     * directory in the current working directory
+     */
+    public PersistenceStorageConfig {
+        if (rootPath.isEmpty()) {
+            Path defaultPath = Paths.get(rootPath).toAbsolutePath().resolve("data");
+            if (!Files.exists(defaultPath)) {
+                try {
+                    Files.createDirectories(defaultPath);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            rootPath = defaultPath.toString();
+        }
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -26,7 +26,8 @@ import java.nio.file.Paths;
 /**
  * Use this configuration across the persistent storage package
  *
- * @param rootPath provides the root path for saving block data
+ * @param rootPath provides the root path for saving block data, if you want to override it need to set
+ *     it as persistence.storage.rootPath
  */
 @ConfigData("persistence.storage")
 public record PersistenceStorageConfig(@ConfigProperty(defaultValue = "") String rootPath) {

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReader.java
@@ -21,8 +21,8 @@ import static com.hedera.block.protos.BlockStreamService.Block.Builder;
 import static com.hedera.block.protos.BlockStreamService.BlockItem;
 import static com.hedera.block.server.Constants.BLOCK_FILE_EXTENSION;
 
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.helidon.config.Config;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -49,18 +49,16 @@ class BlockAsDirReader implements BlockReader<Block> {
      * Constructor for the BlockAsDirReader class. It initializes the BlockAsDirReader with the
      * given parameters.
      *
-     * @param key the key to retrieve the block node root path from the configuration
      * @param config the configuration to retrieve the block node root path
      * @param filePerms the file permissions to set on the block node root path
      */
     BlockAsDirReader(
-            @NonNull final String key,
-            @NonNull final Config config,
+            @NonNull final PersistenceStorageConfig config,
             @NonNull final FileAttribute<Set<PosixFilePermission>> filePerms) {
 
         LOGGER.log(System.Logger.Level.INFO, "Initializing FileSystemBlockReader");
 
-        @NonNull final Path blockNodeRootPath = Path.of(config.get(key).asString().get());
+        @NonNull final Path blockNodeRootPath = Path.of(config.rootPath());
 
         LOGGER.log(System.Logger.Level.INFO, config.toString());
         LOGGER.log(System.Logger.Level.INFO, "Block Node Root Path: " + blockNodeRootPath);

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderBuilder.java
@@ -18,9 +18,9 @@ package com.hedera.block.server.persistence.storage.read;
 
 import static com.hedera.block.protos.BlockStreamService.Block;
 
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.Util;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.helidon.config.Config;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
@@ -32,27 +32,23 @@ import java.util.Set;
  */
 public class BlockAsDirReaderBuilder {
 
-    private final String key;
-    private final Config config;
     private FileAttribute<Set<PosixFilePermission>> filePerms = Util.defaultPerms;
+    private final PersistenceStorageConfig config;
 
-    private BlockAsDirReaderBuilder(@NonNull final String key, @NonNull final Config config) {
-        this.key = key;
+    private BlockAsDirReaderBuilder(@NonNull PersistenceStorageConfig config) {
         this.config = config;
     }
 
     /**
      * Creates a new block reader builder using the minimum required parameters.
      *
-     * @param key is required to read pertinent configuration info.
      * @param config is required to supply pertinent configuration info for the block reader to
      *     access storage.
      * @return a block reader builder configured with required parameters.
      */
     @NonNull
-    public static BlockAsDirReaderBuilder newBuilder(
-            @NonNull final String key, @NonNull final Config config) {
-        return new BlockAsDirReaderBuilder(key, config);
+    public static BlockAsDirReaderBuilder newBuilder(@NonNull PersistenceStorageConfig config) {
+        return new BlockAsDirReaderBuilder(config);
     }
 
     /**
@@ -80,6 +76,6 @@ public class BlockAsDirReaderBuilder {
      */
     @NonNull
     public BlockReader<Block> build() {
-        return new BlockAsDirReader(key, config, filePerms);
+        return new BlockAsDirReader(config, filePerms);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderBuilder.java
@@ -18,8 +18,8 @@ package com.hedera.block.server.persistence.storage.read;
 
 import static com.hedera.block.protos.BlockStreamService.Block;
 
+import com.hedera.block.server.persistence.storage.FileUtils;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
-import com.hedera.block.server.persistence.storage.Util;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
@@ -32,7 +32,7 @@ import java.util.Set;
  */
 public class BlockAsDirReaderBuilder {
 
-    private FileAttribute<Set<PosixFilePermission>> filePerms = Util.defaultPerms;
+    private FileAttribute<Set<PosixFilePermission>> filePerms = FileUtils.defaultPerms;
     private final PersistenceStorageConfig config;
 
     private BlockAsDirReaderBuilder(@NonNull PersistenceStorageConfig config) {
@@ -56,8 +56,8 @@ public class BlockAsDirReaderBuilder {
      * and directories.
      *
      * <p>By default, the block reader will use the permissions defined in {@link
-     * Util#defaultPerms}. This method is primarily used for testing purposes. Default values should
-     * be sufficient for production use.
+     * FileUtils#defaultPerms}. This method is primarily used for testing purposes. Default values
+     * should be sufficient for production use.
      *
      * @param filePerms the file permissions to use when managing block files and directories.
      * @return a block reader builder configured with required parameters.

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
@@ -54,8 +54,7 @@ class BlockAsDirWriter implements BlockWriter<BlockItem> {
     private final BlockNodeContext blockNodeContext;
 
     /**
-     * Use the corresponding builder to construct a new BlockAsDirWriter with the
-     * given parameters.
+     * Use the corresponding builder to construct a new BlockAsDirWriter with the given parameters.
      *
      * @param blockRemover the block remover to use for removing blocks
      * @param filePerms the file permissions to use for writing blocks

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
@@ -54,12 +54,12 @@ class BlockAsDirWriter implements BlockWriter<BlockItem> {
     private final BlockNodeContext blockNodeContext;
 
     /**
-     * Constructor for the BlockAsDirWriter class. It initializes the BlockAsDirWriter with the
-     * given key, config, block remover, and file permissions.
+     * Use the corresponding builder to construct a new BlockAsDirWriter with the
+     * given parameters.
      *
-     * @param blockRemover the block remover to use to remove blocks if there is an exception while
-     *     writing a partial block
-     * @param filePerms the file permissions to set on the block node root path
+     * @param blockRemover the block remover to use for removing blocks
+     * @param filePerms the file permissions to use for writing blocks
+     * @param blockNodeContext the block node context to use for writing blocks
      * @throws IOException if an error occurs while initializing the BlockAsDirWriter
      */
     BlockAsDirWriter(

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
@@ -73,8 +73,6 @@ class BlockAsDirWriter implements BlockWriter<BlockItem> {
                 blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
         final Path blockNodeRootPath = Path.of(config.rootPath());
 
-        // TODO: Remove comment but, Ask matt why we are logging the config?
-        // LOGGER.log(System.Logger.Level.INFO, config.toString());
         LOGGER.log(System.Logger.Level.INFO, "Block Node Root Path: " + blockNodeRootPath);
 
         this.blockNodeRootPath = blockNodeRootPath;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
@@ -19,8 +19,8 @@ package com.hedera.block.server.persistence.storage.write;
 import static com.hedera.block.protos.BlockStreamService.BlockItem;
 
 import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.persistence.storage.FileUtils;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
-import com.hedera.block.server.persistence.storage.Util;
 import com.hedera.block.server.persistence.storage.remove.BlockAsDirRemover;
 import com.hedera.block.server.persistence.storage.remove.BlockRemover;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -38,7 +38,7 @@ import java.util.Set;
 public class BlockAsDirWriterBuilder {
 
     private final BlockNodeContext blockNodeContext;
-    private FileAttribute<Set<PosixFilePermission>> filePerms = Util.defaultPerms;
+    private FileAttribute<Set<PosixFilePermission>> filePerms = FileUtils.defaultPerms;
     private BlockRemover blockRemover;
 
     private BlockAsDirWriterBuilder(@NonNull final BlockNodeContext blockNodeContext) {
@@ -46,7 +46,8 @@ public class BlockAsDirWriterBuilder {
         PersistenceStorageConfig config =
                 blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
-        this.blockRemover = new BlockAsDirRemover(Path.of(config.rootPath()), Util.defaultPerms);
+        this.blockRemover =
+                new BlockAsDirRemover(Path.of(config.rootPath()), FileUtils.defaultPerms);
     }
 
     /**
@@ -67,8 +68,8 @@ public class BlockAsDirWriterBuilder {
      * and directories.
      *
      * <p>By default, the block writer will use the permissions defined in {@link
-     * Util#defaultPerms}. This method is primarily used for testing purposes. Default values should
-     * be sufficient for production use.
+     * FileUtils#defaultPerms}. This method is primarily used for testing purposes. Default values
+     * should be sufficient for production use.
      *
      * @param filePerms the file permissions to use when managing block files and directories.
      * @return a block writer builder configured with required parameters.

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
@@ -19,11 +19,11 @@ package com.hedera.block.server.persistence.storage.write;
 import static com.hedera.block.protos.BlockStreamService.BlockItem;
 
 import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.Util;
 import com.hedera.block.server.persistence.storage.remove.BlockAsDirRemover;
 import com.hedera.block.server.persistence.storage.remove.BlockRemover;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import io.helidon.config.Config;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
@@ -37,39 +37,29 @@ import java.util.Set;
  */
 public class BlockAsDirWriterBuilder {
 
-    private final String key;
-    private final Config config;
     private final BlockNodeContext blockNodeContext;
     private FileAttribute<Set<PosixFilePermission>> filePerms = Util.defaultPerms;
     private BlockRemover blockRemover;
 
-    private BlockAsDirWriterBuilder(
-            @NonNull final String key,
-            @NonNull final Config config,
-            @NonNull final BlockNodeContext blockNodeContext) {
-        this.key = key;
-        this.config = config;
+    private BlockAsDirWriterBuilder(@NonNull final BlockNodeContext blockNodeContext) {
         this.blockNodeContext = blockNodeContext;
-        this.blockRemover =
-                new BlockAsDirRemover(Path.of(config.get(key).asString().get()), Util.defaultPerms);
+        PersistenceStorageConfig config =
+                blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
+
+        this.blockRemover = new BlockAsDirRemover(Path.of(config.rootPath()), Util.defaultPerms);
     }
 
     /**
      * Creates a new block writer builder using the minimum required parameters.
      *
-     * @param key is required to read pertinent configuration info.
-     * @param config is required to supply pertinent configuration info for the block writer to
-     *     access storage.
      * @param blockNodeContext is required to provide metrics reporting mechanisms .
      * @return a block writer builder configured with required parameters.
      */
     @NonNull
     public static BlockAsDirWriterBuilder newBuilder(
-            @NonNull final String key,
-            @NonNull final Config config,
             @NonNull final BlockNodeContext blockNodeContext) {
 
-        return new BlockAsDirWriterBuilder(key, config, blockNodeContext);
+        return new BlockAsDirWriterBuilder(blockNodeContext);
     }
 
     /**
@@ -114,6 +104,6 @@ public class BlockAsDirWriterBuilder {
      */
     @NonNull
     public BlockWriter<BlockItem> build() throws IOException {
-        return new BlockAsDirWriter(key, config, blockRemover, filePerms, blockNodeContext);
+        return new BlockAsDirWriter(blockRemover, filePerms, blockNodeContext);
     }
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -2,6 +2,11 @@ import com.hedera.block.server.config.BlockNodeConfigExtension;
 
 /** Runtime module of the server. */
 module com.hedera.block.server {
+    exports com.hedera.block.server.consumer to
+            com.swirlds.config.impl;
+    exports com.hedera.block.server.persistence.storage to
+            com.swirlds.config.impl;
+
     requires com.hedera.block.protos;
     requires com.google.protobuf;
     requires com.lmax.disruptor;
@@ -11,7 +16,6 @@ module com.hedera.block.server {
     requires com.swirlds.metrics.api;
     requires io.grpc.stub;
     requires io.helidon.common;
-    requires io.helidon.config;
     requires io.helidon.webserver.grpc;
     requires io.helidon.webserver;
     requires static com.github.spotbugs.annotations;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -2,11 +2,6 @@ import com.hedera.block.server.config.BlockNodeConfigExtension;
 
 /** Runtime module of the server. */
 module com.hedera.block.server {
-    exports com.hedera.block.server.consumer to
-            com.swirlds.config.impl;
-    exports com.hedera.block.server.persistence.storage to
-            com.swirlds.config.impl;
-
     requires com.hedera.block.protos;
     requires com.google.protobuf;
     requires com.lmax.disruptor;

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
@@ -114,10 +114,9 @@ public class BlockStreamServiceIT {
 
         final BlockNodeContext blockNodeContext = mock(BlockNodeContext.class);
 
-
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                         new ItemAckBuilder(),
+                        new ItemAckBuilder(),
                         streamMediator,
                         blockReader,
                         serviceStatus,
@@ -612,10 +611,6 @@ public class BlockStreamServiceIT {
         final BlockNodeContext blockNodeContext = TestConfigUtil.getSpyBlockNodeContext();
 
         return new BlockStreamService(
-                new ItemAckBuilder(),
-                streamMediator,
-                blockReader,
-                serviceStatus,
-                blockNodeContext);
+                new ItemAckBuilder(), streamMediator, blockReader, serviceStatus, blockNodeContext);
     }
 }

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
@@ -35,6 +35,7 @@ import com.hedera.block.server.persistence.storage.remove.BlockRemover;
 import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
 import com.hedera.block.server.producer.ItemAckBuilder;
+import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.block.server.util.TestUtils;
 import com.lmax.disruptor.BatchEventProcessor;
 import com.lmax.disruptor.EventHandler;
@@ -111,11 +112,12 @@ public class BlockStreamServiceIT {
     public void testPublishBlockStreamRegistrationAndExecution()
             throws IOException, NoSuchAlgorithmException {
 
-        final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
+        final BlockNodeContext blockNodeContext = mock(BlockNodeContext.class);
+
+
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        1500L,
-                        new ItemAckBuilder(),
+                         new ItemAckBuilder(),
                         streamMediator,
                         blockReader,
                         serviceStatus,
@@ -159,7 +161,8 @@ public class BlockStreamServiceIT {
         final ServiceStatus serviceStatus = new ServiceStatusImpl();
         serviceStatus.setWebServer(webServer);
 
-        final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
+        final BlockNodeContext blockNodeContext = TestConfigUtil.getSpyBlockNodeContext();
+
         final var streamMediator =
                 LiveStreamMediatorBuilder.newBuilder(blockWriter, blockNodeContext, serviceStatus)
                         .build();
@@ -167,7 +170,6 @@ public class BlockStreamServiceIT {
         // Build the BlockStreamService
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        2000L,
                         new ItemAckBuilder(),
                         streamMediator,
                         blockReader,
@@ -607,9 +609,9 @@ public class BlockStreamServiceIT {
             final ServiceStatus serviceStatus)
             throws IOException {
 
-        final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
+        final BlockNodeContext blockNodeContext = TestConfigUtil.getSpyBlockNodeContext();
+
         return new BlockStreamService(
-                2000,
                 new ItemAckBuilder(),
                 streamMediator,
                 blockReader,

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
@@ -26,8 +26,8 @@ import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.LiveStreamMediatorBuilder;
 import com.hedera.block.server.mediator.StreamMediator;
+import com.hedera.block.server.persistence.storage.FileUtils;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
-import com.hedera.block.server.persistence.storage.Util;
 import com.hedera.block.server.persistence.storage.read.BlockAsDirReaderBuilder;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.persistence.storage.remove.BlockAsDirRemover;
@@ -318,7 +318,7 @@ public class BlockStreamServiceIT {
                         EventHandler<ObjectEvent<SubscribeStreamResponse>>,
                         BatchEventProcessor<ObjectEvent<SubscribeStreamResponse>>>
                 subscribers = new LinkedHashMap<>();
-        final var streamMediator = buildStreamMediator(subscribers, Util.defaultPerms);
+        final var streamMediator = buildStreamMediator(subscribers, FileUtils.defaultPerms);
         final var blockStreamService =
                 buildBlockStreamService(streamMediator, blockReader, serviceStatus);
 
@@ -566,7 +566,7 @@ public class BlockStreamServiceIT {
 
     private BlockStreamService buildBlockStreamService() throws IOException {
         final var streamMediator =
-                buildStreamMediator(new ConcurrentHashMap<>(32), Util.defaultPerms);
+                buildStreamMediator(new ConcurrentHashMap<>(32), FileUtils.defaultPerms);
 
         return buildBlockStreamService(streamMediator, blockReader, serviceStatus);
     }
@@ -581,7 +581,7 @@ public class BlockStreamServiceIT {
 
         // Initialize with concrete a concrete BlockReader, BlockWriter and Mediator
         final BlockRemover blockRemover =
-                new BlockAsDirRemover(Path.of(testConfig.rootPath()), Util.defaultPerms);
+                new BlockAsDirRemover(Path.of(testConfig.rootPath()), FileUtils.defaultPerms);
 
         final BlockWriter<BlockItem> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext)

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
@@ -95,10 +95,10 @@ public class BlockStreamServiceIT {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        testConfig = new PersistenceStorageConfig(testPath.toString());
         blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(
+                TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
+        testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
     }
 
     @AfterEach
@@ -156,7 +156,7 @@ public class BlockStreamServiceIT {
         final ServiceStatus serviceStatus = new ServiceStatusImpl();
         serviceStatus.setWebServer(webServer);
 
-        final BlockNodeContext blockNodeContext = TestConfigUtil.getSpyBlockNodeContext();
+        final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
 
         final var streamMediator =
                 LiveStreamMediatorBuilder.newBuilder(blockWriter, blockNodeContext, serviceStatus)
@@ -603,7 +603,7 @@ public class BlockStreamServiceIT {
             final ServiceStatus serviceStatus)
             throws IOException {
 
-        final BlockNodeContext blockNodeContext = TestConfigUtil.getSpyBlockNodeContext();
+        final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
 
         return new BlockStreamService(
                 new ItemAckBuilder(), streamMediator, blockReader, serviceStatus, blockNodeContext);

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIT.java
@@ -83,7 +83,6 @@ public class BlockStreamServiceIT {
     @Mock private BlockWriter<BlockItem> blockWriter;
 
     private static final String TEMP_DIR = "block-node-unit-test-dir";
-    private static final String JUNIT = "my-junit-test";
 
     private Path testPath;
     private BlockNodeContext blockNodeContext;
@@ -110,8 +109,6 @@ public class BlockStreamServiceIT {
     @Test
     public void testPublishBlockStreamRegistrationAndExecution()
             throws IOException, NoSuchAlgorithmException {
-
-        // final BlockNodeContext blockNodeContext = mock(BlockNodeContext.class);
 
         final BlockStreamService blockStreamService =
                 new BlockStreamService(

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -101,7 +101,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -121,7 +120,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -145,7 +143,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -201,7 +198,6 @@ public class BlockStreamServiceTest {
         // Call the service
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -221,7 +217,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -245,7 +240,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,
@@ -271,7 +265,6 @@ public class BlockStreamServiceTest {
         final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
-                        TIMEOUT_THRESHOLD_MILLIS,
                         itemAckBuilder,
                         streamMediator,
                         blockReader,

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -72,7 +72,6 @@ public class BlockStreamServiceTest {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     private static final String TEMP_DIR = "block-node-unit-test-dir";
-    private static final String JUNIT = "my-junit-test";
 
     private Path testPath;
     // private Config testConfig;
@@ -84,12 +83,7 @@ public class BlockStreamServiceTest {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        // Map<String, String> testProperties = Map.of(JUNIT, testPath.toString());
-        // ConfigSource testConfigSource = MapConfigSource.builder().map(testProperties).build();
-        // testConfig = Config.builder(testConfigSource).build();
-
         config = new PersistenceStorageConfig(testPath.toString());
-
         blockNodeContext =
                 TestConfigUtil.getSpyBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
@@ -103,7 +97,6 @@ public class BlockStreamServiceTest {
     @Test
     public void testServiceName() throws IOException, NoSuchAlgorithmException {
 
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,
@@ -122,7 +115,6 @@ public class BlockStreamServiceTest {
 
     @Test
     public void testProto() throws IOException, NoSuchAlgorithmException {
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,
@@ -144,7 +136,6 @@ public class BlockStreamServiceTest {
     void testSingleBlockHappyPath() throws IOException {
 
         final BlockReader<Block> blockReader = BlockAsDirReaderBuilder.newBuilder(config).build();
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,
@@ -187,8 +178,6 @@ public class BlockStreamServiceTest {
     @Test
     void testSingleBlockNotFoundPath() throws IOException {
 
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
-
         // Get the block so we can verify the response payload
         when(blockReader.read(1)).thenReturn(Optional.empty());
 
@@ -216,9 +205,8 @@ public class BlockStreamServiceTest {
     }
 
     @Test
-    void testSingleBlockServiceNotAvailable() throws IOException {
+    void testSingleBlockServiceNotAvailable() {
 
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,
@@ -241,7 +229,6 @@ public class BlockStreamServiceTest {
 
     @Test
     public void testSingleBlockIOExceptionPath() throws IOException {
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,
@@ -264,9 +251,8 @@ public class BlockStreamServiceTest {
     }
 
     @Test
-    public void testUpdateInvokesRoutingWithLambdas() throws IOException {
+    public void testUpdateInvokesRoutingWithLambdas() {
 
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         itemAckBuilder,

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -73,7 +73,6 @@ public class BlockStreamServiceTest {
     private static final String TEMP_DIR = "block-node-unit-test-dir";
 
     private Path testPath;
-    // private Config testConfig;
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
 

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -83,10 +83,10 @@ public class BlockStreamServiceTest {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        config = new PersistenceStorageConfig(testPath.toString());
         blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(
+                TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
+        config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
     }
 
     @AfterEach

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.*;
 
 import com.google.protobuf.Descriptors;
 import com.hedera.block.server.config.BlockNodeContext;
-// import com.hedera.block.server.config.BlockNodeContextFactory;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.StreamMediator;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;

--- a/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
+++ b/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.config;
+
+import com.swirlds.common.config.singleton.ConfigurationHolder;
+import com.swirlds.common.threading.locks.AutoClosableLock;
+import com.swirlds.common.threading.locks.Locks;
+import com.swirlds.common.threading.locks.locked.Locked;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.api.converter.ConfigConverter;
+import com.swirlds.config.api.source.ConfigSource;
+import com.swirlds.config.api.validation.ConfigValidator;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Objects;
+
+/**
+ * Helper for use the config in test and change the config for specific tests. Instance can be used per class or per
+ * test.
+ */
+public class TestConfigBuilder {
+
+    private final AutoClosableLock configLock = Locks.createAutoLock();
+
+    private Configuration configuration = null;
+
+    private final ConfigurationBuilder builder;
+
+    /**
+     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
+     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera}.
+     */
+    public TestConfigBuilder() {
+        this(true);
+    }
+
+    /**
+     * Creates a new instance and automatically registers all given config data records. This call will not do a class
+     * scan for config data records on classpath / modulepath like some of the other constructors do.
+     *
+     * @param dataTypes
+     */
+    public TestConfigBuilder(@Nullable final Class<? extends Record> dataTypes) {
+        this(false);
+        if (dataTypes != null) {
+            this.builder.withConfigDataTypes(dataTypes);
+        }
+    }
+
+    /**
+     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
+     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera}.
+     * if the {@code registerAllTypes} param is true.
+     *
+     * @param registerAllTypes if true all config data records on classpath will automatically be registered
+     */
+    public TestConfigBuilder(final boolean registerAllTypes) {
+        if (registerAllTypes) {
+            this.builder = ConfigurationBuilder.create().autoDiscoverExtensions();
+        } else {
+            this.builder = ConfigurationBuilder.create();
+        }
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final int value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final double value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final long value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, final boolean value) {
+        return withSource(new SimpleConfigSource(propertyName, value));
+    }
+
+    /**
+     * Sets the value for the config.
+     *
+     * @param propertyName name of the property
+     * @param value        the value
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
+        Objects.requireNonNull(value, "value must not be null");
+        return withSource(new SimpleConfigSource(propertyName, value.toString()));
+    }
+
+    /**
+     * This method returns the {@link Configuration} instance. If the method is called for the first time the
+     * {@link Configuration} instance will be created. All values that have been set (see
+     * {@link #withValue(String, int)}) methods will be part of the config. Next to this the config will support all
+     * config data record types (see {@link ConfigData}) that are on the classpath.
+     *
+     * @return the created configuration
+     */
+    @NonNull
+    public Configuration getOrCreateConfig() {
+        try (final Locked ignore = configLock.lock()) {
+            if (configuration == null) {
+                configuration = builder.build();
+                ConfigurationHolder.getInstance().setConfiguration(configuration);
+            }
+            return configuration;
+        }
+    }
+
+    private void checkConfigState() {
+        try (final Locked ignore = configLock.lock()) {
+            if (configuration != null) {
+                throw new IllegalStateException("Configuration already created!");
+            }
+        }
+    }
+
+    /**
+     * Adds the given config source to the builder
+     *
+     * @param configSource the config source that will be added
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withSource(@NonNull final ConfigSource configSource) {
+        checkConfigState();
+        builder.withSource(configSource);
+        return this;
+    }
+
+    /**
+     * Adds the given config converter to the builder
+     *
+     * @param converterType the type of the config converter
+     * @param converter the config converter that will be added
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public <T> TestConfigBuilder withConverter(
+            @NonNull final Class<T> converterType, @NonNull final ConfigConverter<T> converter) {
+        checkConfigState();
+        builder.withConverter(converterType, converter);
+        return this;
+    }
+
+    /**
+     * Adds the given config validator to the builder
+     *
+     * @param validator the config validator that will be added
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public TestConfigBuilder withValidator(@NonNull final ConfigValidator validator) {
+        checkConfigState();
+        builder.withValidator(validator);
+        return this;
+    }
+
+    /**
+     * Adds the given config data type to the builder
+     *
+     * @param type the config data type that will be added
+     * @param <T>  the type of the config data type
+     * @return the {@link TestConfigBuilder} instance (for fluent API)
+     */
+    @NonNull
+    public <T extends Record> TestConfigBuilder withConfigDataType(@NonNull final Class<T> type) {
+        checkConfigState();
+        builder.withConfigDataType(type);
+        return this;
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
+++ b/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
@@ -32,8 +32,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Objects;
 
 /**
- * Helper for use the config in test and change the config for specific tests. Instance can be used per class or per
- * test.
+ * Helper for use the config in test and change the config for specific tests. Instance can be used
+ * per class or per test.
  */
 public class TestConfigBuilder {
 
@@ -44,16 +44,18 @@ public class TestConfigBuilder {
     private final ConfigurationBuilder builder;
 
     /**
-     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
-     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera}.
+     * Creates a new instance and automatically registers all config data records (see {@link
+     * ConfigData}) on classpath / modulepath that are part of the packages {@code com.swirlds} and
+     * {@code com.hedera}.
      */
     public TestConfigBuilder() {
         this(true);
     }
 
     /**
-     * Creates a new instance and automatically registers all given config data records. This call will not do a class
-     * scan for config data records on classpath / modulepath like some of the other constructors do.
+     * Creates a new instance and automatically registers all given config data records. This call
+     * will not do a class scan for config data records on classpath / modulepath like some of the
+     * other constructors do.
      *
      * @param dataTypes
      */
@@ -65,11 +67,12 @@ public class TestConfigBuilder {
     }
 
     /**
-     * Creates a new instance and automatically registers all config data records (see {@link ConfigData}) on classpath
-     * / modulepath that are part of the packages {@code com.swirlds} and {@code com.hedera}.
-     * if the {@code registerAllTypes} param is true.
+     * Creates a new instance and automatically registers all config data records (see {@link
+     * ConfigData}) on classpath / modulepath that are part of the packages {@code com.swirlds} and
+     * {@code com.hedera}. if the {@code registerAllTypes} param is true.
      *
-     * @param registerAllTypes if true all config data records on classpath will automatically be registered
+     * @param registerAllTypes if true all config data records on classpath will automatically be
+     *     registered
      */
     public TestConfigBuilder(final boolean registerAllTypes) {
         if (registerAllTypes) {
@@ -83,11 +86,12 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
+    public TestConfigBuilder withValue(
+            @NonNull final String propertyName, @Nullable final String value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -95,7 +99,7 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
@@ -107,7 +111,7 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
@@ -119,7 +123,7 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
@@ -131,7 +135,7 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
@@ -143,20 +147,21 @@ public class TestConfigBuilder {
      * Sets the value for the config.
      *
      * @param propertyName name of the property
-     * @param value        the value
+     * @param value the value
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
+    public TestConfigBuilder withValue(
+            @NonNull final String propertyName, @NonNull final Object value) {
         Objects.requireNonNull(value, "value must not be null");
         return withSource(new SimpleConfigSource(propertyName, value.toString()));
     }
 
     /**
-     * This method returns the {@link Configuration} instance. If the method is called for the first time the
-     * {@link Configuration} instance will be created. All values that have been set (see
-     * {@link #withValue(String, int)}) methods will be part of the config. Next to this the config will support all
-     * config data record types (see {@link ConfigData}) that are on the classpath.
+     * This method returns the {@link Configuration} instance. If the method is called for the first
+     * time the {@link Configuration} instance will be created. All values that have been set (see
+     * {@link #withValue(String, int)}) methods will be part of the config. Next to this the config
+     * will support all config data record types (see {@link ConfigData}) that are on the classpath.
      *
      * @return the created configuration
      */
@@ -224,7 +229,7 @@ public class TestConfigBuilder {
      * Adds the given config data type to the builder
      *
      * @param type the config data type that will be added
-     * @param <T>  the type of the config data type
+     * @param <T> the type of the config data type
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -49,15 +49,11 @@ public class ConsumerStreamResponseObserverTest {
     @Test
     public void testProducerTimeoutWithinWindow() {
 
-
         when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        responseStreamObserver);
+                        consumerConfig, testClock, streamMediator, responseStreamObserver);
 
         final BlockHeader blockHeader = BlockHeader.newBuilder().setBlockNumber(1).build();
         final BlockItem blockItem = BlockItem.newBuilder().setHeader(blockHeader).build();
@@ -84,10 +80,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        responseStreamObserver);
+                        consumerConfig, testClock, streamMediator, responseStreamObserver);
 
         consumerBlockItemObserver.onEvent(objectEvent, 0, true);
         verify(streamMediator).unsubscribe(consumerBlockItemObserver);
@@ -112,10 +105,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        serverCallStreamObserver);
+                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
         final SubscribeStreamResponse subscribeStreamResponse =
@@ -140,10 +130,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        serverCallStreamObserver);
+                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
         final SubscribeStreamResponse subscribeStreamResponse =
@@ -172,10 +159,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        responseStreamObserver);
+                        consumerConfig, testClock, streamMediator, responseStreamObserver);
 
         // Send non-header BlockItems to validate that the observer does not send them
         for (int i = 1; i <= 10; i++) {

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -44,14 +44,17 @@ public class ConsumerStreamResponseObserverTest {
     @Mock private ServerCallStreamObserver<SubscribeStreamResponse> serverCallStreamObserver;
     @Mock private InstantSource testClock;
 
+    final ConsumerConfig consumerConfig = new ConsumerConfig(TIMEOUT_THRESHOLD_MILLIS);
+
     @Test
     public void testProducerTimeoutWithinWindow() {
+
 
         when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         responseStreamObserver);
@@ -81,7 +84,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         responseStreamObserver);
@@ -98,7 +101,7 @@ public class ConsumerStreamResponseObserverTest {
         when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
 
         new ConsumerStreamResponseObserver(
-                TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, serverCallStreamObserver);
+                consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         verify(serverCallStreamObserver, timeout(50).times(1)).setOnCloseHandler(any());
         verify(serverCallStreamObserver, timeout(50).times(1)).setOnCancelHandler(any());
@@ -109,7 +112,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         serverCallStreamObserver);
@@ -137,7 +140,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         serverCallStreamObserver);
@@ -169,7 +172,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         responseStreamObserver);
@@ -209,12 +212,12 @@ public class ConsumerStreamResponseObserverTest {
     private static class TestConsumerStreamResponseObserver extends ConsumerStreamResponseObserver {
 
         public TestConsumerStreamResponseObserver(
-                long timeoutThresholdMillis,
+                ConsumerConfig consumerConfig,
                 InstantSource producerLivenessClock,
                 StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> subscriptionHandler,
                 StreamObserver<SubscribeStreamResponse> subscribeStreamResponseObserver) {
             super(
-                    timeoutThresholdMillis,
+                    consumerConfig,
                     producerLivenessClock,
                     subscriptionHandler,
                     subscribeStreamResponseObserver);

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -20,12 +20,16 @@ import static com.hedera.block.protos.BlockStreamService.*;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
 import static org.mockito.Mockito.*;
 
+import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.StreamMediator;
+import com.hedera.block.server.util.TestConfigUtil;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,7 +48,15 @@ public class ConsumerStreamResponseObserverTest {
     @Mock private ServerCallStreamObserver<SubscribeStreamResponse> serverCallStreamObserver;
     @Mock private InstantSource testClock;
 
-    final ConsumerConfig consumerConfig = new ConsumerConfig(TIMEOUT_THRESHOLD_MILLIS);
+    final BlockNodeContext testContext;
+
+    public ConsumerStreamResponseObserverTest() throws IOException {
+        this.testContext =
+                TestConfigUtil.getTestBlockNodeContext(
+                        Map.of(
+                                TestConfigUtil.CONSUMER_TIMEOUT_THRESHOLD_KEY,
+                                String.valueOf(TIMEOUT_THRESHOLD_MILLIS)));
+    }
 
     @Test
     public void testProducerTimeoutWithinWindow() {
@@ -53,7 +65,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, responseStreamObserver);
+                        testContext, testClock, streamMediator, responseStreamObserver);
 
         final BlockHeader blockHeader = BlockHeader.newBuilder().setBlockNumber(1).build();
         final BlockItem blockItem = BlockItem.newBuilder().setHeader(blockHeader).build();
@@ -80,7 +92,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, responseStreamObserver);
+                        testContext, testClock, streamMediator, responseStreamObserver);
 
         consumerBlockItemObserver.onEvent(objectEvent, 0, true);
         verify(streamMediator).unsubscribe(consumerBlockItemObserver);
@@ -94,7 +106,7 @@ public class ConsumerStreamResponseObserverTest {
         when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
 
         new ConsumerStreamResponseObserver(
-                consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                testContext, testClock, streamMediator, serverCallStreamObserver);
 
         verify(serverCallStreamObserver, timeout(50).times(1)).setOnCloseHandler(any());
         verify(serverCallStreamObserver, timeout(50).times(1)).setOnCancelHandler(any());
@@ -105,7 +117,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                        testContext, testClock, streamMediator, serverCallStreamObserver);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
         final SubscribeStreamResponse subscribeStreamResponse =
@@ -130,7 +142,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final TestConsumerStreamResponseObserver consumerStreamResponseObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                        testContext, testClock, streamMediator, serverCallStreamObserver);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
         final SubscribeStreamResponse subscribeStreamResponse =
@@ -159,7 +171,7 @@ public class ConsumerStreamResponseObserverTest {
 
         final var consumerBlockItemObserver =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, responseStreamObserver);
+                        testContext, testClock, streamMediator, responseStreamObserver);
 
         // Send non-header BlockItems to validate that the observer does not send them
         for (int i = 1; i <= 10; i++) {
@@ -196,12 +208,12 @@ public class ConsumerStreamResponseObserverTest {
     private static class TestConsumerStreamResponseObserver extends ConsumerStreamResponseObserver {
 
         public TestConsumerStreamResponseObserver(
-                ConsumerConfig consumerConfig,
+                BlockNodeContext context,
                 InstantSource producerLivenessClock,
                 StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> subscriptionHandler,
                 StreamObserver<SubscribeStreamResponse> subscribeStreamResponseObserver) {
             super(
-                    consumerConfig,
+                    context,
                     producerLivenessClock,
                     subscriptionHandler,
                     subscribeStreamResponseObserver);

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -28,6 +28,7 @@ import com.hedera.block.server.consumer.ConsumerConfig;
 import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
+import com.hedera.block.server.util.TestConfigUtil;
 import com.lmax.disruptor.EventHandler;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.stub.ServerCallStreamObserver;
@@ -35,6 +36,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -62,6 +64,15 @@ public class LiveStreamMediatorImplTest {
     private static final int testTimeout = 200;
 
     private final ConsumerConfig consumerConfig = new ConsumerConfig(TIMEOUT_THRESHOLD_MILLIS);
+    private final BlockNodeContext testContext;
+
+    public LiveStreamMediatorImplTest() throws IOException {
+        this.testContext =
+                TestConfigUtil.getTestBlockNodeContext(
+                        Map.of(
+                                TestConfigUtil.CONSUMER_TIMEOUT_THRESHOLD_KEY,
+                                String.valueOf(TIMEOUT_THRESHOLD_MILLIS)));
+    }
 
     @Test
     public void testUnsubscribeEach() throws InterruptedException, IOException {
@@ -142,15 +153,15 @@ public class LiveStreamMediatorImplTest {
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver1);
+                        testContext, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver2);
+                        testContext, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver3);
+                        testContext, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);
@@ -199,15 +210,15 @@ public class LiveStreamMediatorImplTest {
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver1);
+                        testContext, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver2);
+                        testContext, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver3);
+                        testContext, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);
@@ -235,7 +246,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                        testContext, testClock, streamMediator, serverCallStreamObserver);
 
         streamMediator.subscribe(testConsumerBlockItemObserver);
         assertTrue(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -271,7 +282,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                        testContext, testClock, streamMediator, serverCallStreamObserver);
 
         streamMediator.subscribe(testConsumerBlockItemObserver);
         assertTrue(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -337,7 +348,7 @@ public class LiveStreamMediatorImplTest {
                         .build();
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
+                        testContext, testClock, streamMediator, serverCallStreamObserver);
 
         // Confirm the observer is not subscribed
         assertFalse(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -351,12 +362,12 @@ public class LiveStreamMediatorImplTest {
 
     private static class TestConsumerStreamResponseObserver extends ConsumerStreamResponseObserver {
         public TestConsumerStreamResponseObserver(
-                ConsumerConfig consumerConfig,
+                BlockNodeContext context,
                 final InstantSource producerLivenessClock,
                 final StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>>
                         streamMediator,
                 final StreamObserver<SubscribeStreamResponse> responseStreamObserver) {
-            super(consumerConfig, producerLivenessClock, streamMediator, responseStreamObserver);
+            super(context, producerLivenessClock, streamMediator, responseStreamObserver);
         }
 
         @NonNull

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import com.hedera.block.server.ServiceStatusImpl;
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
+import com.hedera.block.server.consumer.ConsumerConfig;
 import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
@@ -59,6 +60,8 @@ public class LiveStreamMediatorImplTest {
     private final long TEST_TIME = 1_719_427_664_950L;
 
     private static final int testTimeout = 200;
+
+    private final ConsumerConfig consumerConfig = new ConsumerConfig(TIMEOUT_THRESHOLD_MILLIS);
 
     @Test
     public void testUnsubscribeEach() throws InterruptedException, IOException {
@@ -139,15 +142,15 @@ public class LiveStreamMediatorImplTest {
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver1);
+                        consumerConfig, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver2);
+                        consumerConfig, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver3);
+                        consumerConfig, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);
@@ -196,15 +199,15 @@ public class LiveStreamMediatorImplTest {
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver1);
+                        consumerConfig, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver2);
+                        consumerConfig, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver3);
+                        consumerConfig, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);
@@ -232,7 +235,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         serverCallStreamObserver);
@@ -271,7 +274,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         serverCallStreamObserver);
@@ -340,7 +343,7 @@ public class LiveStreamMediatorImplTest {
                         .build();
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS,
+                        consumerConfig,
                         testClock,
                         streamMediator,
                         serverCallStreamObserver);
@@ -357,13 +360,13 @@ public class LiveStreamMediatorImplTest {
 
     private static class TestConsumerStreamResponseObserver extends ConsumerStreamResponseObserver {
         public TestConsumerStreamResponseObserver(
-                long timeoutThresholdMillis,
+                ConsumerConfig consumerConfig,
                 final InstantSource producerLivenessClock,
                 final StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>>
                         streamMediator,
                 final StreamObserver<SubscribeStreamResponse> responseStreamObserver) {
             super(
-                    timeoutThresholdMillis,
+                    consumerConfig,
                     producerLivenessClock,
                     streamMediator,
                     responseStreamObserver);

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -235,10 +235,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        serverCallStreamObserver);
+                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         streamMediator.subscribe(testConsumerBlockItemObserver);
         assertTrue(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -274,10 +271,7 @@ public class LiveStreamMediatorImplTest {
 
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        serverCallStreamObserver);
+                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         streamMediator.subscribe(testConsumerBlockItemObserver);
         assertTrue(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -343,10 +337,7 @@ public class LiveStreamMediatorImplTest {
                         .build();
         final var testConsumerBlockItemObserver =
                 new TestConsumerStreamResponseObserver(
-                        consumerConfig,
-                        testClock,
-                        streamMediator,
-                        serverCallStreamObserver);
+                        consumerConfig, testClock, streamMediator, serverCallStreamObserver);
 
         // Confirm the observer is not subscribed
         assertFalse(streamMediator.isSubscribed(testConsumerBlockItemObserver));
@@ -365,11 +356,7 @@ public class LiveStreamMediatorImplTest {
                 final StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>>
                         streamMediator,
                 final StreamObserver<SubscribeStreamResponse> responseStreamObserver) {
-            super(
-                    consumerConfig,
-                    producerLivenessClock,
-                    streamMediator,
-                    responseStreamObserver);
+            super(consumerConfig, producerLivenessClock, streamMediator, responseStreamObserver);
         }
 
         @NonNull

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -28,11 +28,16 @@ import org.junit.jupiter.api.Test;
 
 class PersistenceStorageConfigTest {
 
+    final String TEMP_DIR = "block-node-unit-test-dir";
+
     @Test
-    void testPersistenceStorageConfig() {
+    void testPersistenceStorageConfig_happyPath() throws IOException {
+
+        Path testPath = Files.createTempDirectory(TEMP_DIR);
+
         PersistenceStorageConfig persistenceStorageConfig =
-                new PersistenceStorageConfig("rootPath");
-        assertEquals("rootPath", persistenceStorageConfig.rootPath());
+                new PersistenceStorageConfig(testPath.toString());
+        assertEquals(testPath.toString(), persistenceStorageConfig.rootPath());
     }
 
     @Test
@@ -44,6 +49,26 @@ class PersistenceStorageConfigTest {
 
         PersistenceStorageConfig persistenceStorageConfig = new PersistenceStorageConfig("");
         assertEquals(expectedDefaultRootPath, persistenceStorageConfig.rootPath());
+    }
+
+    @Test
+    void persistenceStorageConfig_throwsExceptionForRelativePath() {
+        IllegalArgumentException exception =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new PersistenceStorageConfig("relative/path"));
+        assertEquals("relative/path Root path must be absolute", exception.getMessage());
+    }
+
+    @Test
+    void persistenceStorageConfig_throwsRuntimeExceptionOnIOException() {
+        Path invalidPath = Paths.get("/invalid/path");
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> new PersistenceStorageConfig(invalidPath.toString()));
+        assertInstanceOf(IOException.class, exception.getCause());
     }
 
     public static void deleteDirectory(Path path) throws IOException {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.persistence.storage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class PersistenceStorageConfigTest {
+
+    @Test
+    void testPersistenceStorageConfig() {
+        PersistenceStorageConfig persistenceStorageConfig =
+                new PersistenceStorageConfig("rootPath");
+        assertEquals("rootPath", persistenceStorageConfig.rootPath());
+    }
+
+    @Test
+    void testPersistenceStorageConfig_emptyRootPath() throws IOException {
+        final String expectedDefaultRootPath =
+                Paths.get("").toAbsolutePath().resolve("data").toString();
+        // delete if exists
+        deleteDirectory(Paths.get(expectedDefaultRootPath));
+
+        PersistenceStorageConfig persistenceStorageConfig = new PersistenceStorageConfig("");
+        assertEquals(expectedDefaultRootPath, persistenceStorageConfig.rootPath());
+    }
+
+    public static void deleteDirectory(Path path) throws IOException {
+        if(!Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(path)) {
+            walk.sorted(Comparator.reverseOrder())
+                    .forEach(
+                            p -> {
+                                try {
+                                    Files.delete(p);
+                                } catch (IOException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+        }
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -47,7 +47,7 @@ class PersistenceStorageConfigTest {
     }
 
     public static void deleteDirectory(Path path) throws IOException {
-        if(!Files.exists(path)) {
+        if (!Files.exists(path)) {
             return;
         }
         try (Stream<Path> walk = Files.walk(path)) {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -51,10 +51,9 @@ public class BlockAsDirReaderTest {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     private static final String TEMP_DIR = "block-node-unit-test-dir";
-    // private static final String JUNIT = "my-junit-test";
 
     private Path testPath;
-    // private Config testConfig;
+
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
 

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -63,15 +63,10 @@ public class BlockAsDirReaderTest {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        // final Map<String, String> testProperties = Map.of(JUNIT, testPath.toString());
-        // final ConfigSource testConfigSource =
-        // MapConfigSource.builder().map(testProperties).build();
-        // testConfig = Config.builder(testConfigSource).build();
-
-        config = new PersistenceStorageConfig(testPath.toString());
         blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(
+                TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
+        config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
     }
 
     @AfterEach
@@ -94,7 +89,6 @@ public class BlockAsDirReaderTest {
     public void testReadPermsRepairSucceeded() throws IOException {
         final List<BlockItem> blockItems = PersistTestUtils.generateBlockItems(1);
 
-        // final BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
         final BlockWriter<BlockItem> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
         for (BlockItem blockItem : blockItems) {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -25,8 +25,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
 import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.persistence.storage.FileUtils;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
-import com.hedera.block.server.persistence.storage.Util;
 import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
 import com.hedera.block.server.util.PersistTestUtils;
@@ -227,7 +227,7 @@ public class BlockAsDirReaderTest {
     // IOException while allowing the real setPerm() method to remain protected.
     private static final class TestBlockAsDirReader extends BlockAsDirReader {
         public TestBlockAsDirReader(PersistenceStorageConfig config) {
-            super(config, Util.defaultPerms);
+            super(config, FileUtils.defaultPerms);
         }
 
         @Override

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
@@ -44,7 +44,6 @@ public class BlockAsDirRemoverTest {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     private static final String TEMP_DIR = "block-node-unit-test-dir";
-    private static final String JUNIT = "my-junit-test";
 
     private Path testPath;
     private BlockNodeContext blockNodeContext;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
@@ -54,10 +54,10 @@ public class BlockAsDirRemoverTest {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        testConfig = new PersistenceStorageConfig(testPath.toString());
         blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(
+                TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
+        testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
@@ -21,8 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.hedera.block.protos.BlockStreamService.Block;
 import com.hedera.block.protos.BlockStreamService.BlockItem;
 import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.persistence.storage.FileUtils;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
-import com.hedera.block.server.persistence.storage.Util;
 import com.hedera.block.server.persistence.storage.read.BlockAsDirReaderBuilder;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder;
@@ -73,7 +73,7 @@ public class BlockAsDirRemoverTest {
         }
 
         // Remove a block that does not exist
-        final BlockRemover blockRemover = new BlockAsDirRemover(testPath, Util.defaultPerms);
+        final BlockRemover blockRemover = new BlockAsDirRemover(testPath, FileUtils.defaultPerms);
         blockRemover.remove(2);
 
         // Verify the block was not removed
@@ -117,7 +117,7 @@ public class BlockAsDirRemoverTest {
                 blockItems.getFirst().getHeader(), blockOpt.get().getBlockItems(0).getHeader());
 
         // Now remove the block
-        blockRemover = new BlockAsDirRemover(testPath, Util.defaultPerms);
+        blockRemover = new BlockAsDirRemover(testPath, FileUtils.defaultPerms);
         blockRemover.remove(1);
 
         // Verify the block is removed

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterTest.java
@@ -62,10 +62,10 @@ public class BlockAsDirWriterTest {
         testPath = Files.createTempDirectory(TEMP_DIR);
         LOGGER.log(System.Logger.Level.INFO, "Created temp directory: " + testPath.toString());
 
-        testConfig = new PersistenceStorageConfig(testPath.toString());
         blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(
+                TestConfigUtil.getTestBlockNodeContext(
                         Map.of(PERSISTENCE_STORAGE_ROOT_PATH_KEY, testPath.toString()));
+        testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
     }
 
     @AfterEach
@@ -83,7 +83,7 @@ public class BlockAsDirWriterTest {
                 Map.of(PERSISTENCE_STORAGE_ROOT_PATH_KEY, "invalid-path");
 
         final BlockNodeContext blockNodeContext =
-                TestConfigUtil.getSpyBlockNodeContext(testProperties);
+                TestConfigUtil.getTestBlockNodeContext(testProperties);
 
         assertThrows(
                 IllegalArgumentException.class,

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -20,6 +20,7 @@ import static com.hedera.block.protos.BlockStreamService.*;
 import static com.hedera.block.protos.BlockStreamService.PublishStreamResponse.ItemAcknowledgement;
 import static com.hedera.block.server.producer.Util.getFakeHash;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
+import static com.hedera.block.server.util.TestConfigUtil.CONSUMER_TIMEOUT_THRESHOLD_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -36,11 +37,13 @@ import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.LiveStreamMediatorBuilder;
 import com.hedera.block.server.mediator.StreamMediator;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
+import com.hedera.block.server.util.TestConfigUtil;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -109,22 +112,27 @@ public class ProducerBlockItemObserverTest {
 
         // Mock a clock with 2 different return values in response to anticipated
         // millis() calls. Here the second call will always be inside the timeout window.
-        ConsumerConfig consumerConfig = new ConsumerConfig(100);
+        final BlockNodeContext testContext =
+                TestConfigUtil.getTestBlockNodeContext(
+                        Map.of(CONSUMER_TIMEOUT_THRESHOLD_KEY, "100"));
+        final ConsumerConfig consumerConfig =
+                testContext.configuration().getConfigData(ConsumerConfig.class);
+
         long TEST_TIME = 1_719_427_664_950L;
         when(testClock.millis())
                 .thenReturn(TEST_TIME, TEST_TIME + consumerConfig.timeoutThresholdMillis());
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver1);
+                        testContext, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver2);
+                        testContext, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        consumerConfig, testClock, streamMediator, streamObserver3);
+                        testContext, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -30,6 +30,7 @@ import com.hedera.block.server.ServiceStatus;
 import com.hedera.block.server.ServiceStatusImpl;
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
+import com.hedera.block.server.consumer.ConsumerConfig;
 import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.data.ObjectEvent;
 import com.hedera.block.server.mediator.LiveStreamMediatorBuilder;
@@ -108,21 +109,21 @@ public class ProducerBlockItemObserverTest {
 
         // Mock a clock with 2 different return values in response to anticipated
         // millis() calls. Here the second call will always be inside the timeout window.
-        long TIMEOUT_THRESHOLD_MILLIS = 100L;
+        ConsumerConfig consumerConfig = new ConsumerConfig(100);
         long TEST_TIME = 1_719_427_664_950L;
-        when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
+        when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + consumerConfig.timeoutThresholdMillis());
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver1);
+                        consumerConfig, testClock, streamMediator, streamObserver1);
 
         final var concreteObserver2 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver2);
+                        consumerConfig, testClock, streamMediator, streamObserver2);
 
         final var concreteObserver3 =
                 new ConsumerStreamResponseObserver(
-                        TIMEOUT_THRESHOLD_MILLIS, testClock, streamMediator, streamObserver3);
+                        consumerConfig, testClock, streamMediator, streamObserver3);
 
         // Set up the subscribers
         streamMediator.subscribe(concreteObserver1);

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -111,7 +111,8 @@ public class ProducerBlockItemObserverTest {
         // millis() calls. Here the second call will always be inside the timeout window.
         ConsumerConfig consumerConfig = new ConsumerConfig(100);
         long TEST_TIME = 1_719_427_664_950L;
-        when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + consumerConfig.timeoutThresholdMillis());
+        when(testClock.millis())
+                .thenReturn(TEST_TIME, TEST_TIME + consumerConfig.timeoutThresholdMillis());
 
         final var concreteObserver1 =
                 new ConsumerStreamResponseObserver(

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -1,0 +1,56 @@
+package com.hedera.block.server.util;
+
+import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.config.BlockNodeContextFactory;
+import com.hedera.block.server.config.TestConfigBuilder;
+import com.hedera.block.server.consumer.ConsumerConfig;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TestConfigUtil {
+    private TestConfigUtil() {}
+
+    @NonNull
+    public static BlockNodeContext getSpyBlockNodeContext(Map<String, String> customProperties) throws IOException {
+        // If customProperties is null, assign it an empty map
+        if (customProperties == null) {
+            customProperties = Collections.emptyMap();
+        }
+
+        // we still use the BlockNodeContextFactory to create the BlockNodeContext temporally,
+        // but we will replace the configuration with a test configuration
+        // sooner we will need to create a metrics mock, and never use the BlockNodeContextFactory.
+        BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
+
+        // create test configuration
+        TestConfigBuilder testConfigBuilder = new TestConfigBuilder(true)
+                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")));
+
+        for (Map.Entry<String, String> entry : customProperties.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            testConfigBuilder = testConfigBuilder.withValue(key, value);
+        }
+
+        testConfigBuilder = testConfigBuilder.withConfigDataType(ConsumerConfig.class);
+
+        Configuration testConfiguration = testConfigBuilder.getOrCreateConfig();
+
+        BlockNodeContext spyBlockNodeContext = spy(blockNodeContext);
+        when(spyBlockNodeContext.configuration()).thenReturn(testConfiguration);
+        return spyBlockNodeContext;
+    }
+
+    public static BlockNodeContext getSpyBlockNodeContext() throws IOException {
+        return getSpyBlockNodeContext(null);
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -16,8 +16,6 @@
 
 package com.hedera.block.server.util;
 
-import static org.mockito.Mockito.spy;
-
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
 import com.hedera.block.server.config.TestConfigBuilder;
@@ -29,18 +27,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
-import org.mockito.Mockito;
 
 public class TestConfigUtil {
+
+    public static final String TEST_APP_PROPERTIES_FILE = "test.app.properties";
+
     private TestConfigUtil() {}
 
     @NonNull
-    public static BlockNodeContext getSpyBlockNodeContext(Map<String, String> customProperties)
-            throws IOException {
-        // If customProperties is null, assign it an empty map
-        if (customProperties == null) {
-            customProperties = Collections.emptyMap();
-        }
+    public static BlockNodeContext getTestBlockNodeContext(
+            @NonNull Map<String, String> customProperties) throws IOException {
 
         // we still use the BlockNodeContextFactory to create the BlockNodeContext temporally,
         // but we will replace the configuration with a test configuration
@@ -50,7 +46,8 @@ public class TestConfigUtil {
         // create test configuration
         TestConfigBuilder testConfigBuilder =
                 new TestConfigBuilder(true)
-                        .withSource(new ClasspathFileConfigSource(Path.of("app.properties")));
+                        .withSource(
+                                new ClasspathFileConfigSource(Path.of(TEST_APP_PROPERTIES_FILE)));
 
         for (Map.Entry<String, String> entry : customProperties.entrySet()) {
             String key = entry.getKey();
@@ -62,12 +59,11 @@ public class TestConfigUtil {
 
         Configuration testConfiguration = testConfigBuilder.getOrCreateConfig();
 
-        BlockNodeContext spyBlockNodeContext = spy(blockNodeContext);
-        Mockito.lenient().when(spyBlockNodeContext.configuration()).thenReturn(testConfiguration);
-        return spyBlockNodeContext;
+        return new BlockNodeContext(
+                blockNodeContext.metrics(), blockNodeContext.metricsService(), testConfiguration);
     }
 
-    public static BlockNodeContext getSpyBlockNodeContext() throws IOException {
-        return getSpyBlockNodeContext(null);
+    public static BlockNodeContext getTestBlockNodeContext() throws IOException {
+        return getTestBlockNodeContext(Collections.emptyMap());
     }
 }

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -32,7 +32,7 @@ public class TestConfigUtil {
 
     public static final String CONSUMER_TIMEOUT_THRESHOLD_KEY = "consumer.timeoutThresholdMillis";
 
-    private static final String TEST_APP_PROPERTIES_FILE = "test.app.properties";
+    private static final String TEST_APP_PROPERTIES_FILE = "app.properties";
 
     private TestConfigUtil() {}
 

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -17,7 +17,6 @@
 package com.hedera.block.server.util;
 
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
+import org.mockito.Mockito;
 
 public class TestConfigUtil {
     private TestConfigUtil() {}
@@ -63,7 +63,7 @@ public class TestConfigUtil {
         Configuration testConfiguration = testConfigBuilder.getOrCreateConfig();
 
         BlockNodeContext spyBlockNodeContext = spy(blockNodeContext);
-        when(spyBlockNodeContext.configuration()).thenReturn(testConfiguration);
+        Mockito.lenient().when(spyBlockNodeContext.configuration()).thenReturn(testConfiguration);
         return spyBlockNodeContext;
     }
 

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -1,4 +1,23 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.block.server.util;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.config.BlockNodeContextFactory;
@@ -7,20 +26,17 @@ import com.hedera.block.server.consumer.ConsumerConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Map;
 
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
 public class TestConfigUtil {
     private TestConfigUtil() {}
 
     @NonNull
-    public static BlockNodeContext getSpyBlockNodeContext(Map<String, String> customProperties) throws IOException {
+    public static BlockNodeContext getSpyBlockNodeContext(Map<String, String> customProperties)
+            throws IOException {
         // If customProperties is null, assign it an empty map
         if (customProperties == null) {
             customProperties = Collections.emptyMap();
@@ -32,8 +48,9 @@ public class TestConfigUtil {
         BlockNodeContext blockNodeContext = BlockNodeContextFactory.create();
 
         // create test configuration
-        TestConfigBuilder testConfigBuilder = new TestConfigBuilder(true)
-                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")));
+        TestConfigBuilder testConfigBuilder =
+                new TestConfigBuilder(true)
+                        .withSource(new ClasspathFileConfigSource(Path.of("app.properties")));
 
         for (Map.Entry<String, String> entry : customProperties.entrySet()) {
             String key = entry.getKey();

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -30,7 +30,9 @@ import java.util.Map;
 
 public class TestConfigUtil {
 
-    public static final String TEST_APP_PROPERTIES_FILE = "test.app.properties";
+    public static final String CONSUMER_TIMEOUT_THRESHOLD_KEY = "consumer.timeoutThresholdMillis";
+
+    private static final String TEST_APP_PROPERTIES_FILE = "test.app.properties";
 
     private TestConfigUtil() {}
 

--- a/server/src/test/resources/app.properties
+++ b/server/src/test/resources/app.properties
@@ -1,0 +1,1 @@
+prometheus.endpointEnabled=false

--- a/server/src/test/resources/app.properties
+++ b/server/src/test/resources/app.properties
@@ -1,1 +1,2 @@
+# Test Properties File
 prometheus.endpointEnabled=false

--- a/server/src/test/resources/app.properties
+++ b/server/src/test/resources/app.properties
@@ -1,1 +1,0 @@
-prometheus.endpointEnabled=false

--- a/server/src/test/resources/test.app.properties
+++ b/server/src/test/resources/test.app.properties
@@ -1,0 +1,1 @@
+prometheus.endpointEnabled=false


### PR DESCRIPTION
**Description**:
- Created the following config classes
  - ConsumerConfig
  - PersistenceStorageConfig
- Refactored Classes to use those config instead of Helidon config
- Simplified Classes that already had BlockNodeContext to use config from there directly
- Refactored and Simplified all related Unit Tests
- 

**Related issue(s)**:

Fixes #98 
Fixes #99 
Fixes #33 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
