### PR TITLE
refactor: simulator entry point to be flexible as test driver

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -19,31 +19,23 @@ package com.hedera.block.simulator;
 import static java.lang.System.Logger.Level.INFO;
 
 import com.hedera.pbj.runtime.ParseException;
-import com.swirlds.config.api.Configuration;
-import com.swirlds.config.api.ConfigurationBuilder;
-import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
-import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
-import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import java.io.IOException;
 import java.lang.System.Logger;
 
-/**
- * The BlockStreamSimulator class defines the simulator for the block stream.
- */
+/** The BlockStreamSimulator class defines the simulator for the block stream. */
 public class BlockStreamSimulator {
     private static final Logger LOGGER = System.getLogger(BlockStreamSimulator.class.getName());
 
     /** This constructor should not be instantiated. */
-    private BlockStreamSimulator() {
-    }
+    private BlockStreamSimulator() {}
 
     /**
      * The main entry point for the block stream simulator.
      *
      * @param args the arguments to be passed to the block stream simulator
-     * @throws IOException          if an I/O error occurs
+     * @throws IOException if an I/O error occurs
      * @throws InterruptedException if the thread is interrupted
-     * @throws ParseException       if a parse error occurs
+     * @throws ParseException if a parse error occurs
      */
     public static void main(String[] args)
             throws IOException, InterruptedException, ParseException {

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -26,41 +26,31 @@ import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import java.io.IOException;
 import java.lang.System.Logger;
-import java.nio.file.Path;
 
-/** The BlockStreamSimulator class defines the simulator for the block stream. */
+/**
+ * The BlockStreamSimulator class defines the simulator for the block stream.
+ */
 public class BlockStreamSimulator {
     private static final Logger LOGGER = System.getLogger(BlockStreamSimulator.class.getName());
 
     /** This constructor should not be instantiated. */
-    private BlockStreamSimulator() {}
+    private BlockStreamSimulator() {
+    }
 
     /**
      * The main entry point for the block stream simulator.
      *
      * @param args the arguments to be passed to the block stream simulator
-     * @throws IOException if an I/O error occurs
+     * @throws IOException          if an I/O error occurs
      * @throws InterruptedException if the thread is interrupted
-     * @throws ParseException if a parse error occurs
+     * @throws ParseException       if a parse error occurs
      */
     public static void main(String[] args)
             throws IOException, InterruptedException, ParseException {
 
         LOGGER.log(INFO, "Starting Block Stream Simulator");
 
-        ConfigurationBuilder configurationBuilder =
-                ConfigurationBuilder.create()
-                        .withSource(SystemEnvironmentConfigSource.getInstance())
-                        .withSource(SystemPropertiesConfigSource.getInstance())
-                        .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
-                        .autoDiscoverExtensions();
-
-        Configuration configuration = configurationBuilder.build();
-
-        BlockStreamSimulatorInjectionComponent DIComponent =
-                DaggerBlockStreamSimulatorInjectionComponent.factory().create(configuration);
-
-        BlockStreamSimulatorApp blockStreamSimulatorApp = DIComponent.getBlockStreamSimulatorApp();
+        BlockStreamSimulatorApp blockStreamSimulatorApp = new BlockStreamSimulatorApp();
         blockStreamSimulatorApp.start();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -22,31 +22,40 @@ import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;
 import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
+import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
+import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Path;
 import javax.inject.Inject;
 
 /** BlockStream Simulator App */
 public class BlockStreamSimulatorApp {
 
-    private static final System.Logger LOGGER =
-            System.getLogger(BlockStreamSimulatorApp.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(BlockStreamSimulatorApp.class.getName());
 
-    Configuration configuration;
-    BlockStreamManager blockStreamManager;
-    PublishStreamGrpcClient publishStreamGrpcClient;
-    BlockStreamConfig blockStreamConfig;
+    private final Configuration configuration;
+    private BlockStreamManager blockStreamManager;
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+    private BlockStreamConfig blockStreamConfig;
 
     private final int delayBetweenBlockItems;
 
-    boolean isRunning = false;
+    private boolean isRunning = false;
 
     /**
      * Creates a new BlockStreamSimulatorApp instance.
      *
-     * @param configuration the configuration to be used by the block stream simulator
-     * @param blockStreamManager the block stream manager to be used by the block stream simulator
-     * @param publishStreamGrpcClient the gRPC client to be used by the block stream simulator
+     * @param configuration           the configuration to be used by the block
+     *                                stream simulator
+     * @param blockStreamManager      the block stream manager to be used by the
+     *                                block stream simulator
+     * @param publishStreamGrpcClient the gRPC client to be used by the block stream
+     *                                simulator
      */
     @Inject
     public BlockStreamSimulatorApp(
@@ -63,11 +72,76 @@ public class BlockStreamSimulatorApp {
     }
 
     /**
+     * Constructs a new {@code BlockStreamSimulatorApp} with the specified
+     * configuration.
+     *
+     * @param configuration the configuration to use for the simulator app
+     */
+    public BlockStreamSimulatorApp(Configuration configuration) {
+        this.configuration = configuration;
+        initilizeDependencies();
+        initializeConfig();
+
+        this.delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+    }
+
+    /**
+     * Constructs a new {@code BlockStreamSimulatorApp} with the default
+     * configuration.
+     *
+     * @throws IOException if an I/O error occurs while loading the default
+     *                     configuration
+     */
+    public BlockStreamSimulatorApp() throws IOException {
+        this.configuration = loadDefaultConfiguration();
+        initilizeDependencies();
+        initializeConfig();
+
+        this.delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+    }
+
+    /**
+     * Initializes the configuration by retrieving the {@code BlockStreamConfig}
+     * from the current
+     * configuration.
+     */
+    private void initializeConfig() {
+        this.blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
+    }
+
+    /**
+     * Initializes the dependencies required by the simulator app using Dagger
+     * dependency injection.
+     */
+    private void initilizeDependencies() {
+        BlockStreamSimulatorInjectionComponent DIComponent = DaggerBlockStreamSimulatorInjectionComponent.factory()
+                .create(configuration);
+
+        this.blockStreamManager = DIComponent.getBlockStreamManager();
+        this.publishStreamGrpcClient = DIComponent.getPublishStreamGrpcClient();
+    }
+
+    /**
+     * Loads the default configuration for the simulator app.
+     *
+     * @return the default configuration
+     * @throws IOException if an I/O error occurs while loading the configuration
+     */
+    private Configuration loadDefaultConfiguration() throws IOException {
+        ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
+                .withSource(SystemEnvironmentConfigSource.getInstance())
+                .withSource(SystemPropertiesConfigSource.getInstance())
+                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
+                .autoDiscoverExtensions();
+        return configurationBuilder.build();
+    }
+
+    /**
      * Starts the block stream simulator.
      *
      * @throws InterruptedException if the thread is interrupted
-     * @throws ParseException if a parse error occurs
-     * @throws IOException if an I/O error occurs
+     * @throws ParseException       if a parse error occurs
+     * @throws IOException          if an I/O error occurs
      */
     public void start() throws InterruptedException, ParseException, IOException {
         int delayMSBetweenBlockItems = delayBetweenBlockItems / 1_000_000;

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
@@ -17,8 +17,10 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.ConfigInjectionModule;
+import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.generator.GeneratorInjectionModule;
 import com.hedera.block.simulator.grpc.GrpcInjectionModule;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
 import com.swirlds.config.api.Configuration;
 import dagger.BindsInstance;
 import dagger.Component;
@@ -40,6 +42,20 @@ public interface BlockStreamSimulatorInjectionComponent {
      * @return the block stream simulator
      */
     BlockStreamSimulatorApp getBlockStreamSimulatorApp();
+
+    /**
+     * Gets the block stream manager.
+     *
+     * @return the block stream manager
+     */
+    BlockStreamManager getBlockStreamManager();
+
+    /**
+     * Gets publish grpc client.
+     *
+     * @return publish grpc client
+     */
+    PublishStreamGrpcClient getPublishStreamGrpcClient();
 
     /** The factory used to create the block stream simulator injection component. */
     @Component.Factory

--- a/simulator/src/main/java/com/hedera/block/simulator/Constants.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/Constants.java
@@ -18,8 +18,12 @@ package com.hedera.block.simulator;
 
 public class Constants {
 
-    // The file extension for block files.
+    /** The file extension for block files. */
     public static final String RECORD_EXTENSION = "blk";
-    // postfix for gzipped files
+
+    /** Postfix for gzipped files */
     public static final String GZ_EXTENSION = ".gz";
+
+    /** Name and file extension used for the configuration file. */
+    public static final String CONFIGURATION_FILE = "app.properties";
 }

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -3,6 +3,7 @@ import com.hedera.block.simulator.config.SimulatorConfigExtension;
 /** Runtime module of the simulator. */
 module com.hedera.block.simulator {
     exports com.hedera.block.simulator.config.data;
+    exports com.hedera.block.simulator;
 
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -3,7 +3,6 @@ import com.hedera.block.simulator.config.SimulatorConfigExtension;
 /** Runtime module of the simulator. */
 module com.hedera.block.simulator {
     exports com.hedera.block.simulator.config.data;
-    exports com.hedera.block.simulator;
 
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -40,21 +40,21 @@ class BlockStreamSimulatorTest {
 
     private Configuration configuration;
 
-    @Mock private BlockStreamManager blockStreamManager;
+    @Mock
+    private BlockStreamManager blockStreamManager;
 
-    @Mock private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
 
     private BlockStreamSimulatorApp blockStreamSimulator;
 
     @BeforeEach
     void setUp() throws IOException {
 
-        configuration =
-                TestUtils.getTestConfiguration(Map.of("blockStream.maxBlockItemsToStream", "100"));
+        configuration = TestUtils.getTestConfiguration(Map.of("blockStream.maxBlockItemsToStream", "100"));
 
-        blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient);
     }
 
     @AfterEach
@@ -88,12 +88,20 @@ class BlockStreamSimulatorTest {
                 new BlockStreamSimulatorApp(
                         configuration, blockStreamManager, publishStreamGrpcClient);
 
+    void start_usingConfigurationConstructor() throws InterruptedException {
+        blockStreamSimulator = new BlockStreamSimulatorApp(configuration);
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
     }
 
     private String getAbsoluteFolder(String relativePath) {
         return Paths.get(relativePath).toAbsolutePath().toString();
+
+    @Test
+    void start_usingEmptyConstructor() throws IOException, InterruptedException {
+        blockStreamSimulator = new BlockStreamSimulatorApp();
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -40,21 +40,21 @@ class BlockStreamSimulatorTest {
 
     private Configuration configuration;
 
-    @Mock
-    private BlockStreamManager blockStreamManager;
+    @Mock private BlockStreamManager blockStreamManager;
 
-    @Mock
-    private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock private PublishStreamGrpcClient publishStreamGrpcClient;
 
     private BlockStreamSimulatorApp blockStreamSimulator;
 
     @BeforeEach
     void setUp() throws IOException {
 
-        configuration = TestUtils.getTestConfiguration(Map.of("blockStream.maxBlockItemsToStream", "100"));
+        configuration =
+                TestUtils.getTestConfiguration(Map.of("blockStream.maxBlockItemsToStream", "100"));
 
-        blockStreamSimulator = new BlockStreamSimulatorApp(
-                configuration, blockStreamManager, publishStreamGrpcClient);
+        blockStreamSimulator =
+                new BlockStreamSimulatorApp(
+                        configuration, blockStreamManager, publishStreamGrpcClient);
     }
 
     @AfterEach
@@ -88,7 +88,12 @@ class BlockStreamSimulatorTest {
                 new BlockStreamSimulatorApp(
                         configuration, blockStreamManager, publishStreamGrpcClient);
 
-    void start_usingConfigurationConstructor() throws InterruptedException {
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
+
+    void start_usingConfigurationConstructor()
+            throws InterruptedException, ParseException, IOException {
         blockStreamSimulator = new BlockStreamSimulatorApp(configuration);
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
@@ -96,9 +101,10 @@ class BlockStreamSimulatorTest {
 
     private String getAbsoluteFolder(String relativePath) {
         return Paths.get(relativePath).toAbsolutePath().toString();
+    }
 
     @Test
-    void start_usingEmptyConstructor() throws IOException, InterruptedException {
+    void start_usingEmptyConstructor() throws IOException, InterruptedException, ParseException {
         blockStreamSimulator = new BlockStreamSimulatorApp();
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());


### PR DESCRIPTION
**Description**:
This PR aims to refactor the simulator entry point and add flexabilty, in terms of how it can be started.
Adding two new constructors and moving the dagger initialization in the applicaiton itself, rather being in the main method.
This allows us to use it easy in the suites module, where we have the E2E tests.

**Related issue(s)**:

Fixes #190 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
