### PR TITLE
feat: added MILLIS_PER_BLOCK Streaming mode to the simulator 

### DIFF
--- a/buildSrc/src/main/kotlin/com.hedera.block.jpms-modules.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.jpms-modules.gradle.kts
@@ -191,6 +191,7 @@ extraJavaModuleInfo {
         "com.github.docker-java:docker-java-transport-zerodep",
         "com.github.dockerjava.transport.zerodep"
     )
+
     module("io.github.cdimascio:java-dotenv", "io.github.cdimascio")
     module("com.google.protobuf:protobuf-java-util", "com.google.protobuf.util")
     module("com.squareup:javapoet", "com.squareup.javapoet") {

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -38,15 +38,17 @@ There are 2 configuration sets:
 ### BlockStreamConfig
 Uses the prefix `blockStream` so all properties should start with `blockStream.`
 
-| Key                      | Description                                                                                                                                                                | Default Value                   |
-|--------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
-| `generationMode`         | The desired generation Mode to use, it can only be `DIR` or `AD_HOC`                                                                                                       | `DIR`                           |
-| `folderRootPath`         | If the generationMode is DIR this will be used as the source of the recording to stream to the Block-Node                                                                  | ``                              |
-| `delayBetweenBlockItems` | The delay between each block item in nanoseconds                                                                                                                           | `1_500_000`                     |
-| `managerImplementation`  | The desired implementation of the BlockStreamManager to use, it can only be `BlockAsDirBlockStreamManager`, `BlockAsFileBlockStreamManager` or `BlockAsFileLargeDataSets`  | `BlockAsFileBlockStreamManager` |
-| `maxBlockItemsToStream`  | exit condition for the simulator and the circular implementations such as `BlockAsDir` or `BlockAsFile` implementations                                                    | `10_000`                        |
-| `paddedLength`           | on the `BlockAsFileLargeDataSets` implementation, the length of the padded left zeroes `000001.blk.gz`                                                                     | 36                              |
-| `fileExtension`          | on the `BlockAsFileLargeDataSets` implementation, the extension of the files to be streamed                                                                                | `.blk.gz`                       |
+| Key                      | Description                                                                                                                                                               | Default Value                   |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| `generationMode`         | The desired generation Mode to use, it can only be `DIR` or `AD_HOC`                                                                                                      | `DIR`                           |
+| `folderRootPath`         | If the generationMode is DIR this will be used as the source of the recording to stream to the Block-Node                                                                 | ``                              |
+| `delayBetweenBlockItems` | The delay between each block item in nanoseconds, only applicable when streamingMode=CONSTANT_RATE                                                                        | `1_500_000`                     |
+| `managerImplementation`  | The desired implementation of the BlockStreamManager to use, it can only be `BlockAsDirBlockStreamManager`, `BlockAsFileBlockStreamManager` or `BlockAsFileLargeDataSets` | `BlockAsFileBlockStreamManager` |
+| `maxBlockItemsToStream`  | exit condition for the simulator and the circular implementations such as `BlockAsDir` or `BlockAsFile` implementations                                                   | `10_000`                        |
+| `paddedLength`           | on the `BlockAsFileLargeDataSets` implementation, the length of the padded left zeroes `000001.blk.gz`                                                                    | 36                              |
+| `fileExtension`          | on the `BlockAsFileLargeDataSets` implementation, the extension of the files to be streamed                                                                               | `.blk.gz`                       |
+| `streamingMode`          | can either be `CONSTANT_RATE` or `MILLIS_PER_BLOCK`, if `CONSTANT_RATE`                                                                                                   | `CONSTANT_RATE`                 |
+| `millisecondsPerBlock`   | if streamingMode is `MILLIS_PER_BLOCK` this will be the time to wait between blocks in milliseconds                                                                       | `1_000`                         |
 
 ### GrpcConfig
 Uses the prefix `grpc` so all properties should start with `grpc.`

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -17,9 +17,11 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -33,12 +35,14 @@ public class BlockStreamSimulatorApp {
     private static final System.Logger LOGGER =
             System.getLogger(BlockStreamSimulatorApp.class.getName());
 
-    Configuration configuration;
-    BlockStreamManager blockStreamManager;
-    PublishStreamGrpcClient publishStreamGrpcClient;
-    BlockStreamConfig blockStreamConfig;
+    private final Configuration configuration;
+    private final BlockStreamManager blockStreamManager;
+    private final PublishStreamGrpcClient publishStreamGrpcClient;
+    private final BlockStreamConfig blockStreamConfig;
+    private final StreamingMode streamingMode;
 
     private final int delayBetweenBlockItems;
+    private final int millisecondsPerBlock;
 
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -59,7 +63,8 @@ public class BlockStreamSimulatorApp {
         this.publishStreamGrpcClient = publishStreamGrpcClient;
 
         blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
-
+        streamingMode = blockStreamConfig.streamingMode();
+        millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
         delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
     }
 
@@ -71,38 +76,13 @@ public class BlockStreamSimulatorApp {
      * @throws IOException if an I/O error occurs
      */
     public void start() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        int delayMSBetweenBlockItems = delayBetweenBlockItems / 1_000_000;
-        int delayNSBetweenBlockItems = delayBetweenBlockItems % 1_000_000;
-
         isRunning.set(true);
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has started");
 
-        boolean streamBlockItem = true;
-        int blockItemsStreamed = 0;
-
-        while (streamBlockItem) {
-            // get block item
-            BlockItem blockItem = blockStreamManager.getNextBlockItem();
-
-            if (blockItem == null) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the end of the block items");
-                break;
-            }
-
-            publishStreamGrpcClient.streamBlockItem(blockItem);
-            blockItemsStreamed++;
-
-            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
-
-            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the maximum number of block items to"
-                                + " stream");
-                streamBlockItem = false;
-            }
+        if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
+            millisPerBlockStreaming();
+        } else {
+            constantRateStreaming();
         }
 
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
@@ -121,5 +101,59 @@ public class BlockStreamSimulatorApp {
     public void stop() {
         isRunning.set(false);
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
+    }
+
+    private void constantRateStreaming()
+            throws InterruptedException, IOException, BlockSimulatorParsingException {
+        int delayMSBetweenBlockItems = delayBetweenBlockItems / 1_000_000;
+        int delayNSBetweenBlockItems = delayBetweenBlockItems % 1_000_000;
+        boolean streamBlockItem = true;
+        int blockItemsStreamed = 0;
+
+        while (streamBlockItem) {
+            // get block item
+            BlockItem blockItem = blockStreamManager.getNextBlockItem();
+            if (blockItem == null) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the end of the block items");
+                break;
+            }
+            publishStreamGrpcClient.streamBlockItem(blockItem);
+            blockItemsStreamed++;
+            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
+            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the maximum number of block items to"
+                                + " stream");
+                streamBlockItem = false;
+            }
+        }
+
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
+    }
+
+    private void millisPerBlockStreaming()
+            throws IOException, InterruptedException, BlockSimulatorParsingException {
+        final long secondsPerBlockNanos = millisecondsPerBlock * 1_000_000L;
+
+        Block nextBlock = blockStreamManager.getNextBlock();
+        while (nextBlock != null) {
+            long startTime = System.nanoTime();
+            publishStreamGrpcClient.streamBlock(nextBlock);
+            long elapsedTime = System.nanoTime() - startTime;
+            long timeToDelay = secondsPerBlockNanos - elapsedTime;
+            if (timeToDelay > 0) {
+                Thread.sleep(timeToDelay / 1_000_000, (int) (timeToDelay % 1_000_000));
+            } else {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "Block Server is running behind, Streaming took longer than max expected: "
+                                + millisecondsPerBlock
+                                + " milliseconds");
+            }
+            nextBlock = blockStreamManager.getNextBlock();
+        }
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -17,6 +17,7 @@
 package com.hedera.block.simulator.config.data;
 
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import java.nio.file.Files;
@@ -33,6 +34,8 @@ import java.nio.file.Paths;
  * @param maxBlockItemsToStream the maximum number of block items to stream
  * @param paddedLength the padded length of 0 the block file format
  * @param fileExtension the file extension of the block file format
