### PR TITLE
refactor: adjust configuration management and smoke test setup to support production config by default

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -65,7 +65,6 @@ jobs:
           sudo tar -xzf grpcurl.tar.gz -C /usr/local/bin grpcurl
           rm grpcurl.tar.gz
 
-
       - name: Cache Gradle packages
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
@@ -76,18 +75,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build application
-        run: ${{ env.GRADLE_EXEC }} build
+      - name: Build And Run Smoke Tests Container
+        run: ${{ env.GRADLE_EXEC }} buildAndRunSmokeTestsContainer -x test
 
-      - name: Run application in background, capture logs in app.log
-        run: |
-          ${{ env.GRADLE_EXEC }} :server:run 2> server/src/test/resources/app.log < /dev/null &
-          echo "Application started with PID $APP_PID"
-          sleep 10
-
-      - name: Print App Logs
-        run: cat server/src/test/resources/app.log
-
-      - name: Smoke Test
+      - name: Run Smoke Test
         working-directory: server/src/test/resources/
-        run: ./smoke-test.sh app.log
+        run: ./smoke-test.sh
+
+      - name: Stop Smoke Tests Container
+        run: docker compose -p block-node stop

--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ Please do not file a public ticket mentioning the vulnerability. Refer to the se
 
 ## Configuration
 
