### PR TITLE
fix: update-env.sh now injects JAVA_OPTS params

### DIFF
--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -12,6 +12,7 @@ echo "VERSION=$1" > .env
 echo "REGISTRY_PREFIX=" >> .env
 # Storage root path, this is temporary until we have a proper .properties file for all configs
 echo "BLOCKNODE_STORAGE_ROOT_PATH=/app/storage" >> .env
+echo "JAVA_OPTS='-Xms8G -Xmx16G'" >> .env
 
 if [ $# -eq 2 ]; then
   echo "SERVER_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'" >> .env


### PR DESCRIPTION
**Description**:
* Added shell code to append the JVM memory requirements via JAVA_OPTS into the `.env` file

**Related issue(s)**:

Fixes #244 