+ * @param streamingMode the mode of streaming for the block stream
+ * @param millisecondsPerBlock the milliseconds per block
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
@@ -43,7 +46,9 @@ public record BlockStreamConfig(
                 String managerImplementation,
         @ConfigProperty(defaultValue = "10_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "36") int paddedLength,
-        @ConfigProperty(defaultValue = ".blk.gz") String fileExtension) {
+        @ConfigProperty(defaultValue = ".blk.gz") String fileExtension,
+        @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
+        @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock) {
 
     /**
      * Constructor to set the default root path if not provided, it will be set to the data

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/StreamingMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/StreamingMode.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.types;
+
+/** The StreamingMode enum defines the different modes for streaming blocks. */
+public enum StreamingMode {
+
+    /** It will wait X Nanos between each block. */
+    CONSTANT_RATE,
+
+    /** It will attempt to send a block each X Millis. */
+    MILLIS_PER_BLOCK;
+
+    /**
+     * Converts a string to a StreamingMode.
+     *
+     * @param mode the string to convert
+     * @return the StreamingMode
+     */
+    public static StreamingMode fromString(String mode) {
+        return switch (mode) {
+            case "CONSTANT_RATE" -> CONSTANT_RATE;
+            case "MILLIS_PER_BLOCK" -> MILLIS_PER_BLOCK;
+            default -> throw new IllegalArgumentException("Invalid mode: " + mode);
+        };
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator.config.data;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -31,6 +32,8 @@ class BlockStreamConfigTest {
     private final int maxBlockItemsToStream = 10_000;
     private final int paddedLength = 36;
     private final String fileExtension = ".blk";
+    private final StreamingMode streamingMode = StreamingMode.CONSTANT_RATE;
+    private final int millisPerBlock = 1000;
 
     private String getAbsoluteFolder(String relativePath) {
         return Paths.get(relativePath).toAbsolutePath().toString();
@@ -56,7 +59,9 @@ class BlockStreamConfigTest {
                         blockStreamManagerImplementation,
                         maxBlockItemsToStream,
                         paddedLength,
-                        fileExtension);
+                        fileExtension,
+                        streamingMode,
+                        millisPerBlock);
 
         assertEquals(folderRootPath, config.folderRootPath());
         assertEquals(GenerationMode.DIR, config.generationMode());
@@ -77,7 +82,9 @@ class BlockStreamConfigTest {
                         blockStreamManagerImplementation,
                         maxBlockItemsToStream,
                         paddedLength,
-                        fileExtension);
+                        fileExtension,
+                        streamingMode,
+                        millisPerBlock);
 
         // Verify that the path is set to the default
         Path expectedPath = Paths.get("src/main/resources/block-0.0.3/").toAbsolutePath();
@@ -103,7 +110,9 @@ class BlockStreamConfigTest {
                                         blockStreamManagerImplementation,
                                         maxBlockItemsToStream,
                                         paddedLength,
-                                        fileExtension));
+                                        fileExtension,
+                                        streamingMode,
+                                        millisPerBlock));
 
         // Verify the exception message
         assertEquals(relativeFolderPath + " Root path must be absolute", exception.getMessage());
@@ -131,7 +140,9 @@ class BlockStreamConfigTest {
                                         blockStreamManagerImplementation,
                                         maxBlockItemsToStream,
                                         paddedLength,
-                                        fileExtension));
+                                        fileExtension,
+                                        streamingMode,
+                                        millisPerBlock));
 
         // Verify the exception message
         assertEquals("Folder does not exist: " + path, exception.getMessage());
