### PR TITLE
fix: Increased testTimeouts to promote test success on GHA runners

### DIFF
--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceIntegrationTest.java
@@ -134,7 +134,7 @@ public class BlockStreamServiceIntegrationTest {
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig testConfig;
 
-    private static final int testTimeout = 200;
+    private static final int testTimeout = 1000;
 
     @BeforeEach
     public void setUp() throws IOException {

--- a/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockStreamServiceTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -89,6 +88,8 @@ public class BlockStreamServiceTest {
 
     private static final String TEMP_DIR = "block-node-unit-test-dir";
 
+    private static final int testTimeout = 1000;
+
     private Path testPath;
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
@@ -120,7 +121,7 @@ public class BlockStreamServiceTest {
         assertEquals(Constants.SERVICE_NAME, blockStreamService.serviceName());
 
         // Verify other methods not invoked
-        verify(streamMediator, never()).publish(any(BlockItem.class));
+        verify(streamMediator, timeout(testTimeout).times(0)).publish(any(BlockItem.class));
     }
 
     @Test
@@ -134,7 +135,7 @@ public class BlockStreamServiceTest {
         assertEquals(5, fileDescriptor.getServices().getFirst().getMethods().size());
 
         // Verify other methods not invoked
-        verify(streamMediator, never()).publish(any(BlockItem.class));
+        verify(streamMediator, timeout(testTimeout).times(0)).publish(any(BlockItem.class));
     }
 
     @Test
@@ -280,13 +281,13 @@ public class BlockStreamServiceTest {
         GrpcService.Routing routing = mock(GrpcService.Routing.class);
         blockStreamService.update(routing);
 
-        verify(routing, timeout(50).times(1))
+        verify(routing, timeout(testTimeout).times(1))
                 .bidi(eq(CLIENT_STREAMING_METHOD_NAME), any(ServerCalls.BidiStreamingMethod.class));
-        verify(routing, timeout(50).times(1))
+        verify(routing, timeout(testTimeout).times(1))
                 .serverStream(
                         eq(SERVER_STREAMING_METHOD_NAME),
                         any(ServerCalls.ServerStreamingMethod.class));
-        verify(routing, timeout(50).times(1))
+        verify(routing, timeout(testTimeout).times(1))
                 .unary(eq(SINGLE_BLOCK_METHOD_NAME), any(ServerCalls.UnaryMethod.class));
     }
 

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -20,7 +20,6 @@ import static com.hedera.block.server.Translator.fromPbj;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -52,6 +51,8 @@ public class ConsumerStreamResponseObserverTest {
 
     private final long TIMEOUT_THRESHOLD_MILLIS = 50L;
     private final long TEST_TIME = 1_719_427_664_950L;
+
+    private static final int testTimeout = 1000;
 
     @Mock private StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> streamMediator;
 
@@ -99,7 +100,8 @@ public class ConsumerStreamResponseObserverTest {
         verify(responseStreamObserver).onNext(fromPbj(subscribeStreamResponse));
 
         // verify the mediator is NOT called to unsubscribe the observer
-        verify(streamMediator, never()).unsubscribe(consumerBlockItemObserver);
+        verify(streamMediator, timeout(testTimeout).times(0))
+                .unsubscribe(consumerBlockItemObserver);
     }
 
     @Test
@@ -127,8 +129,8 @@ public class ConsumerStreamResponseObserverTest {
         new ConsumerStreamResponseObserver(
                 testContext, testClock, streamMediator, serverCallStreamObserver);
 
-        verify(serverCallStreamObserver, timeout(50).times(1)).setOnCloseHandler(any());
-        verify(serverCallStreamObserver, timeout(50).times(1)).setOnCancelHandler(any());
+        verify(serverCallStreamObserver, timeout(testTimeout).times(1)).setOnCloseHandler(any());
+        verify(serverCallStreamObserver, timeout(testTimeout).times(1)).setOnCancelHandler(any());
     }
 
     @Test
@@ -153,7 +155,7 @@ public class ConsumerStreamResponseObserverTest {
         consumerStreamResponseObserver.onEvent(objectEvent, 0, true);
 
         // Confirm that canceling the observer allowed only 1 response to be sent.
-        verify(serverCallStreamObserver, timeout(50).times(1))
+        verify(serverCallStreamObserver, timeout(testTimeout).times(1))
                 .onNext(fromPbj(subscribeStreamResponse));
     }
 
@@ -179,7 +181,7 @@ public class ConsumerStreamResponseObserverTest {
         consumerStreamResponseObserver.onEvent(objectEvent, 0, true);
 
         // Confirm that canceling the observer allowed only 1 response to be sent.
-        verify(serverCallStreamObserver, timeout(50).times(1))
+        verify(serverCallStreamObserver, timeout(testTimeout).times(1))
                 .onNext(fromPbj(subscribeStreamResponse));
     }
 
@@ -221,7 +223,7 @@ public class ConsumerStreamResponseObserverTest {
 
         // Confirm that the observer was called with the next BlockItem
         // since we never send a BlockItem with a Header to start the stream.
-        verify(responseStreamObserver, timeout(50).times(0))
+        verify(responseStreamObserver, timeout(testTimeout).times(0))
                 .onNext(fromPbj(subscribeStreamResponse));
     }
 

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -77,7 +77,7 @@ public class LiveStreamMediatorImplTest {
     private final long TIMEOUT_THRESHOLD_MILLIS = 100L;
     private final long TEST_TIME = 1_719_427_664_950L;
 
-    private static final int testTimeout = 200;
+    private static final int testTimeout = 1000;
 
     private final BlockNodeContext testContext;
 

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -83,6 +83,7 @@ public class ProducerBlockItemObserverTest {
 
     @Mock private ServiceStatus serviceStatus;
     @Mock private InstantSource testClock;
+    private static final int testTimeout = 1000;
 
     @Test
     public void testProducerOnNext() throws IOException, NoSuchAlgorithmException {
@@ -99,19 +100,19 @@ public class ProducerBlockItemObserverTest {
                 PublishStreamRequest.newBuilder().blockItem(blockHeader).build();
         producerBlockItemObserver.onNext(fromPbj(publishStreamRequest));
 
-        verify(streamMediator, timeout(50).times(1)).publish(blockHeader);
+        verify(streamMediator, timeout(testTimeout).times(1)).publish(blockHeader);
 
         final Acknowledgement ack = buildAck(blockHeader);
         final PublishStreamResponse publishStreamResponse =
                 PublishStreamResponse.newBuilder().acknowledgement(ack).build();
 
-        verify(publishStreamResponseObserver, timeout(50).times(1))
+        verify(publishStreamResponseObserver, timeout(testTimeout).times(1))
                 .onNext(fromPbj(publishStreamResponse));
 
         // Helidon will call onCompleted after onNext
         producerBlockItemObserver.onCompleted();
 
-        verify(publishStreamResponseObserver, timeout(50).times(1)).onCompleted();
+        verify(publishStreamResponseObserver, timeout(testTimeout).times(1)).onCompleted();
     }
 
     @Test
@@ -181,9 +182,12 @@ public class ProducerBlockItemObserverTest {
         assertEquals(1, blockNodeContext.metricsService().liveBlockItems.get());
 
         // Confirm each subscriber was notified of the new block
-        verify(streamObserver1, timeout(50).times(1)).onNext(fromPbj(subscribeStreamResponse));
-        verify(streamObserver2, timeout(50).times(1)).onNext(fromPbj(subscribeStreamResponse));
-        verify(streamObserver3, timeout(50).times(1)).onNext(fromPbj(subscribeStreamResponse));
+        verify(streamObserver1, timeout(testTimeout).times(1))
+                .onNext(fromPbj(subscribeStreamResponse));
+        verify(streamObserver2, timeout(testTimeout).times(1))
+                .onNext(fromPbj(subscribeStreamResponse));
+        verify(streamObserver3, timeout(testTimeout).times(1))
+                .onNext(fromPbj(subscribeStreamResponse));
 
         // Confirm the BlockStorage write method was
         // called despite the absence of subscribers
@@ -222,7 +226,8 @@ public class ProducerBlockItemObserverTest {
                         .build();
         final PublishStreamResponse errorResponse =
                 PublishStreamResponse.newBuilder().status(endOfStream).build();
-        verify(publishStreamResponseObserver, timeout(50).times(1)).onNext(fromPbj(errorResponse));
+        verify(publishStreamResponseObserver, timeout(testTimeout).times(1))
+                .onNext(fromPbj(errorResponse));
     }
 
     @Test
@@ -262,10 +267,10 @@ public class ProducerBlockItemObserverTest {
         fromPbj(PublishStreamResponse.newBuilder().status(endOfStream).build());
 
         // verify the ProducerBlockItemObserver has sent an error response
-        verify(publishStreamResponseObserver, timeout(50).times(1))
+        verify(publishStreamResponseObserver, timeout(testTimeout).times(1))
                 .onNext(fromPbj(PublishStreamResponse.newBuilder().status(endOfStream).build()));
 
-        verify(serviceStatus, timeout(50).times(1)).stopWebServer();
+        verify(serviceStatus, timeout(testTimeout).times(1)).stopWebServer();
     }
 
     private static class TestProducerBlockItemObserver extends ProducerBlockItemObserver {


### PR DESCRIPTION
**Description**:

The flaky test in the bug ticket succeeds 100% locally. The test failure in the ticket points to the test timing out before it can confirm the observer is called.

* I increased the testTimeout values to 1 sec
* I did a light refactor on the tests to get them aligned on using a common test timeout at the test suite level.

**Related issue(s)**:

Fixes #139 

- [ ] Tested (unit, integration, etc.)