-| Environment Variable            | Description                                                                                                   | Default Value |
-|---------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|
-| persistence.storage.rootPath    | The root path for the storage, if not provided will attempt to create a `data` on the working dir of the app. | ./data        |
-| consumer.timeoutThresholdMillis | Time to wait for subscribers before disconnecting in milliseconds                                             | 1500          |
-
-
+| Environment Variable              | Description                                                                                                   | Default Value |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------------|---------------|
+| PERSISTENCE_STORAGE_ROOT_PATH     | The root path for the storage, if not provided will attempt to create a `data` on the working dir of the app. |               |
+| CONSUMER_TIMEOUT_THRESHOLD_MILLIS | Time to wait for subscribers before disconnecting in milliseconds                                             | 1500          |
+| SERVICE_DELAY_MILLIS              | Service shutdown delay in milliseconds                                                                        | 500           |
+| MEDIATOR_RING_BUFFER_SIZE         | Size of the ring buffer used by the mediator (must be a power of 2)                                           | 67108864      |
+| NOTIFIER_RING_BUFFER_SIZE         | Size of the ring buffer used by the notifier (must be a power of 2)                                           | 2048          |
 
 # Starting locally:
 ```bash

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -4,19 +4,33 @@
 # This script is called by gradle and get the current project version as an input param
 
 if [ $# -lt 1 ]; then
-  echo "USAGE: $0 <VERSION> <DEBUG>"
+  echo "USAGE: $0 <VERSION> <DEBUG> <SMOKE_TEST>"
   exit 1
 fi
 
-echo "VERSION=$1" > .env
+project_version=$1
+# determine if we should include debug opts
+[ "$2" = true ] && is_debug=true || is_debug=false
+# determine if we should include smoke test env variables
+[ "$3" = true ] && is_smoke_test=true || is_smoke_test=false
+
+echo "VERSION=$project_version" > .env
 echo "REGISTRY_PREFIX=" >> .env
 # Storage root path, this is temporary until we have a proper .properties file for all configs
 echo "BLOCKNODE_STORAGE_ROOT_PATH=/app/storage" >> .env
 echo "JAVA_OPTS='-Xms8G -Xmx16G'" >> .env
 
-if [ $# -eq 2 ]; then
+if [ true = "$is_debug" ]; then
+  # wait for debugger to attach
   echo "SERVER_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'" >> .env
 fi
 
-echo "DEBUG $2"
-echo "VERSION/TAG UPDATED TO $1"
+if [ true = "$is_smoke_test" ]; then
+  # add smoke test variables
+  echo "MEDIATOR_RING_BUFFER_SIZE=1024" >> .env
+  echo "NOTIFIER_RING_BUFFER_SIZE=1024" >> .env
+fi
+
+# Output the values
+echo ".env properties:"
+cat .env

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -22,10 +22,10 @@ import static io.helidon.config.ConfigSources.file;
 import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.INFO;
 
+import com.hedera.block.server.config.ServerMappedConfigSourceInitializer;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
-import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import io.helidon.config.Config;
 import java.io.IOException;
@@ -59,7 +59,7 @@ public class Server {
         // Init BlockNode Configuration
         final Configuration configuration =
                 ConfigurationBuilder.create()
-                        .withSource(SystemEnvironmentConfigSource.getInstance())
+                        .withSource(ServerMappedConfigSourceInitializer.getMappedConfigSource())
                         .withSource(SystemPropertiesConfigSource.getInstance())
                         .withSources(new ClasspathFileConfigSource(Path.of(APPLICATION_PROPERTIES)))
                         .autoDiscoverExtensions()

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.config;
+
+import com.swirlds.config.extensions.sources.ConfigMapping;
+import com.swirlds.config.extensions.sources.MappedConfigSource;
+import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+
+/**
+ * A class that extends {@link MappedConfigSource} ir order to have project-relevant initialization.
+ */
+public final class ServerMappedConfigSourceInitializer {
+    private static final List<ConfigMapping> MAPPINGS =
+            List.of(
+                    new ConfigMapping(
+                            "consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
+                    new ConfigMapping(
+                            "persistence.storage.rootPath", "PERSISTENCE_STORAGE_ROOT_PATH"),
+                    new ConfigMapping("service.delayMillis", "SERVICE_DELAY_MILLIS"),
+                    new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
+                    new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE"));
+
+    private ServerMappedConfigSourceInitializer() {}
+
+    /**
+     * This method constructs, initializes and returns a new instance of {@link MappedConfigSource}
+     * which internally uses {@link SystemEnvironmentConfigSource} and maps relevant config keys to
+     * other keys so that they could be used within the application
+     *
+     * @return newly constructed fully initialized {@link MappedConfigSource}
+     */
+    @NonNull
+    public static MappedConfigSource getMappedConfigSource() {
+        final MappedConfigSource config =
+                new MappedConfigSource(SystemEnvironmentConfigSource.getInstance());
+        MAPPINGS.forEach(config::addMapping);
+        return config;
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/mediator/MediatorConfig.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/MediatorConfig.java
@@ -28,9 +28,8 @@ import com.swirlds.config.api.ConfigProperty;
  *
  * @param ringBufferSize the size of the ring buffer used by the mediator
  */
-// TODO: defaultValue here should be 67108864
 @ConfigData("mediator")
-public record MediatorConfig(@ConfigProperty(defaultValue = "1024") int ringBufferSize) {
+public record MediatorConfig(@ConfigProperty(defaultValue = "67108864") int ringBufferSize) {
     private static final System.Logger LOGGER = System.getLogger(MediatorConfig.class.getName());
 
     /**

--- a/server/src/main/java/com/hedera/block/server/notifier/NotifierConfig.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/NotifierConfig.java
@@ -28,9 +28,8 @@ import com.swirlds.config.api.ConfigProperty;
  *
  * @param ringBufferSize the size of the ring buffer used by the notifier
  */
-// TODO: defaultValue here should be 2048
 @ConfigData("notifier")
-public record NotifierConfig(@ConfigProperty(defaultValue = "1024") int ringBufferSize) {
+public record NotifierConfig(@ConfigProperty(defaultValue = "2048") int ringBufferSize) {
     private static final System.Logger LOGGER = System.getLogger(NotifierConfig.class.getName());
 
     /**

--- a/server/src/main/resources/app.properties
+++ b/server/src/main/resources/app.properties
@@ -1,8 +1,8 @@
 prometheus.endpointPortNumber=9999
 
 # Ring buffer sizes for the mediator and notifier
-mediator.ringBufferSize=67108864
-notifier.ringBufferSize=2048
+#mediator.ringBufferSize=
+#notifier.ringBufferSize=
 
 # Timeout for consumers to wait for block item before timing out. Default is 1500 milliseconds.
 #consumer.timeoutThresholdMillis=1500

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.swirlds.config.extensions.sources.ConfigMapping;
+import com.swirlds.config.extensions.sources.MappedConfigSource;
+import java.lang.reflect.Field;
+import java.util.Queue;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ServerMappedConfigSourceInitializerTest {
+    private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
+        new ConfigMapping("consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
+        new ConfigMapping("persistence.storage.rootPath", "PERSISTENCE_STORAGE_ROOT_PATH"),
+        new ConfigMapping("service.delayMillis", "SERVICE_DELAY_MILLIS"),
+        new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
+        new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE")
+    };
+    private static MappedConfigSource toTest;
+
+    @BeforeAll
+    static void setUp() {
+        toTest = ServerMappedConfigSourceInitializer.getMappedConfigSource();
+    }
+
+    /**
+     * This test aims to fail if we have added or removed any {@link ConfigMapping} that will be
+     * initialized by the {@link ServerMappedConfigSourceInitializer#getMappedConfigSource()}
+     * without reflecting it here in the test. The purpose is to bring attention to any changes to
+     * the developer so we can make sure we are aware of them in order to be sure we require the
+     * change. This test is more to bring attention than to test actual logic. So if this fails, we
+     * either change the {@link #SUPPORTED_MAPPINGS} here or the {@link
+     * ServerMappedConfigSourceInitializer#MAPPINGS} to make this pass.
+     */
+    @Test
+    void test_VerifyAllSupportedMappingsAreAddedToInstance() throws ReflectiveOperationException {
+        final Queue<ConfigMapping> actual = extractConfigMappings();
+
+        assertEquals(SUPPORTED_MAPPINGS.length, actual.size());
+
+        for (final ConfigMapping current : SUPPORTED_MAPPINGS) {
+            final Predicate<ConfigMapping> predicate =
+                    cm ->
+                            current.mappedName().equals(cm.mappedName())
+                                    && current.originalName().equals(cm.originalName());
+            assertTrue(
+                    actual.stream().anyMatch(predicate),
+                    () ->
+                            "when testing for: [%s] it is not contained in mappings of the actual initialized object %s"
+                                    .formatted(current, actual));
+        }
+    }
+
+    private static Queue<ConfigMapping> extractConfigMappings()
+            throws ReflectiveOperationException {
+        final Field configMappings = MappedConfigSource.class.getDeclaredField("configMappings");
+        try {
+            configMappings.setAccessible(true);
+            return (Queue<ConfigMapping>) configMappings.get(toTest);
+        } finally {
+            configMappings.setAccessible(false);
+        }
+    }
+}

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -45,7 +45,7 @@ val updateDockerEnv =
         group = "docker"
 
         workingDir(layout.projectDirectory.dir("../server/docker"))
-        commandLine("./update-env.sh", project.version)
+        commandLine("sh", "-c", "./update-env.sh ${project.version} false false")
     }
 
 // Task to build the Docker image


### PR DESCRIPTION
**Description**:

- make the default values in config records to be the production ones;
- the app.properties file should not be setting the production values, by default it should be empty, we should only set props there if we want to override the production defaults;
- when executing smoke tests, the config records should be with test values;
- explore options to achieve the result: **(1)** use env variables - does not seem to work as expected, the config dependency gets the vars via `System.getenv()` and it only shows case-sensitive keys, so adding a value like `mediator.ringBufferSize=1024` will result into not being visible in runtime, it seems to me to be inconsistent. **(2)** build the jar for the smoke tests with the `app.properties` from `src/test/resources` - this works, the file gets packaged into the jar, only hurdle currently is to find a good and reliable way to do it with a `gradle` task.
- a single `gradle` task execution should be sufficient to build and run the needed environment for the test to pass

**UPDATE:**
- after some discussions with @mattp-swirldslabs & @AlfredoG87, we have discussed some issues that we have discovered:
    1. environment variables that are set to the docker container are read only if they are all upper case and separated only via `_`.;
    1. the initial idea of making a single `gradle` task (see some previous commits in this PR) that will build the project with correct test props, create the docker image and run it (so we can have an easy single entry point) did not seem to work when I tried it, since when in `gh actions` I execute either a shell script or the `gradle` task that contains a shell invocation of the `docker` executable, `gh actions` failed with exit code 14 (insufficient privileges). After some research, I see that I probably need to use the `docker` executable directly in the `run` part of the step. That worked and the test passed after commiting. So this part is still debatable, can I or can I not use the `docker` executable from a shell script.;

- since this discussions, there are several discoveries:
    1. using the `IntelliJ` IDE, if we modify the run config to include an environment variable with lowercase and `.` separator, it gets discovered. I am still to understand how that works and why, it does not seem to get passed as an CLI arg when starting the jar, so the IDE is doing something else. But that only means that it is indeed possible to discover non-conventional keys for environment variables.;
    1. as an approach, we could use `PropertyFileConfigSource.class` and read vars directly from a file (this is different from `ClasspathFileConfigSource.java` where we technically still load a file `app.properties` but this is packaged into the jar, here we are talking about an arbitrary file outside the `classpath`), this worked and is a potential approach. However, it has the lowest precedence, so if the same key comes from basically any other source, this will get overridden, we need to keep that in mind. Ordinals could be set in the constructor, so we can decide precedence. (see `ConfigSourceOrdinalConstants.java`);

- final approach (or the usage of multiple approaches so more could be tested if decided so) is still under debate;

**UPDATE:**
- after a discussion with @jsync-swirlds, he noted that we will be able to support by default unconventional casing for environment variables (meaning an environment variable like `mediator.ringBufferSize=1024` will be picked up without having to do anything special). Until then, we can use the `MappedConfigSource` in order to support the mapping between uppercase variables and the formate we need them (for example the env variable `MEDIATOR_RING_BUFFER_SIZE=1024` will be available with that key as well as with this one `mediator.ringBufferSize=1024`). For now, we can only pick up uppercase variables with an `_` separator, but with the mapping, we will be able to read the values with the mapped key.

**Related issue(s)**:

Fixes #185 

**Notes for reviewer**:

Tested locally:
- Start the `jar` directly and use `app.properties`
- Start the `jar` directly and use `env` vars
- Start the `docker` container and use `app.properties`
- Start the `docker` container and use `env` vars
- Start the `smoke-test` action locally and use `app.properties`
- Start the `smoke-test` action locally and use `env` vars
- Start `k8s` cluster with the container and use `app.properties`
- Start `k8s` cluster with the container and use `env` vars
- Started all of the above with both `app.properties` and `env` vars, expected that the `env` vars take precedence (as is by default and we have not changed the default precedence)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