@@ -152,7 +163,9 @@ class BlockStreamConfigTest {
                         blockStreamManagerImplementation,
                         maxBlockItemsToStream,
                         paddedLength,
-                        fileExtension);
+                        fileExtension,
+                        streamingMode,
+                        millisPerBlock);
 
         // Verify that the configuration was created successfully
         assertEquals(folderRootPath, config.folderRootPath());

--- a/simulator/src/test/java/com/hedera/block/simulator/config/types/StreamingModeTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/types/StreamingModeTest.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package com.hedera.block.simulator;
+package com.hedera.block.simulator.config.types;
 
-/** The Constants class defines the constants for the block simulator. */
-public class Constants {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    /** Constructor to prevent instantiation. this is only a utility class */
-    private Constants() {}
+class StreamingModeTest {
 
-    /** The file extension for block files. */
-    public static final String RECORD_EXTENSION = "blk";
-
-    /** postfix for gzip files */
-    public static final String GZ_EXTENSION = ".gz";
+    @org.junit.jupiter.api.Test
+    void fromString() {
+        assertEquals(StreamingMode.CONSTANT_RATE, StreamingMode.fromString("CONSTANT_RATE"));
+        assertEquals(StreamingMode.MILLIS_PER_BLOCK, StreamingMode.fromString("MILLIS_PER_BLOCK"));
+        assertThrows(IllegalArgumentException.class, () -> StreamingMode.fromString("INVALID"));
+    }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -82,7 +83,9 @@ class BlockAsDirBlockStreamManagerTest {
                         "BlockAsDirBlockStreamManager",
                         10_000,
                         36,
-                        ".blk");
+                        ".blk",
+                        StreamingMode.CONSTANT_RATE,
+                        1000);
         return new BlockAsDirBlockStreamManager(blockStreamConfig);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -84,7 +85,9 @@ class BlockAsFileBlockStreamManagerTest {
                         "BlockAsFileBlockStreamManager",
                         10_000,
                         36,
-                        ".blk");
+                        ".blk",
+                        StreamingMode.CONSTANT_RATE,
+                        1000);
         return new BlockAsFileBlockStreamManager(blockStreamConfig);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.File;
