### PR TITLE
fix: fix config exports

### DIFF
--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -2,6 +2,11 @@ import com.hedera.block.server.config.BlockNodeConfigExtension;
 
 /** Runtime module of the server. */
 module com.hedera.block.server {
+    exports com.hedera.block.server.consumer to
+            com.swirlds.config.impl;
+    exports com.hedera.block.server.persistence.storage to
+            com.swirlds.config.impl;
+
     requires com.hedera.block.protos;
     requires com.google.protobuf;
     requires com.lmax.disruptor;


### PR DESCRIPTION
**Description**:
On a previous PR #101  we introduced Configuration Classes (Config Holders and owners) using the `Platform SDK` framework, however we removed from modules-info.java file the necessary exports, and this is an issue that is only happening on runtime, so CI checks did not catch it.

This PR fixes that by re-introducing them back.

**Related issue(s)**:

Fixes #104 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
