### PR TITLE
ci: Update release-automation.yaml to enable completion

### DIFF
--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -135,7 +135,7 @@ jobs:
         uses: Decathlon/release-notes-generator-action@98423db7024696a339f3988ac8a2b051c5860741 # v3.1.6
         env:
           FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           MILESTONE_NUMBER: ${{ steps.milestone.outputs.milestone_id }}
 
       - name: Commit and Tag

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -30,9 +30,6 @@ defaults:
   run:
     shell: bash
 
-env:
-  LC_ALL: C.UTF-8
-
 jobs:
   release:
     name: Release
@@ -84,7 +81,7 @@ jobs:
 
       - name: Import GPG Key
         id: gpg_importer
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4 # v6.1.0
+        uses: step-security/ghaction-import-gpg@6c8fe4d0126a59d57c21f87c9ae5dd3451fa3cca # v6.1.0
         with:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
@@ -103,13 +100,14 @@ jobs:
 
       - name: Create and Switch to Release Branch
         run: |
+          git fetch origin
           if ! git ls-remote --exit-code --heads --quiet origin refs/heads/${RELEASE_BRANCH}; then
             git checkout -b ${RELEASE_BRANCH}
             git push -u origin ${RELEASE_BRANCH}
 
             # create a PR to bump main branch to the next snapshot version
             echo "CREATE_PR=true" >> $GITHUB_ENV
-            echo "PR_TITLE=Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
+            echo "PR_TITLE=chore(release): Bump versions for v$NEXT_VERSION_SNAPSHOT" >> $GITHUB_ENV
           else
             git checkout ${RELEASE_BRANCH}
           fi

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -24,7 +24,7 @@ on:
 
 permissions:
   contents: write
-  issues: write
+  actions: write
 
 defaults:
   run:
@@ -80,7 +80,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -89,8 +89,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_user_signingkey: true
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Install JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
@@ -128,7 +128,7 @@ jobs:
         with:
           milestone_name: ${{ steps.version_parser.outputs.release }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Create Release Notes
         if: ${{ steps.milestone.outputs.milestone_id != '' }}
@@ -158,7 +158,7 @@ jobs:
           omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}
           tag: ${{ env.RELEASE_TAG }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
   create_pr:
     name: Create PR
@@ -178,7 +178,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
+          fetch-depth: 0
           ref: main
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -187,8 +189,8 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: true
           git_user_signingkey: true
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
 
       - name: Install JDK
         uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
@@ -218,4 +220,4 @@ jobs:
           delete-branch: true
           signoff: true
           title: ${{ needs.release.outputs.pr_title }}
-          token: ${{ secrets.HEDERA_BOT_TOKEN }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -78,6 +78,7 @@ jobs:
           fetch-depth: 0
           ref: main
           token: ${{ secrets.GH_ACCESS_TOKEN }}
+          persist-credentials: 'true'
 
       - name: Import GPG Key
         id: gpg_importer


### PR DESCRIPTION
**Description**:

Uses the newly added GPG_KEY_CONTENTS, GPG_KEY_PASSPHRASE, and GH_ACCESS_TOKEN github actions secrets to enable the workflow to run.

**Related Issue(s)**:

Fixes: #235
Fixes: #229 

Testing:

See the [v99.99.99-draft workflow run](https://github.com/hashgraph/hedera-block-node/actions/runs/11247622943/job/31272540073) which completes successfully