@@ -103,7 +104,9 @@ class BlockAsFileLargeDataSetsTest {
                         "BlockAsFileBlockStreamManager",
                         10_000,
                         36,
-                        ".blk");
+                        ".blk",
+                        StreamingMode.CONSTANT_RATE,
+                        1000);
         BlockAsFileLargeDataSets blockStreamManager =
                 new BlockAsFileLargeDataSets(blockStreamConfig);
 
@@ -123,7 +126,9 @@ class BlockAsFileLargeDataSetsTest {
                         "BlockAsFileBlockStreamManager",
                         10_000,
                         36,
-                        ".blk");
+                        ".blk",
+                        StreamingMode.CONSTANT_RATE,
+                        1000);
         return new BlockAsFileLargeDataSets(blockStreamConfig);
     }
 

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -71,6 +71,8 @@ public abstract class BaseSuite {
      * Setup method to be executed before all tests.
      *
      * <p>This method initializes the Block Node server container using Testcontainers.
+     *
+     * @throws IOException if an I/O error occurs
      */
     @BeforeAll
     public static void setup() throws IOException {

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -19,6 +19,7 @@ package com.hedera.block.suites.persistence.positive;
 import com.hedera.block.suites.BaseSuite;
 import org.junit.jupiter.api.DisplayName;
 
+/** Positive Data Persistence Tests */
 @DisplayName("Positive Data Persistence Tests")
 public class PositiveDataPersistenceTests extends BaseSuite {
     /** Default constructor for the {@link PositiveDataPersistenceTests} class. */


### PR DESCRIPTION
**Description**:
Improvements to how the simulator is able to stream to the BlockNode, this commit creates a StreamingMode enum, with 2 values, CONSTANT_RATE and MILLIS_PER_BLOCK.

CONSTANT_RATE is the streaming mode that we have been using, that streams a block item, then waits X amount of NS, then streams another blockItem.

MILLIS_PER_BLOCK, does a lot less thread interruptions, and has a more realistic behaviour, since is going to stream the whole block, as fast as it can, and then going to sleep for X-(time it took to stream) being X the target of block production, by default 1 block is produced each second, so it will attempt to stream 1 block per every 1000 ms, however if the block takes more than 1000 ms to stream, it wont sleep at all, but WARN of a potential issue.

Added documentation for explaining the changes.

**Related issue(s)**:

Fixes #249 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
