### PR TITLE
refactor: Stream of repeated block items instead of block items

### DIFF
--- a/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
+++ b/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.common.utils;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -23,8 +24,14 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+/** Utility class for chunking collections. */
 public final class ChunkUtils {
-    public static <T> List<List<T>> chunkify(final Collection<T> collection, final int chunkSize) {
+    /** Chunks a collection into a list of lists of the specified size.
+     * @param collection the collection to chunk, if the collection is empty, an empty list is returned.
+     * @param chunkSize the size of each chunk
+     *  */
+    public static <T> List<List<T>> chunkify(
+            @NonNull final Collection<T> collection, final int chunkSize) {
         Objects.requireNonNull(collection);
         if (chunkSize <= 0) {
             throw new IllegalArgumentException("Chunk size must be greater than 0");

--- a/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
+++ b/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.common.utils;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ChunkUtils {
+    public static <T> List<List<T>> chunkify(final Collection<T> collection, final int chunkSize) {
+        Objects.requireNonNull(collection);
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException("Chunk size must be greater than 0");
+        }
+        if (collection.isEmpty()) {
+            return Collections.emptyList(); // or throw, depends on how we want to handle
+        }
+        final List<T> localCollection = List.copyOf(collection);
+        final int localCollectionSize = localCollection.size();
+        return IntStream.iterate(0, i -> i < localCollectionSize, i -> i + chunkSize)
+                .mapToObj(
+                        i ->
+                                localCollection.subList(
+                                        i, Math.min(i + chunkSize, localCollectionSize)))
+                .collect(Collectors.toList());
+    }
+
+    private ChunkUtils() {}
+}

--- a/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
+++ b/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
@@ -29,6 +29,8 @@ public final class ChunkUtils {
     /** Chunks a collection into a list of lists of the specified size.
      * @param collection the collection to chunk, if the collection is empty, an empty list is returned.
      * @param chunkSize the size of each chunk
+     * @param <T> the type of the collection
+     * @return a list of lists of the specified size
      *  */
     public static <T> List<List<T>> chunkify(
             @NonNull final Collection<T> collection, final int chunkSize) {

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -1,3 +1,6 @@
+/**
+ * Module info for common module.
+ */
 module com.hedera.block.common {
     exports com.hedera.block.common.constants;
     exports com.hedera.block.common.utils;

--- a/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
@@ -16,7 +16,9 @@
 
 package com.hedera.block.common.utils;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.common.utils;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class ChunkUtilsTest {
+
+    @Test
+    public void testEmptyCollection() {
+        List<Integer> emptyList = Collections.emptyList();
+        List<List<Integer>> chunks = ChunkUtils.chunkify(emptyList, 3);
+        assertTrue(chunks.isEmpty(), "Chunks of empty collection should be empty");
+    }
+
+    @Test
+    public void testChunkSizeZero() {
+        List<Integer> list = Arrays.asList(1, 2, 3);
+        Exception exception =
+                assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, 0));
+        assertEquals("Chunk size must be greater than 0", exception.getMessage());
+    }
+
+    @Test
+    public void testChunkSizeNegative() {
+        List<Integer> list = Arrays.asList(1, 2, 3);
+        Exception exception =
+                assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, -1));
+        assertEquals("Chunk size must be greater than 0", exception.getMessage());
+    }
+
+    @Test
+    public void testChunkifyCollectionSmallerThanChunkSize() {
+        List<Integer> list = Arrays.asList(1, 2);
+        List<List<Integer>> chunks = ChunkUtils.chunkify(list, 5);
+        assertEquals(1, chunks.size(), "Should return one chunk");
+        assertEquals(list, chunks.get(0), "Chunk should contain the entire collection");
+    }
+
+    @Test
+    public void testChunkifyCollectionExactlyDivisible() {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4);
+        List<List<Integer>> chunks = ChunkUtils.chunkify(list, 2);
+        assertEquals(2, chunks.size(), "Should return two chunks");
+        assertEquals(Arrays.asList(1, 2), chunks.get(0), "First chunk mismatch");
+        assertEquals(Arrays.asList(3, 4), chunks.get(1), "Second chunk mismatch");
+    }
+
+    @Test
+    public void testChunkifyCollectionNotExactlyDivisible() {
+        List<Integer> list = Arrays.asList(1, 2, 3, 4, 5);
+        List<List<Integer>> chunks = ChunkUtils.chunkify(list, 2);
+        assertEquals(3, chunks.size(), "Should return three chunks");
+        assertEquals(Arrays.asList(1, 2), chunks.get(0), "First chunk mismatch");
+        assertEquals(Arrays.asList(3, 4), chunks.get(1), "Second chunk mismatch");
+        assertEquals(Arrays.asList(5), chunks.get(2), "Third chunk mismatch");
+    }
+
+    @Test
+    public void testNullCollection() {
+        assertThrows(NullPointerException.class, () -> ChunkUtils.chunkify(null, 3));
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
@@ -17,6 +17,7 @@
 package com.hedera.block.server;
 
 import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.grpc.BlockStreamService;
 import com.hedera.block.server.metrics.MetricsService;
 import com.swirlds.config.api.Configuration;
 import dagger.Binds;

--- a/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
@@ -17,14 +17,11 @@
 package com.hedera.block.server;
 
 import com.hedera.block.server.config.BlockNodeContext;
-import com.hedera.block.server.grpc.BlockStreamService;
 import com.hedera.block.server.metrics.MetricsService;
 import com.swirlds.config.api.Configuration;
-import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import io.helidon.webserver.WebServerConfig;
-import io.helidon.webserver.grpc.GrpcService;
 import javax.inject.Singleton;
 
 /**
@@ -47,16 +44,6 @@ public interface BlockNodeAppInjectionModule {
             Configuration config, MetricsService metricsService) {
         return new BlockNodeContext(metricsService, config);
     }
-
-    /**
-     * Provides a block stream service singleton using DI.
-     *
-     * @param blockStreamService should come from DI
-     * @return a block stream service singleton
-     */
-    @Singleton
-    @Binds
-    GrpcService bindBlockStreamService(BlockStreamService blockStreamService);
 
     /**
      * Provides a web server config builder singleton using DI.

--- a/server/src/main/java/com/hedera/block/server/BlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/BlockStreamService.java
@@ -18,7 +18,7 @@ package com.hedera.block.server;
 
 import static com.hedera.block.server.Constants.CLIENT_STREAMING_METHOD_NAME;
 import static com.hedera.block.server.Constants.SERVER_STREAMING_METHOD_NAME;
-import static com.hedera.block.server.Constants.SERVICE_NAME;
+import static com.hedera.block.server.Constants.SERVICE_NAME_BLOCK_STREAM;
 import static com.hedera.block.server.Constants.SINGLE_BLOCK_METHOD_NAME;
 import static com.hedera.block.server.Translator.fromPbj;
 import static com.hedera.block.server.Translator.toPbj;
@@ -126,7 +126,7 @@ public class BlockStreamService implements GrpcService {
     @NonNull
     @Override
     public String serviceName() {
-        return SERVICE_NAME;
+        return SERVICE_NAME_BLOCK_STREAM;
     }
 
     /**

--- a/server/src/main/java/com/hedera/block/server/Constants.java
+++ b/server/src/main/java/com/hedera/block/server/Constants.java
@@ -32,7 +32,9 @@ public final class Constants {
     @NonNull public static final String LOGGING_PROPERTIES = "logging.properties";
 
     /** Constant mapped to the name of the service in the .proto file */
-    @NonNull public static final String SERVICE_NAME = "BlockStreamService";
+    @NonNull public static final String SERVICE_NAME_BLOCK_STREAM = "BlockStreamService";
+
+    @NonNull public static final String SERVICE_NAME_BLOCK_ACCESS = "BlockAccessService";
 
     /** Constant mapped to the publishBlockStream service method name in the .proto file */
     @NonNull public static final String CLIENT_STREAMING_METHOD_NAME = "publishBlockStream";

--- a/server/src/main/java/com/hedera/block/server/Constants.java
+++ b/server/src/main/java/com/hedera/block/server/Constants.java
@@ -31,9 +31,10 @@ public final class Constants {
      */
     @NonNull public static final String LOGGING_PROPERTIES = "logging.properties";
 
-    /** Constant mapped to the name of the service in the .proto file */
+    /** Constant mapped to the name of the BlockStream service in the .proto file */
     @NonNull public static final String SERVICE_NAME_BLOCK_STREAM = "BlockStreamService";
 
+    /** Constant mapped to the name of the BlockAccess service in the .proto file */
     @NonNull public static final String SERVICE_NAME_BLOCK_ACCESS = "BlockAccessService";
 
     /** Constant mapped to the publishBlockStream service method name in the .proto file */

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -17,7 +17,6 @@
 package com.hedera.block.server.consumer;
 
 import static com.hedera.block.server.Translator.fromPbj;
-import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItemsConsumed;
 import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
@@ -27,14 +26,17 @@ import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.LivenessCalculator;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.mediator.SubscriptionHandler;
+import com.hedera.block.server.metrics.BlockNodeMetricTypes;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.hapi.block.SubscribeStreamResponse;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.OneOf;
+import com.swirlds.metrics.api.Counter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.time.InstantSource;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -55,7 +57,7 @@ public class ConsumerStreamResponseObserver
 
     private final AtomicBoolean isResponsePermitted = new AtomicBoolean(true);
     private final ResponseSender statusResponseSender = new StatusResponseSender();
-    private final ResponseSender blockItemResponseSender = new BlockItemResponseSender();
+    private final ResponseSender blockItemsResponseSender = new BlockItemsResponseSender();
 
     private static final String PROTOCOL_VIOLATION_MESSAGE =
             "Protocol Violation. %s is OneOf type %s but %s is null.\n%s";
@@ -186,7 +188,7 @@ public class ConsumerStreamResponseObserver
                 subscribeStreamResponse.response();
         return switch (oneOfTypeOneOf.kind()) {
             case STATUS -> statusResponseSender;
-            case BLOCK_ITEM -> blockItemResponseSender;
+            case BLOCK_ITEMS -> blockItemsResponseSender;
             default -> throw new IllegalArgumentException(
                     "Unknown response type: " + oneOfTypeOneOf.kind());
         };
@@ -196,35 +198,39 @@ public class ConsumerStreamResponseObserver
         void send(@NonNull final SubscribeStreamResponse subscribeStreamResponse);
     }
 
-    private final class BlockItemResponseSender implements ResponseSender {
+    private final class BlockItemsResponseSender implements ResponseSender {
         private boolean streamStarted = false;
 
         public void send(@NonNull final SubscribeStreamResponse subscribeStreamResponse) {
 
-            // Only start sending BlockItems after we've reached
-            // the beginning of a block.
-            final BlockItem blockItem = subscribeStreamResponse.blockItem();
-            if (blockItem == null) {
+            if (subscribeStreamResponse.blockItems() == null) {
                 final String message =
                         PROTOCOL_VIOLATION_MESSAGE.formatted(
                                 "SubscribeStreamResponse",
-                                "BLOCK_ITEM",
-                                "block_item",
+                                "BLOCK_ITEMS",
+                                "block_items",
                                 subscribeStreamResponse);
                 LOGGER.log(ERROR, message);
                 throw new IllegalArgumentException(message);
-            } else {
-                if (!streamStarted && blockItem.hasBlockHeader()) {
-                    streamStarted = true;
-                }
+            }
 
-                if (streamStarted) {
-                    LOGGER.log(DEBUG, "Sending BlockItem downstream: " + blockItem);
+            final List<BlockItem> blockItems = subscribeStreamResponse.blockItems().blockItems();
+            // Only start sending BlockItems after we've reached
+            // the beginning of a block.
+            if (!streamStarted && blockItems.getFirst().hasBlockHeader()) {
+                streamStarted = true;
+            }
 
-                    // Increment counter
-                    metricsService.get(LiveBlockItemsConsumed).increment();
-                    subscribeStreamResponseObserver.onNext(fromPbj(subscribeStreamResponse));
+            if (streamStarted) {
+                LOGGER.log(DEBUG, "Sending BlockItem Batch downstream");
+
+                final Counter liveBlockItemsConsumed =
+                        metricsService.get(BlockNodeMetricTypes.Counter.LiveBlockItemsConsumed);
+                // Increment counter manually
+                for (int i = 0; i < blockItems.size(); i++) {
+                    liveBlockItemsConsumed.increment();
                 }
+                subscribeStreamResponseObserver.onNext(fromPbj(subscribeStreamResponse));
             }
         }
     }

--- a/server/src/main/java/com/hedera/block/server/grpc/BlockAccessService.java
+++ b/server/src/main/java/com/hedera/block/server/grpc/BlockAccessService.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.grpc;
+
+import static com.hedera.block.server.Constants.SINGLE_BLOCK_METHOD_NAME;
+import static com.hedera.block.server.Translator.fromPbj;
+import static com.hedera.block.server.Translator.toPbj;
+import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SingleBlocksNotFound;
+import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SingleBlocksRetrieved;
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.ERROR;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.hedera.block.server.Constants;
+import com.hedera.block.server.metrics.MetricsService;
+import com.hedera.block.server.persistence.storage.read.BlockReader;
+import com.hedera.block.server.service.ServiceStatus;
+import com.hedera.hapi.block.SingleBlockRequest;
+import com.hedera.hapi.block.SingleBlockResponseCode;
+import com.hedera.hapi.block.protoc.BlockService;
+import com.hedera.hapi.block.protoc.SingleBlockResponse;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.pbj.runtime.ParseException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.grpc.stub.StreamObserver;
+import io.helidon.webserver.grpc.GrpcService;
+import java.io.IOException;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/**
+ * The BlockAccessService class provides a gRPC service to access blocks.
+ *
+ * <p>This service provides a unary gRPC method to retrieve a single block by block number.
+ */
+public class BlockAccessService implements GrpcService {
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    private final ServiceStatus serviceStatus;
+    private final BlockReader<Block> blockReader;
+    private final MetricsService metricsService;
+
+    /**
+     * Constructs a new BlockAccessService instance with the given dependencies.
+     *
+     * @param serviceStatus used to query the service status
+     * @param blockReader used to retrieve blocks
+     * @param metricsService used to observe metrics
+     */
+    @Inject
+    public BlockAccessService(
+            @NonNull ServiceStatus serviceStatus,
+            @NonNull BlockReader<Block> blockReader,
+            @NonNull MetricsService metricsService) {
+        this.serviceStatus = serviceStatus;
+        this.blockReader = blockReader;
+        this.metricsService = metricsService;
+    }
+
+    @Override
+    public Descriptors.FileDescriptor proto() {
+        return BlockService.getDescriptor();
+    }
+
+    @Override
+    public String serviceName() {
+        return Constants.SERVICE_NAME_BLOCK_ACCESS;
+    }
+
+    @Override
+    public void update(Routing routing) {
+        routing.unary(SINGLE_BLOCK_METHOD_NAME, this::protocSingleBlock);
+    }
+
+    void protocSingleBlock(
+            @NonNull final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest,
+            @NonNull final StreamObserver<SingleBlockResponse> singleBlockResponseStreamObserver) {
+        LOGGER.log(DEBUG, "Executing Unary singleBlock gRPC method");
+
+        try {
+            final SingleBlockRequest pbjSingleBlockRequest =
+                    toPbj(SingleBlockRequest.PROTOBUF, singleBlockRequest.toByteArray());
+            singleBlock(pbjSingleBlockRequest, singleBlockResponseStreamObserver);
+        } catch (ParseException e) {
+            LOGGER.log(ERROR, "Error parsing protoc SingleBlockRequest: {0}", singleBlockRequest);
+            singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
+        }
+    }
+
+    private void singleBlock(
+            @NonNull final SingleBlockRequest singleBlockRequest,
+            @NonNull
+                    final StreamObserver<com.hedera.hapi.block.protoc.SingleBlockResponse>
+                            singleBlockResponseStreamObserver) {
+
+        LOGGER.log(DEBUG, "Executing Unary singleBlock gRPC method");
+
+        if (serviceStatus.isRunning()) {
+            final long blockNumber = singleBlockRequest.blockNumber();
+            try {
+                final Optional<Block> blockOpt = blockReader.read(blockNumber);
+                if (blockOpt.isPresent()) {
+                    LOGGER.log(DEBUG, "Successfully returning block number: {0}", blockNumber);
+                    singleBlockResponseStreamObserver.onNext(
+                            fromPbjSingleBlockSuccessResponse(blockOpt.get()));
+
+                    metricsService.get(SingleBlocksRetrieved).increment();
+                } else {
+                    LOGGER.log(DEBUG, "Block number {0} not found", blockNumber);
+                    singleBlockResponseStreamObserver.onNext(buildSingleBlockNotFoundResponse());
+                    metricsService.get(SingleBlocksNotFound).increment();
+                }
+            } catch (IOException e) {
+                LOGGER.log(ERROR, "Error reading block number: {0}", blockNumber);
+                singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
+            } catch (ParseException e) {
+                LOGGER.log(ERROR, "Error parsing block number: {0}", blockNumber);
+                singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
+            }
+        } else {
+            LOGGER.log(ERROR, "Unary singleBlock gRPC method is not currently running");
+            singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
+        }
+
+        // Send the response
+        singleBlockResponseStreamObserver.onCompleted();
+    }
+
+    @NonNull
+    static com.hedera.hapi.block.protoc.SingleBlockResponse buildSingleBlockNotAvailableResponse() {
+        final com.hedera.hapi.block.SingleBlockResponse response =
+                com.hedera.hapi.block.SingleBlockResponse.newBuilder()
+                        .status(SingleBlockResponseCode.READ_BLOCK_NOT_AVAILABLE)
+                        .build();
+
+        return fromPbj(response);
+    }
+
+    @NonNull
+    static com.hedera.hapi.block.protoc.SingleBlockResponse buildSingleBlockNotFoundResponse()
+            throws InvalidProtocolBufferException {
+        final com.hedera.hapi.block.SingleBlockResponse response =
+                com.hedera.hapi.block.SingleBlockResponse.newBuilder()
+                        .status(SingleBlockResponseCode.READ_BLOCK_NOT_FOUND)
+                        .build();
+
+        return fromPbj(response);
+    }
+
+    @NonNull
+    static com.hedera.hapi.block.protoc.SingleBlockResponse fromPbjSingleBlockSuccessResponse(
+            @NonNull final Block block) {
+        final com.hedera.hapi.block.SingleBlockResponse singleBlockResponse =
+                com.hedera.hapi.block.SingleBlockResponse.newBuilder()
+                        .status(SingleBlockResponseCode.READ_BLOCK_SUCCESS)
+                        .block(block)
+                        .build();
+
+        return fromPbj(singleBlockResponse);
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/grpc/BlockAccessService.java
+++ b/server/src/main/java/com/hedera/block/server/grpc/BlockAccessService.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.server.grpc;
 
+import static com.hedera.block.server.Constants.SERVICE_NAME_BLOCK_ACCESS;
 import static com.hedera.block.server.Constants.SINGLE_BLOCK_METHOD_NAME;
 import static com.hedera.block.server.Translator.fromPbj;
 import static com.hedera.block.server.Translator.toPbj;
@@ -26,7 +27,6 @@ import static java.lang.System.Logger.Level.ERROR;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.hedera.block.server.Constants;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.service.ServiceStatus;
@@ -79,7 +79,7 @@ public class BlockAccessService implements GrpcService {
 
     @Override
     public String serviceName() {
-        return Constants.SERVICE_NAME_BLOCK_ACCESS;
+        return SERVICE_NAME_BLOCK_ACCESS;
     }
 
     @Override

--- a/server/src/main/java/com/hedera/block/server/grpc/BlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/grpc/BlockStreamService.java
@@ -30,15 +30,12 @@ import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.mediator.LiveStreamMediator;
-import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.notifier.Notifier;
-import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.producer.ProducerBlockItemObserver;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.hapi.block.SubscribeStreamResponse;
 import com.hedera.hapi.block.SubscribeStreamResponseCode;
 import com.hedera.hapi.block.protoc.BlockService;
-import com.hedera.hapi.block.stream.Block;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.stub.StreamObserver;
 import io.helidon.webserver.grpc.GrpcService;
@@ -55,10 +52,7 @@ public class BlockStreamService implements GrpcService {
 
     private final LiveStreamMediator streamMediator;
     private final ServiceStatus serviceStatus;
-    private final BlockReader<Block> blockReader;
-
     private final BlockNodeContext blockNodeContext;
-    private final MetricsService metricsService;
 
     private final Notifier notifier;
 
@@ -68,26 +62,21 @@ public class BlockStreamService implements GrpcService {
      *
      * @param streamMediator the stream mediator to proxy block items from the producer to the
      *     subscribers and manage the subscription lifecycle for subscribers
-     * @param blockReader the block reader to fetch blocks from storage for unary singleBlock
-     *     service calls
      * @param serviceStatus the service status provides methods to check service availability and to
      *     stop the service and web server in the event of an unrecoverable exception
      */
     @Inject
     BlockStreamService(
             @NonNull final LiveStreamMediator streamMediator,
-            @NonNull final BlockReader<Block> blockReader,
             @NonNull final ServiceStatus serviceStatus,
             @NonNull
                     final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponse>>
                             streamPersistenceHandler,
             @NonNull final Notifier notifier,
             @NonNull final BlockNodeContext blockNodeContext) {
-        this.blockReader = blockReader;
         this.serviceStatus = serviceStatus;
         this.notifier = notifier;
         this.blockNodeContext = blockNodeContext;
-        this.metricsService = blockNodeContext.metricsService();
 
         streamMediator.subscribe(streamPersistenceHandler);
         this.streamMediator = streamMediator;

--- a/server/src/main/java/com/hedera/block/server/grpc/BlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/grpc/BlockStreamService.java
@@ -14,22 +14,17 @@
  * limitations under the License.
  */
 
-package com.hedera.block.server;
+package com.hedera.block.server.grpc;
 
 import static com.hedera.block.server.Constants.CLIENT_STREAMING_METHOD_NAME;
 import static com.hedera.block.server.Constants.SERVER_STREAMING_METHOD_NAME;
 import static com.hedera.block.server.Constants.SERVICE_NAME_BLOCK_STREAM;
-import static com.hedera.block.server.Constants.SINGLE_BLOCK_METHOD_NAME;
 import static com.hedera.block.server.Translator.fromPbj;
-import static com.hedera.block.server.Translator.toPbj;
-import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SingleBlocksNotFound;
-import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SingleBlocksRetrieved;
 import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 
 import com.google.protobuf.Descriptors;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.consumer.ConsumerStreamResponseObserver;
 import com.hedera.block.server.events.BlockNodeEventHandler;
@@ -40,26 +35,19 @@ import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.producer.ProducerBlockItemObserver;
 import com.hedera.block.server.service.ServiceStatus;
-import com.hedera.hapi.block.SingleBlockRequest;
-import com.hedera.hapi.block.SingleBlockResponse;
-import com.hedera.hapi.block.SingleBlockResponseCode;
 import com.hedera.hapi.block.SubscribeStreamResponse;
 import com.hedera.hapi.block.SubscribeStreamResponseCode;
 import com.hedera.hapi.block.protoc.BlockService;
 import com.hedera.hapi.block.stream.Block;
-import com.hedera.pbj.runtime.ParseException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.stub.StreamObserver;
 import io.helidon.webserver.grpc.GrpcService;
-import java.io.IOException;
 import java.time.Clock;
-import java.util.Optional;
 import javax.inject.Inject;
 
 /**
  * The BlockStreamService class defines the gRPC service for the block stream service. It provides
- * the implementation for the bidirectional streaming, server streaming, and unary methods defined
- * in the proto file.
+ * the implementation for the bidirectional streaming, server streaming as defined in the proto file.
  */
 public class BlockStreamService implements GrpcService {
 
@@ -140,7 +128,6 @@ public class BlockStreamService implements GrpcService {
     public void update(@NonNull final Routing routing) {
         routing.bidi(CLIENT_STREAMING_METHOD_NAME, this::protocPublishBlockStream);
         routing.serverStream(SERVER_STREAMING_METHOD_NAME, this::protocSubscribeBlockStream);
-        routing.unary(SINGLE_BLOCK_METHOD_NAME, this::protocSingleBlock);
     }
 
     StreamObserver<com.hedera.hapi.block.protoc.PublishStreamRequest> protocPublishBlockStream(
@@ -198,62 +185,6 @@ public class BlockStreamService implements GrpcService {
         }
     }
 
-    void protocSingleBlock(
-            @NonNull final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest,
-            @NonNull
-                    final StreamObserver<com.hedera.hapi.block.protoc.SingleBlockResponse>
-                            singleBlockResponseStreamObserver) {
-        LOGGER.log(DEBUG, "Executing Unary singleBlock gRPC method");
-
-        try {
-            final SingleBlockRequest pbjSingleBlockRequest =
-                    toPbj(SingleBlockRequest.PROTOBUF, singleBlockRequest.toByteArray());
-            singleBlock(pbjSingleBlockRequest, singleBlockResponseStreamObserver);
-        } catch (ParseException e) {
-            LOGGER.log(ERROR, "Error parsing protoc SingleBlockRequest: {0}", singleBlockRequest);
-            singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
-        }
-    }
-
-    private void singleBlock(
-            @NonNull final SingleBlockRequest singleBlockRequest,
-            @NonNull
-                    final StreamObserver<com.hedera.hapi.block.protoc.SingleBlockResponse>
-                            singleBlockResponseStreamObserver) {
-
-        LOGGER.log(DEBUG, "Executing Unary singleBlock gRPC method");
-
-        if (serviceStatus.isRunning()) {
-            final long blockNumber = singleBlockRequest.blockNumber();
-            try {
-                final Optional<Block> blockOpt = blockReader.read(blockNumber);
-                if (blockOpt.isPresent()) {
-                    LOGGER.log(DEBUG, "Successfully returning block number: {0}", blockNumber);
-                    singleBlockResponseStreamObserver.onNext(
-                            fromPbjSingleBlockSuccessResponse(blockOpt.get()));
-
-                    metricsService.get(SingleBlocksRetrieved).increment();
-                } else {
-                    LOGGER.log(DEBUG, "Block number {0} not found", blockNumber);
-                    singleBlockResponseStreamObserver.onNext(buildSingleBlockNotFoundResponse());
-                    metricsService.get(SingleBlocksNotFound).increment();
-                }
-            } catch (IOException e) {
-                LOGGER.log(ERROR, "Error reading block number: {0}", blockNumber);
-                singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
-            } catch (ParseException e) {
-                LOGGER.log(ERROR, "Error parsing block number: {0}", blockNumber);
-                singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
-            }
-        } else {
-            LOGGER.log(ERROR, "Unary singleBlock gRPC method is not currently running");
-            singleBlockResponseStreamObserver.onNext(buildSingleBlockNotAvailableResponse());
-        }
-
-        // Send the response
-        singleBlockResponseStreamObserver.onCompleted();
-    }
-
     // TODO: Fix this error type once it's been standardized in `hedera-protobufs`
     //  this should not be success
     @NonNull
@@ -265,38 +196,5 @@ public class BlockStreamService implements GrpcService {
                         .build();
 
         return fromPbj(response);
-    }
-
-    @NonNull
-    static com.hedera.hapi.block.protoc.SingleBlockResponse buildSingleBlockNotAvailableResponse() {
-        final SingleBlockResponse response =
-                SingleBlockResponse.newBuilder()
-                        .status(SingleBlockResponseCode.READ_BLOCK_NOT_AVAILABLE)
-                        .build();
-
-        return fromPbj(response);
-    }
-
-    @NonNull
-    static com.hedera.hapi.block.protoc.SingleBlockResponse buildSingleBlockNotFoundResponse()
-            throws InvalidProtocolBufferException {
-        final SingleBlockResponse response =
-                SingleBlockResponse.newBuilder()
-                        .status(SingleBlockResponseCode.READ_BLOCK_NOT_FOUND)
-                        .build();
-
-        return fromPbj(response);
-    }
-
-    @NonNull
-    static com.hedera.hapi.block.protoc.SingleBlockResponse fromPbjSingleBlockSuccessResponse(
-            @NonNull final Block block) {
-        final SingleBlockResponse singleBlockResponse =
-                SingleBlockResponse.newBuilder()
-                        .status(SingleBlockResponseCode.READ_BLOCK_SUCCESS)
-                        .block(block)
-                        .build();
-
-        return fromPbj(singleBlockResponse);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/grpc/GrpcServiceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/grpc/GrpcServiceInjectionModule.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.grpc;
+
+import dagger.Binds;
+import dagger.Module;
+import javax.inject.Singleton;
+
+/**
+ * A Dagger Module for GRPC services that are at the BlockNode Services.
+ */
+@Module
+public interface GrpcServiceInjectionModule {
+
+    /**
+     * Provides a block stream service singleton using DI.
+     *
+     * @param blockStreamService should come from DI
+     * @return a block stream service singleton
+     */
+    @Singleton
+    @Binds
+    BlockStreamService bindBlockStreamService(BlockStreamService blockStreamService);
+
+    /**
+     * Provides a block access service singleton using DI.
+     *
+     * @param blockAccessService should come from DI
+     * @return a block access service singleton
+     */
+    @Singleton
+    @Binds
+    BlockAccessService bindBlockAccessService(BlockAccessService blockAccessService);
+}

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
@@ -19,10 +19,11 @@ package com.hedera.block.server.mediator;
 import com.hedera.block.server.notifier.Notifiable;
 import com.hedera.hapi.block.SubscribeStreamResponse;
 import com.hedera.hapi.block.stream.BlockItem;
+import java.util.List;
 
 /**
  * Use this interface to combine the contract for mediating the live stream of blocks from the
  * Hedera network with the contract to be notified of critical system events.
  */
 public interface LiveStreamMediator
-        extends StreamMediator<BlockItem, SubscribeStreamResponse>, Notifiable {}
+        extends StreamMediator<List<BlockItem>, SubscribeStreamResponse>, Notifiable {}

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
@@ -33,7 +33,6 @@ import com.hedera.hapi.block.SubscribeStreamResponseCode;
 import com.hedera.hapi.block.SubscribeStreamResponseSet;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.lmax.disruptor.BatchEventProcessor;
-import com.swirlds.metrics.api.Counter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Map;
@@ -109,11 +108,8 @@ class LiveStreamMediatorImpl extends SubscriptionHandlerBase<SubscribeStreamResp
                     SubscribeStreamResponse.newBuilder().blockItems(blockItemsSet).build();
             ringBuffer.publishEvent((event, sequence) -> event.set(subscribeStreamResponse));
 
-            // Increment the block item counter
-            Counter liveBlockItems = metricsService.get(LiveBlockItems);
-            for (int i = 0; i < blockItems.size(); i++) {
-                liveBlockItems.increment();
-            }
+            // Increment the block item counter by all block items published
+            metricsService.get(LiveBlockItems).add(blockItems.size());
 
         } else {
             LOGGER.log(ERROR, "StreamMediator is not accepting BlockItems");

--- a/server/src/main/java/com/hedera/block/server/notifier/Notifier.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/Notifier.java
@@ -19,9 +19,11 @@ package com.hedera.block.server.notifier;
 import com.hedera.block.server.mediator.StreamMediator;
 import com.hedera.hapi.block.PublishStreamResponse;
 import com.hedera.hapi.block.stream.BlockItem;
+import java.util.List;
 
 /**
  * Use this interface to combine the contract for streaming block items with the contract to be
  * notified of critical system events.
  */
-public interface Notifier extends StreamMediator<BlockItem, PublishStreamResponse>, Notifiable {}
+public interface Notifier
+        extends StreamMediator<List<BlockItem>, PublishStreamResponse>, Notifiable {}

--- a/server/src/main/java/com/hedera/block/server/notifier/NotifierImpl.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/NotifierImpl.java
@@ -34,6 +34,7 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -104,18 +105,18 @@ public class NotifierImpl extends SubscriptionHandlerBase<PublishStreamResponse>
     /**
      * Publishes the given block item to all subscribed producers.
      *
-     * @param blockItem the block item from the persistence layer to publish a response to upstream
-     *     producers
+     * @param blockItems the block items from the persistence layer to publish a response to
+     *     upstream producers
      */
     @Override
-    public void publish(@NonNull BlockItem blockItem) {
+    public void publish(@NonNull List<BlockItem> blockItems) {
 
         try {
             if (serviceStatus.isRunning()) {
                 // Publish the block item to the subscribers
                 final var publishStreamResponse =
                         PublishStreamResponse.newBuilder()
-                                .acknowledgement(buildAck(blockItem))
+                                .acknowledgement(buildAck(blockItems))
                                 .build();
                 ringBuffer.publishEvent((event, sequence) -> event.set(publishStreamResponse));
 
@@ -150,16 +151,17 @@ public class NotifierImpl extends SubscriptionHandlerBase<PublishStreamResponse>
     /**
      * Protected method meant for testing. Builds an Acknowledgement for the block item.
      *
-     * @param blockItem the block item to build the Acknowledgement for
+     * @param blockItems the block items to build the Acknowledgement for
      * @return the Acknowledgement for the block item
      * @throws NoSuchAlgorithmException if the hash algorithm is not supported
      */
     @NonNull
-    Acknowledgement buildAck(@NonNull final BlockItem blockItem) throws NoSuchAlgorithmException {
+    Acknowledgement buildAck(@NonNull final List<BlockItem> blockItems)
+            throws NoSuchAlgorithmException {
         final ItemAcknowledgement itemAck =
                 ItemAcknowledgement.newBuilder()
                         // TODO: Replace this with a real hash generator
-                        .itemHash(Bytes.wrap(getFakeHash(blockItem)))
+                        .itemsHash(Bytes.wrap(getFakeHash(blockItems)))
                         .build();
 
         return Acknowledgement.newBuilder().itemAck(itemAck).build();

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -31,6 +31,7 @@ import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import java.io.IOException;
+import java.util.List;
 import javax.inject.Singleton;
 
 /** A Dagger module for providing dependencies for Persistence Module. */
@@ -45,7 +46,7 @@ public interface PersistenceInjectionModule {
      */
     @Provides
     @Singleton
-    static BlockWriter<BlockItem> providesBlockWriter(BlockNodeContext blockNodeContext) {
+    static BlockWriter<List<BlockItem>> providesBlockWriter(BlockNodeContext blockNodeContext) {
         try {
             return BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
         } catch (IOException e) {

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -48,7 +49,7 @@ import java.util.Set;
  * to remove the current, incomplete block (directory) before re-throwing the exception to the
  * caller.
  */
-class BlockAsDirWriter implements BlockWriter<BlockItem> {
+class BlockAsDirWriter implements BlockWriter<List<BlockItem>> {
 
     private final Logger LOGGER = System.getLogger(getClass().getName());
 
@@ -94,20 +95,23 @@ class BlockAsDirWriter implements BlockWriter<BlockItem> {
     /**
      * Writes the given block item to the filesystem.
      *
-     * @param blockItem the block item to write
+     * @param blockItems the block item to write
      * @throws IOException if an error occurs while writing the block item
      */
     @Override
-    public Optional<BlockItem> write(@NonNull final BlockItem blockItem) throws IOException {
+    public Optional<List<BlockItem>> write(@NonNull final List<BlockItem> blockItems)
+            throws IOException {
 
-        if (blockItem.hasBlockHeader()) {
-            resetState(blockItem);
+        if (blockItems.getFirst().hasBlockHeader()) {
+            resetState(blockItems.getFirst());
         }
 
         final Path blockItemFilePath = calculateBlockItemPath();
         for (int retries = 0; ; retries++) {
             try {
-                write(blockItemFilePath, blockItem);
+                for (BlockItem blockItem : blockItems) {
+                    write(blockItemFilePath, blockItem);
+                }
                 break;
             } catch (IOException e) {
 
@@ -128,9 +132,9 @@ class BlockAsDirWriter implements BlockWriter<BlockItem> {
             }
         }
 
-        if (blockItem.hasBlockProof()) {
+        if (blockItems.getLast().hasBlockProof()) {
             metricsService.get(BlocksPersisted).increment();
-            return Optional.of(blockItem);
+            return Optional.of(blockItems);
         }
 
         return Optional.empty();

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriter.java
@@ -106,28 +106,28 @@ class BlockAsDirWriter implements BlockWriter<List<BlockItem>> {
             resetState(blockItems.getFirst());
         }
 
-        final Path blockItemFilePath = calculateBlockItemPath();
-        for (int retries = 0; ; retries++) {
-            try {
-                for (BlockItem blockItem : blockItems) {
+        for (BlockItem blockItem : blockItems) {
+            final Path blockItemFilePath = calculateBlockItemPath();
+            for (int retries = 0; ; retries++) {
+                try {
                     write(blockItemFilePath, blockItem);
-                }
-                break;
-            } catch (IOException e) {
+                    break;
+                } catch (IOException e) {
 
-                LOGGER.log(ERROR, "Error writing the BlockItem protobuf to a file: ", e);
+                    LOGGER.log(ERROR, "Error writing the BlockItem protobuf to a file: ", e);
 
-                // Remove the block if repairing the permissions fails
-                if (retries > 0) {
-                    // Attempt to remove the block
-                    blockRemover.remove(Long.parseLong(currentBlockDir.toString()));
-                    throw e;
-                } else {
-                    // Attempt to repair the permissions on the block path
-                    // and the blockItem path
-                    repairPermissions(blockNodeRootPath);
-                    repairPermissions(calculateBlockPath());
-                    LOGGER.log(INFO, "Retrying to write the BlockItem protobuf to a file");
+                    // Remove the block if repairing the permissions fails
+                    if (retries > 0) {
+                        // Attempt to remove the block
+                        blockRemover.remove(Long.parseLong(currentBlockDir.toString()));
+                        throw e;
+                    } else {
+                        // Attempt to repair the permissions on the block path
+                        // and the blockItem path
+                        repairPermissions(blockNodeRootPath);
+                        repairPermissions(calculateBlockPath());
+                        LOGGER.log(INFO, "Retrying to write the BlockItem protobuf to a file");
+                    }
                 }
             }
         }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsDirWriterBuilder.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -103,7 +104,7 @@ public class BlockAsDirWriterBuilder {
      * @throws IOException when an error occurs while persisting block items to storage.
      */
     @NonNull
-    public BlockWriter<BlockItem> build() throws IOException {
+    public BlockWriter<List<BlockItem>> build() throws IOException {
         return new BlockAsDirWriter(blockRemover, filePerms, blockNodeContext);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
+++ b/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
@@ -162,8 +162,10 @@ public class ProducerBlockItemObserver
 
         LOGGER.log(DEBUG, "Received PublishStreamRequest from producer");
         final List<BlockItem> blockItemsPbj = new ArrayList<>();
+
         final Counter liveBlockItemsReceived = metricsService.get(LiveBlockItemsReceived);
-        for (final var blockItemProtoc : publishStreamRequest.getBlockItemsList()) {
+        for (final com.hedera.hapi.block.stream.protoc.BlockItem blockItemProtoc :
+                publishStreamRequest.getBlockItemsList()) {
             try {
                 final BlockItem blockItem =
                         toPbj(BlockItem.PROTOBUF, blockItemProtoc.toByteArray());
@@ -182,7 +184,6 @@ public class ProducerBlockItemObserver
             liveBlockItemsReceived.increment();
         }
 
-        // is this log just too much? see below log for proposed...
         LOGGER.log(DEBUG, "Received block item batch with {} items.", blockItemsPbj.size());
 
         // Publish the block to all the subscribers unless

--- a/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
+++ b/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
@@ -38,10 +38,13 @@ import com.hedera.hapi.block.PublishStreamResponse;
 import com.hedera.hapi.block.PublishStreamResponseCode;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.pbj.runtime.ParseException;
+import com.swirlds.metrics.api.Counter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.time.InstantSource;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -59,7 +62,7 @@ public class ProducerBlockItemObserver
     private final StreamObserver<com.hedera.hapi.block.protoc.PublishStreamResponse>
             publishStreamResponseObserver;
     private final SubscriptionHandler<PublishStreamResponse> subscriptionHandler;
-    private final Publisher<BlockItem> publisher;
+    private final Publisher<List<BlockItem>> publisher;
     private final ServiceStatus serviceStatus;
     private final MetricsService metricsService;
 
@@ -85,8 +88,8 @@ public class ProducerBlockItemObserver
      * to the upstream producer via the responseStreamObserver.
      *
      * @param producerLivenessClock the clock used to calculate the producer liveness.
-     * @param publisher the block item publisher to used to pass block items to consumers as they
-     *     arrive from the upstream producer.
+     * @param publisher the block item list publisher to used to pass block item lists to consumers
+     *     as they arrive from the upstream producer.
      * @param subscriptionHandler the subscription handler used to
      * @param publishStreamResponseObserver the response stream observer to send responses back to
      *     the upstream producer for each block item processed.
@@ -97,7 +100,7 @@ public class ProducerBlockItemObserver
      */
     public ProducerBlockItemObserver(
             @NonNull final InstantSource producerLivenessClock,
-            @NonNull final Publisher<BlockItem> publisher,
+            @NonNull final Publisher<List<BlockItem>> publisher,
             @NonNull final SubscriptionHandler<PublishStreamResponse> subscriptionHandler,
             @NonNull
                     final StreamObserver<com.hedera.hapi.block.protoc.PublishStreamResponse>
@@ -157,42 +160,47 @@ public class ProducerBlockItemObserver
     public void onNext(
             @NonNull final com.hedera.hapi.block.protoc.PublishStreamRequest publishStreamRequest) {
 
-        try {
-            LOGGER.log(DEBUG, "Received PublishStreamRequest from producer");
-            final BlockItem blockItem =
-                    toPbj(BlockItem.PROTOBUF, publishStreamRequest.getBlockItem().toByteArray());
-            LOGGER.log(DEBUG, "Received block item: " + blockItem);
-
-            metricsService.get(LiveBlockItemsReceived).increment();
-
-            // Publish the block to all the subscribers unless
-            // there's an issue with the StreamMediator.
-            if (serviceStatus.isRunning()) {
-                // Refresh the producer liveness
-                livenessCalculator.refresh();
-
-                // Publish the block to the mediator
-                publisher.publish(blockItem);
-
-            } else {
-                LOGGER.log(ERROR, getClass().getName() + " is not accepting BlockItems");
-
-                // Close the upstream connection to the producer(s)
+        LOGGER.log(DEBUG, "Received PublishStreamRequest from producer");
+        final List<BlockItem> blockItemsPbj = new ArrayList<>();
+        final Counter liveBlockItemsReceived = metricsService.get(LiveBlockItemsReceived);
+        for (final var blockItemProtoc : publishStreamRequest.getBlockItemsList()) {
+            try {
+                final BlockItem blockItem =
+                        toPbj(BlockItem.PROTOBUF, blockItemProtoc.toByteArray());
+                blockItemsPbj.add(blockItem);
+            } catch (ParseException e) {
                 final var errorResponse = buildErrorStreamResponse();
                 publishStreamResponseObserver.onNext(errorResponse);
-                LOGGER.log(ERROR, "Error PublishStreamResponse sent to upstream producer");
+                LOGGER.log(
+                        ERROR,
+                        "Error parsing inbound block item from a producer: " + blockItemProtoc,
+                        e);
+
+                // Stop the server
+                serviceStatus.stopWebServer(getClass().getName());
             }
-        } catch (ParseException e) {
+            liveBlockItemsReceived.increment();
+        }
+
+        // is this log just too much? see below log for proposed...
+        LOGGER.log(DEBUG, "Received block item batch with {} items.", blockItemsPbj.size());
+
+        // Publish the block to all the subscribers unless
+        // there's an issue with the StreamMediator.
+        if (serviceStatus.isRunning()) {
+            // Refresh the producer liveness
+            livenessCalculator.refresh();
+
+            // Publish the block to the mediator
+            publisher.publish(blockItemsPbj);
+
+        } else {
+            LOGGER.log(ERROR, getClass().getName() + " is not accepting BlockItems");
+
+            // Close the upstream connection to the producer(s)
             final var errorResponse = buildErrorStreamResponse();
             publishStreamResponseObserver.onNext(errorResponse);
-            LOGGER.log(
-                    ERROR,
-                    "Error parsing inbound block item from a producer: "
-                            + publishStreamRequest.getBlockItem(),
-                    e);
-
-            // Stop the server
-            serviceStatus.stopWebServer(getClass().getName());
+            LOGGER.log(ERROR, "Error PublishStreamResponse sent to upstream producer");
         }
     }
 

--- a/server/src/main/java/com/hedera/block/server/producer/Util.java
+++ b/server/src/main/java/com/hedera/block/server/producer/Util.java
@@ -20,6 +20,7 @@ import com.hedera.hapi.block.stream.BlockItem;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 
 /** Utility class for the BlockNode service. */
 public final class Util {
@@ -29,14 +30,14 @@ public final class Util {
      * Gets a fake hash for the given block item. This is a placeholder and should be replaced with
      * real hash functionality once the hedera-protobufs types are integrated.
      *
-     * @param blockItem the block item to get the fake hash for
+     * @param blockItems the block item to get the fake hash for
      * @return the fake hash for the given block item
      * @throws NoSuchAlgorithmException thrown if the SHA-384 algorithm is not available
      */
-    public static byte[] getFakeHash(@NonNull final BlockItem blockItem)
+    public static byte[] getFakeHash(@NonNull final List<BlockItem> blockItems)
             throws NoSuchAlgorithmException {
         // Calculate the SHA-384 hash
         MessageDigest digest = MessageDigest.getInstance("SHA-384");
-        return digest.digest(BlockItem.PROTOBUF.toBytes(blockItem).toByteArray());
+        return digest.digest(BlockItem.PROTOBUF.toBytes(blockItems.getLast()).toByteArray());
     }
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module com.hedera.block.server {
     exports com.hedera.block.server.persistence;
     exports com.hedera.block.server.notifier;
     exports com.hedera.block.server.service;
+    exports com.hedera.block.server.grpc;
 
     requires com.hedera.block.stream;
     requires com.google.protobuf;

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.block.server.grpc.BlockAccessService;
 import com.hedera.block.server.grpc.BlockStreamService;
 import com.hedera.block.server.health.HealthService;
 import com.hedera.block.server.service.ServiceStatus;
@@ -43,6 +44,8 @@ class BlockNodeAppTest {
     @Mock private HealthService healthService;
 
     @Mock private BlockStreamService blockStreamService;
+
+    @Mock private BlockAccessService blockAccessService;
 
     @Mock private WebServerConfig.Builder webServerBuilder;
 

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.block.server.grpc.BlockStreamService;
 import com.hedera.block.server.health.HealthService;
 import com.hedera.block.server.service.ServiceStatus;
 import io.helidon.webserver.WebServer;

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -30,6 +30,7 @@ import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.mediator.StreamMediator;
 import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.hapi.block.SubscribeStreamResponse;
+import com.hedera.hapi.block.SubscribeStreamResponseSet;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.hapi.block.stream.input.EventHeader;
@@ -90,8 +91,10 @@ public class ConsumerStreamResponseObserverTest {
 
         final BlockHeader blockHeader = BlockHeader.newBuilder().number(1).build();
         final BlockItem blockItem = BlockItem.newBuilder().blockHeader(blockHeader).build();
+        final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                SubscribeStreamResponseSet.newBuilder().blockItems(blockItem).build();
         final SubscribeStreamResponse subscribeStreamResponse =
-                SubscribeStreamResponse.newBuilder().blockItem(blockItem).build();
+                SubscribeStreamResponse.newBuilder().blockItems(subscribeStreamResponseSet).build();
 
         when(objectEvent.get()).thenReturn(subscribeStreamResponse);
 
@@ -142,8 +145,10 @@ public class ConsumerStreamResponseObserverTest {
                         testClock, streamMediator, serverCallStreamObserver, testContext);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
+        final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                SubscribeStreamResponseSet.newBuilder().blockItems(blockItems).build();
         final SubscribeStreamResponse subscribeStreamResponse =
-                SubscribeStreamResponse.newBuilder().blockItem(blockItems.getFirst()).build();
+                SubscribeStreamResponse.newBuilder().blockItems(subscribeStreamResponseSet).build();
         when(objectEvent.get()).thenReturn(subscribeStreamResponse);
 
         // Confirm that the observer is called with the first BlockItem
@@ -168,8 +173,10 @@ public class ConsumerStreamResponseObserverTest {
                         testClock, streamMediator, serverCallStreamObserver, testContext);
 
         final List<BlockItem> blockItems = generateBlockItems(1);
+        final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                SubscribeStreamResponseSet.newBuilder().blockItems(blockItems).build();
         final SubscribeStreamResponse subscribeStreamResponse =
-                SubscribeStreamResponse.newBuilder().blockItem(blockItems.getFirst()).build();
+                SubscribeStreamResponse.newBuilder().blockItems(subscribeStreamResponseSet).build();
         when(objectEvent.get()).thenReturn(subscribeStreamResponse);
 
         // Confirm that the observer is called with the first BlockItem
@@ -204,14 +211,22 @@ public class ConsumerStreamResponseObserverTest {
                 final EventHeader eventHeader =
                         EventHeader.newBuilder().eventCore(EventCore.newBuilder().build()).build();
                 final BlockItem blockItem = BlockItem.newBuilder().eventHeader(eventHeader).build();
+                final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                        SubscribeStreamResponseSet.newBuilder().blockItems(blockItem).build();
                 final SubscribeStreamResponse subscribeStreamResponse =
-                        SubscribeStreamResponse.newBuilder().blockItem(blockItem).build();
+                        SubscribeStreamResponse.newBuilder()
+                                .blockItems(subscribeStreamResponseSet)
+                                .build();
                 when(objectEvent.get()).thenReturn(subscribeStreamResponse);
             } else {
                 final BlockProof blockProof = BlockProof.newBuilder().block(i).build();
                 final BlockItem blockItem = BlockItem.newBuilder().blockProof(blockProof).build();
+                final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                        SubscribeStreamResponseSet.newBuilder().blockItems(blockItem).build();
                 final SubscribeStreamResponse subscribeStreamResponse =
-                        SubscribeStreamResponse.newBuilder().blockItem(blockItem).build();
+                        SubscribeStreamResponse.newBuilder()
+                                .blockItems(subscribeStreamResponseSet)
+                                .build();
                 when(objectEvent.get()).thenReturn(subscribeStreamResponse);
             }
 
@@ -219,8 +234,10 @@ public class ConsumerStreamResponseObserverTest {
         }
 
         final BlockItem blockItem = BlockItem.newBuilder().build();
+        final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                SubscribeStreamResponseSet.newBuilder().blockItems(blockItem).build();
         final SubscribeStreamResponse subscribeStreamResponse =
-                SubscribeStreamResponse.newBuilder().blockItem(blockItem).build();
+                SubscribeStreamResponse.newBuilder().blockItems(subscribeStreamResponseSet).build();
 
         // Confirm that the observer was called with the next BlockItem
         // since we never send a BlockItem with a Header to start the stream.
@@ -235,10 +252,15 @@ public class ConsumerStreamResponseObserverTest {
         // being created with a null BlockItem. Here, I have to used a spy() to even
         // manufacture this scenario. This should not happen in production.
         final BlockItem blockItem = BlockItem.newBuilder().build();
+        final SubscribeStreamResponseSet subscribeStreamResponseSet =
+                SubscribeStreamResponseSet.newBuilder().blockItems(blockItem).build();
         final SubscribeStreamResponse subscribeStreamResponse =
-                spy(SubscribeStreamResponse.newBuilder().blockItem(blockItem).build());
+                spy(
+                        SubscribeStreamResponse.newBuilder()
+                                .blockItems(subscribeStreamResponseSet)
+                                .build());
 
-        when(subscribeStreamResponse.blockItem()).thenReturn(null);
+        when(subscribeStreamResponse.blockItems()).thenReturn(null);
         when(objectEvent.get()).thenReturn(subscribeStreamResponse);
 
         final var consumerBlockItemObserver =

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -21,7 +21,6 @@ import static com.hedera.block.server.grpc.BlockAccessService.buildSingleBlockNo
 import static com.hedera.block.server.grpc.BlockAccessService.buildSingleBlockNotFoundResponse;
 import static com.hedera.block.server.grpc.BlockAccessService.fromPbjSingleBlockSuccessResponse;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
-import static java.lang.System.Logger.Level.INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -36,8 +35,6 @@ import static org.mockito.Mockito.when;
 import com.google.protobuf.Descriptors;
 import com.hedera.block.server.Constants;
 import com.hedera.block.server.config.BlockNodeContext;
-import com.hedera.block.server.mediator.LiveStreamMediator;
-import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.read.BlockAsDirReaderBuilder;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
@@ -54,7 +51,6 @@ import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
 import io.helidon.webserver.grpc.GrpcService;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -64,17 +60,14 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BlockAccessServiceTest {
 
-    @Mock private Notifier notifier;
-
     @Mock private StreamObserver<SingleBlockResponse> responseObserver;
-
-    @Mock private LiveStreamMediator streamMediator;
 
     @Mock private BlockReader<Block> blockReader;
 
@@ -82,20 +75,14 @@ class BlockAccessServiceTest {
 
     @Mock private ServiceStatus serviceStatus;
 
-    private final System.Logger LOGGER = System.getLogger(getClass().getName());
-
-    private static final String TEMP_DIR = "block-node-unit-test-dir";
-
     private static final int testTimeout = 1000;
 
-    private Path testPath;
+    @TempDir private Path testPath;
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
 
     @BeforeEach
     public void setUp() throws IOException {
-        testPath = Files.createTempDirectory(TEMP_DIR);
-        LOGGER.log(INFO, "Created temp directory: " + testPath.toString());
 
         blockNodeContext =
                 TestConfigUtil.getTestBlockNodeContext(

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -42,7 +42,6 @@ import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.util.TestConfigUtil;
-import com.hedera.block.server.util.TestUtils;
 import com.hedera.hapi.block.protoc.SingleBlockResponse;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -55,7 +54,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,11 +86,6 @@ class BlockAccessServiceTest {
                 TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
         config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        TestUtils.deleteDirectory(testPath.toFile());
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.server.grpc;
+
+import static com.hedera.block.server.Constants.SINGLE_BLOCK_METHOD_NAME;
+import static com.hedera.block.server.grpc.BlockAccessService.buildSingleBlockNotAvailableResponse;
+import static com.hedera.block.server.grpc.BlockAccessService.buildSingleBlockNotFoundResponse;
+import static com.hedera.block.server.grpc.BlockAccessService.fromPbjSingleBlockSuccessResponse;
+import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
+import static java.lang.System.Logger.Level.INFO;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.mediator.LiveStreamMediator;
+import com.hedera.block.server.notifier.Notifier;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.read.BlockAsDirReaderBuilder;
+import com.hedera.block.server.persistence.storage.read.BlockReader;
+import com.hedera.block.server.persistence.storage.write.BlockAsDirWriterBuilder;
+import com.hedera.block.server.persistence.storage.write.BlockWriter;
+import com.hedera.block.server.service.ServiceStatus;
+import com.hedera.block.server.util.TestConfigUtil;
+import com.hedera.block.server.util.TestUtils;
+import com.hedera.hapi.block.protoc.SingleBlockResponse;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.pbj.runtime.ParseException;
+import io.grpc.stub.ServerCalls;
+import io.grpc.stub.StreamObserver;
+import io.helidon.webserver.grpc.GrpcService;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BlockAccessServiceTest {
+
+    @Mock private Notifier notifier;
+
+    @Mock private StreamObserver<SingleBlockResponse> responseObserver;
+
+    @Mock private LiveStreamMediator streamMediator;
+
+    @Mock private BlockReader<Block> blockReader;
+
+    @Mock private BlockWriter<List<BlockItem>> blockWriter;
+
+    @Mock private ServiceStatus serviceStatus;
+
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    private static final String TEMP_DIR = "block-node-unit-test-dir";
+
+    private static final int testTimeout = 1000;
+
+    private Path testPath;
+    private BlockNodeContext blockNodeContext;
+    private PersistenceStorageConfig config;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        testPath = Files.createTempDirectory(TEMP_DIR);
+        LOGGER.log(INFO, "Created temp directory: " + testPath.toString());
+
+        blockNodeContext =
+                TestConfigUtil.getTestBlockNodeContext(
+                        Map.of("persistence.storage.rootPath", testPath.toString()));
+        config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        TestUtils.deleteDirectory(testPath.toFile());
+    }
+
+    @Test
+    void testSingleBlockHappyPath() throws IOException, ParseException {
+
+        final BlockReader<Block> blockReader = BlockAsDirReaderBuilder.newBuilder(config).build();
+
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        // Enable the serviceStatus
+        when(serviceStatus.isRunning()).thenReturn(true);
+
+        // Generate and persist a block
+        final BlockWriter<List<BlockItem>> blockWriter =
+                BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
+        final List<BlockItem> blockItems = generateBlockItems(1);
+        blockWriter.write(blockItems);
+
+        // Get the block so we can verify the response payload
+        final Optional<Block> blockOpt = blockReader.read(1);
+        if (blockOpt.isEmpty()) {
+            fail("Block 1 should be present");
+            return;
+        }
+
+        // Build a response to verify what's passed to the response observer
+        final com.hedera.hapi.block.protoc.SingleBlockResponse expectedSingleBlockResponse =
+                fromPbjSingleBlockSuccessResponse(blockOpt.get());
+
+        // Build a request to invoke the service
+        final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest =
+                com.hedera.hapi.block.protoc.SingleBlockRequest.newBuilder()
+                        .setBlockNumber(1)
+                        .build();
+
+        // Call the service
+        blockAccessService.protocSingleBlock(singleBlockRequest, responseObserver);
+        verify(responseObserver, times(1)).onNext(expectedSingleBlockResponse);
+    }
+
+    @Test
+    void testSingleBlockNotFoundPath() throws IOException, ParseException {
+
+        // Get the block so we can verify the response payload
+        when(blockReader.read(1)).thenReturn(Optional.empty());
+
+        // Build a response to verify what's passed to the response observer
+        final com.hedera.hapi.block.protoc.SingleBlockResponse expectedNotFound =
+                buildSingleBlockNotFoundResponse();
+
+        // Build a request to invoke the service
+        final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest =
+                com.hedera.hapi.block.protoc.SingleBlockRequest.newBuilder()
+                        .setBlockNumber(1)
+                        .build();
+
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        // Enable the serviceStatus
+        when(serviceStatus.isRunning()).thenReturn(true);
+
+        blockAccessService.protocSingleBlock(singleBlockRequest, responseObserver);
+        verify(responseObserver, times(1)).onNext(expectedNotFound);
+    }
+
+    @Test
+    void testSingleBlockServiceNotAvailable() {
+
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        // Set the service status to not running
+        when(serviceStatus.isRunning()).thenReturn(false);
+
+        final com.hedera.hapi.block.protoc.SingleBlockResponse expectedNotAvailable =
+                buildSingleBlockNotAvailableResponse();
+
+        // Build a request to invoke the service
+        final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest =
+                com.hedera.hapi.block.protoc.SingleBlockRequest.newBuilder()
+                        .setBlockNumber(1)
+                        .build();
+        blockAccessService.protocSingleBlock(singleBlockRequest, responseObserver);
+        verify(responseObserver, times(1)).onNext(expectedNotAvailable);
+    }
+
+    @Test
+    public void testSingleBlockIOExceptionPath() throws IOException, ParseException {
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        when(serviceStatus.isRunning()).thenReturn(true);
+        when(blockReader.read(1)).thenThrow(new IOException("Test exception"));
+
+        final com.hedera.hapi.block.protoc.SingleBlockResponse expectedNotAvailable =
+                buildSingleBlockNotAvailableResponse();
+
+        // Build a request to invoke the service
+        final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest =
+                com.hedera.hapi.block.protoc.SingleBlockRequest.newBuilder()
+                        .setBlockNumber(1)
+                        .build();
+        blockAccessService.protocSingleBlock(singleBlockRequest, responseObserver);
+        verify(responseObserver, times(1)).onNext(expectedNotAvailable);
+    }
+
+    @Test
+    public void testSingleBlockParseExceptionPath() throws IOException, ParseException {
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        when(serviceStatus.isRunning()).thenReturn(true);
+        when(blockReader.read(1)).thenThrow(new ParseException("Test exception"));
+
+        final com.hedera.hapi.block.protoc.SingleBlockResponse expectedNotAvailable =
+                buildSingleBlockNotAvailableResponse();
+
+        // Build a request to invoke the service
+        final com.hedera.hapi.block.protoc.SingleBlockRequest singleBlockRequest =
+                com.hedera.hapi.block.protoc.SingleBlockRequest.newBuilder()
+                        .setBlockNumber(1)
+                        .build();
+        blockAccessService.protocSingleBlock(singleBlockRequest, responseObserver);
+        verify(responseObserver, times(1)).onNext(expectedNotAvailable);
+    }
+
+    @Test
+    public void testUpdateInvokesRoutingWithLambdas() {
+
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
+        GrpcService.Routing routing = mock(GrpcService.Routing.class);
+        blockAccessService.update(routing);
+
+        verify(routing, timeout(testTimeout).times(1))
+                .unary(eq(SINGLE_BLOCK_METHOD_NAME), any(ServerCalls.UnaryMethod.class));
+    }
+}

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceIntegrationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.block.server;
+package com.hedera.block.server.grpc;
 
 import static com.hedera.block.server.Translator.fromPbj;
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItems;
@@ -578,6 +578,10 @@ public class BlockStreamServiceIntegrationTest {
                         notifier,
                         blockNodeContext);
 
+        final BlockAccessService blockAccessService =
+                new BlockAccessService(
+                        serviceStatus, blockReader, blockNodeContext.metricsService());
+
         // Subscribe the consumers
         blockStreamService.protocSubscribeBlockStream(
                 subscribeStreamRequest, subscribeStreamObserver1);
@@ -616,7 +620,7 @@ public class BlockStreamServiceIntegrationTest {
                         .build();
 
         // Simulate a consumer attempting to connect to the Block Node after the exception.
-        blockStreamService.protocSingleBlock(singleBlockRequest, singleBlockResponseStreamObserver);
+        blockAccessService.protocSingleBlock(singleBlockRequest, singleBlockResponseStreamObserver);
 
         // Build a request to invoke the subscribeBlockStream service
         final SubscribeStreamRequest subscribeStreamRequest =

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceIntegrationTest.java
@@ -173,7 +173,6 @@ public class BlockStreamServiceIntegrationTest {
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -275,7 +274,6 @@ public class BlockStreamServiceIntegrationTest {
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -449,7 +447,6 @@ public class BlockStreamServiceIntegrationTest {
         final var blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -572,7 +569,6 @@ public class BlockStreamServiceIntegrationTest {
         final var blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -747,12 +743,7 @@ public class BlockStreamServiceIntegrationTest {
                         streamMediator, notifier, blockWriter, blockNodeContext, serviceStatus);
 
         return new BlockStreamService(
-                streamMediator,
-                blockReader,
-                serviceStatus,
-                blockNodeEventHandler,
-                notifier,
-                blockNodeContext);
+                streamMediator, serviceStatus, blockNodeEventHandler, notifier, blockNodeContext);
     }
 
     private LiveStreamMediator buildStreamMediator(

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceTest.java
@@ -42,7 +42,6 @@ import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.persistence.storage.write.BlockWriter;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.util.TestConfigUtil;
-import com.hedera.block.server.util.TestUtils;
 import com.hedera.hapi.block.SingleBlockResponse;
 import com.hedera.hapi.block.SingleBlockResponseCode;
 import com.hedera.hapi.block.stream.Block;
@@ -54,7 +53,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,11 +91,6 @@ public class BlockStreamServiceTest {
                 TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
         config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        TestUtils.deleteDirectory(testPath.toFile());
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockStreamServiceTest.java
@@ -21,7 +21,6 @@ import static com.hedera.block.server.Constants.SERVER_STREAMING_METHOD_NAME;
 import static com.hedera.block.server.Translator.fromPbj;
 import static com.hedera.block.server.util.PersistTestUtils.reverseByteArray;
 import static java.lang.System.Logger;
-import static java.lang.System.Logger.Level.INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
@@ -52,7 +51,6 @@ import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
 import io.helidon.webserver.grpc.GrpcService;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +59,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -82,19 +81,14 @@ public class BlockStreamServiceTest {
 
     private final Logger LOGGER = System.getLogger(getClass().getName());
 
-    private static final String TEMP_DIR = "block-node-unit-test-dir";
-
     private static final int testTimeout = 1000;
 
-    private Path testPath;
+    @TempDir private Path testPath;
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
 
     @BeforeEach
     public void setUp() throws IOException {
-        testPath = Files.createTempDirectory(TEMP_DIR);
-        LOGGER.log(INFO, "Created temp directory: " + testPath.toString());
-
         blockNodeContext =
                 TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
@@ -115,7 +109,6 @@ public class BlockStreamServiceTest {
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -138,7 +131,6 @@ public class BlockStreamServiceTest {
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,
@@ -201,7 +193,6 @@ public class BlockStreamServiceTest {
         final BlockStreamService blockStreamService =
                 new BlockStreamService(
                         streamMediator,
-                        blockReader,
                         serviceStatus,
                         blockNodeEventHandler,
                         notifier,

--- a/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
@@ -24,6 +24,7 @@ import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.hapi.block.SubscribeStreamResponse;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,7 +47,7 @@ class MediatorInjectionModuleTest {
         BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
 
         // Call the method under test
-        StreamMediator<BlockItem, SubscribeStreamResponse> streamMediator =
+        StreamMediator<List<BlockItem>, SubscribeStreamResponse> streamMediator =
                 MediatorInjectionModule.providesLiveStreamMediator(blockNodeContext, serviceStatus);
 
         // Verify that the streamMediator is correctly instantiated

--- a/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
@@ -16,8 +16,8 @@
 
 package com.hedera.block.server.notifier;
 
-import static com.hedera.block.server.BlockStreamServiceIntegrationTest.buildAck;
 import static com.hedera.block.server.Translator.fromPbj;
+import static com.hedera.block.server.grpc.BlockStreamServiceIntegrationTest.buildAck;
 import static com.hedera.block.server.notifier.NotifierImpl.buildErrorStreamResponse;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
@@ -54,7 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class NotifierImplTest {
 
     @Mock private Notifiable mediator;
-    @Mock private Publisher<BlockItem> publisher;
+    @Mock private Publisher<List<BlockItem>> publisher;
     @Mock private ServiceStatus serviceStatus;
     @Mock private SubscriptionHandler<PublishStreamResponse> subscriptionHandler;
 
@@ -132,13 +132,11 @@ public class NotifierImplTest {
                 "Expected the notifier to have observer3 subscribed");
 
         List<BlockItem> blockItems = generateBlockItems(1);
-        notifier.publish(blockItems.getFirst());
+        notifier.publish(blockItems);
 
         // Verify the response was received by all observers
         final var publishStreamResponse =
-                PublishStreamResponse.newBuilder()
-                        .acknowledgement(buildAck(blockItems.getFirst()))
-                        .build();
+                PublishStreamResponse.newBuilder().acknowledgement(buildAck(blockItems)).build();
         verify(streamObserver1, timeout(testTimeout).times(1))
                 .onNext(fromPbj(publishStreamResponse));
         verify(streamObserver2, timeout(testTimeout).times(1))
@@ -222,7 +220,7 @@ public class NotifierImplTest {
                 "Expected the notifier to have observer3 subscribed");
 
         List<BlockItem> blockItems = generateBlockItems(1);
-        notifier.publish(blockItems.getFirst());
+        notifier.publish(blockItems);
 
         Thread.sleep(testTimeout);
 
@@ -284,7 +282,7 @@ public class NotifierImplTest {
                 "Expected the notifier to have observer3 subscribed");
 
         List<BlockItem> blockItems = generateBlockItems(1);
-        notifier.publish(blockItems.getFirst());
+        notifier.publish(blockItems);
 
         final PublishStreamResponse errorResponse = buildErrorStreamResponse();
         verify(streamObserver1, timeout(testTimeout).times(1)).onNext(fromPbj(errorResponse));
@@ -340,13 +338,11 @@ public class NotifierImplTest {
                 "Expected the notifier to have observer3 subscribed");
 
         final List<BlockItem> blockItems = generateBlockItems(1);
-        notifier.publish(blockItems.getFirst());
+        notifier.publish(blockItems);
 
         // Verify once the serviceStatus is not running that we do not publish the responses
         final var publishStreamResponse =
-                PublishStreamResponse.newBuilder()
-                        .acknowledgement(buildAck(blockItems.getFirst()))
-                        .build();
+                PublishStreamResponse.newBuilder().acknowledgement(buildAck(blockItems)).build();
         verify(streamObserver1, timeout(testTimeout).times(0))
                 .onNext(fromPbj(publishStreamResponse));
         verify(streamObserver2, timeout(testTimeout).times(0))
@@ -365,7 +361,7 @@ public class NotifierImplTest {
 
         @Override
         @NonNull
-        Acknowledgement buildAck(@NonNull final BlockItem blockItem)
+        Acknowledgement buildAck(@NonNull final List<BlockItem> blockItems)
                 throws NoSuchAlgorithmException {
             throw new NoSuchAlgorithmException("Test exception");
         }

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -35,6 +35,7 @@ import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.swirlds.config.api.Configuration;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,7 @@ class PersistenceInjectionModuleTest {
     @Mock private PersistenceStorageConfig persistenceStorageConfig;
     @Mock private SubscriptionHandler<SubscribeStreamResponse> subscriptionHandler;
     @Mock private Notifier notifier;
-    @Mock private BlockWriter<BlockItem> blockWriter;
+    @Mock private BlockWriter<List<BlockItem>> blockWriter;
     @Mock private ServiceStatus serviceStatus;
 
     @BeforeEach
@@ -62,7 +63,7 @@ class PersistenceInjectionModuleTest {
     @Test
     void testProvidesBlockWriter() {
 
-        BlockWriter<BlockItem> blockWriter =
+        BlockWriter<List<BlockItem>> blockWriter =
                 PersistenceInjectionModule.providesBlockWriter(blockNodeContext);
 
         assertNotNull(blockWriter);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -21,7 +21,6 @@ import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
 import static com.hedera.block.server.util.PersistTestUtils.reverseByteArray;
 import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.ERROR;
-import static java.lang.System.Logger.Level.INFO;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -52,23 +51,19 @@ import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class BlockAsDirReaderTest {
 
     private final Logger LOGGER = System.getLogger(getClass().getName());
 
-    private static final String TEMP_DIR = "block-node-unit-test-dir";
-
-    private Path testPath;
+    @TempDir private Path testPath;
 
     private BlockNodeContext blockNodeContext;
     private PersistenceStorageConfig config;
 
     @BeforeEach
     public void setUp() throws IOException {
-        testPath = Files.createTempDirectory(TEMP_DIR);
-        LOGGER.log(INFO, "Created temp directory: " + testPath.toString());
-
         blockNodeContext =
                 TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
@@ -115,9 +110,6 @@ public class BlockAsDirReaderTest {
 
         final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        //        for (BlockItem blockItem : blockItems) {
-        //            blockWriter.write(blockItem);
-        //        }
         blockWriter.write(blockItems);
 
         // Make the block unreadable
@@ -139,9 +131,6 @@ public class BlockAsDirReaderTest {
 
         final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        //        for (BlockItem blockItem : blockItems) {
-        //            blockWriter.write(blockItem);
-        //        }
         blockWriter.write(blockItems);
 
         removeBlockItemReadPerms(1, 1, config);
@@ -172,9 +161,6 @@ public class BlockAsDirReaderTest {
 
         final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        //        for (final BlockItem blockItem : blockItems) {
-        //            blockWriter.write(blockItem);
-        //        }
         blockWriter.write(blockItems);
 
         removeBlockReadPerms(1, config);
@@ -211,9 +197,6 @@ public class BlockAsDirReaderTest {
 
         final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        //        for (final BlockItem blockItem : blockItems) {
-        //            blockWriter.write(blockItem);
-        //        }
         blockWriter.write(blockItems);
 
         // Read the block back and confirm it's read successfully

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -93,10 +93,10 @@ public class BlockAsDirReaderTest {
     public void testReadPermsRepairSucceeded() throws IOException, ParseException {
         final List<BlockItem> blockItems = generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
         for (BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
+            blockWriter.write(List.of(blockItem));
         }
 
         // Make the block unreadable
@@ -113,11 +113,12 @@ public class BlockAsDirReaderTest {
     public void testRemoveBlockReadPermsRepairFailed() throws IOException, ParseException {
         final List<BlockItem> blockItems = generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        for (BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
-        }
+        //        for (BlockItem blockItem : blockItems) {
+        //            blockWriter.write(blockItem);
+        //        }
+        blockWriter.write(blockItems);
 
         // Make the block unreadable
         removeBlockReadPerms(1, config);
@@ -136,11 +137,12 @@ public class BlockAsDirReaderTest {
     public void testRemoveBlockItemReadPerms() throws IOException {
         final List<BlockItem> blockItems = generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        for (BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
-        }
+        //        for (BlockItem blockItem : blockItems) {
+        //            blockWriter.write(blockItem);
+        //        }
+        blockWriter.write(blockItems);
 
         removeBlockItemReadPerms(1, 1, config);
 
@@ -168,11 +170,12 @@ public class BlockAsDirReaderTest {
 
         final List<BlockItem> blockItems = generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        for (final BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
-        }
+        //        for (final BlockItem blockItem : blockItems) {
+        //            blockWriter.write(blockItem);
+        //        }
+        blockWriter.write(blockItems);
 
         removeBlockReadPerms(1, config);
 
@@ -206,11 +209,12 @@ public class BlockAsDirReaderTest {
     public void testParseExceptionHandling() throws IOException, ParseException {
         final List<BlockItem> blockItems = generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        for (final BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
-        }
+        //        for (final BlockItem blockItem : blockItems) {
+        //            blockWriter.write(blockItem);
+        //        }
+        blockWriter.write(blockItems);
 
         // Read the block back and confirm it's read successfully
         final BlockReader<Block> blockReader = BlockAsDirReaderBuilder.newBuilder(config).build();

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsDirReaderTest.java
@@ -20,7 +20,6 @@ import static com.hedera.block.server.Constants.BLOCK_FILE_EXTENSION;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItems;
 import static com.hedera.block.server.util.PersistTestUtils.reverseByteArray;
 import static java.lang.System.Logger;
-import static java.lang.System.Logger.Level.ERROR;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -48,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -68,13 +66,6 @@ public class BlockAsDirReaderTest {
                 TestConfigUtil.getTestBlockNodeContext(
                         Map.of("persistence.storage.rootPath", testPath.toString()));
         config = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
-    }
-
-    @AfterEach
-    public void tearDown() {
-        if (!TestUtils.deleteDirectory(testPath.toFile())) {
-            LOGGER.log(ERROR, "Failed to delete temp directory: " + testPath.toString());
-        }
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsDirRemoverTest.java
@@ -69,10 +69,10 @@ public class BlockAsDirRemoverTest {
         // Write a block
         final var blockItems = PersistTestUtils.generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
         for (final BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
+            blockWriter.write(List.of(blockItem));
         }
 
         // Remove a block that does not exist
@@ -102,11 +102,10 @@ public class BlockAsDirRemoverTest {
         // Write a block
         final List<BlockItem> blockItems = PersistTestUtils.generateBlockItems(1);
 
-        final BlockWriter<BlockItem> blockWriter =
+        final BlockWriter<List<BlockItem>> blockWriter =
                 BlockAsDirWriterBuilder.newBuilder(blockNodeContext).build();
-        for (final BlockItem blockItem : blockItems) {
-            blockWriter.write(blockItem);
-        }
+
+        blockWriter.write(blockItems);
 
         // Set up the BlockRemover with permissions that will prevent the block from being removed
         BlockRemover blockRemover = new BlockAsDirRemover(testPath, TestUtils.getNoPerms());

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -151,7 +151,8 @@ public class ProducerBlockItemObserverTest {
         // verify the ProducerBlockItemObserver has sent an error response
         verify(
                         publishStreamResponseObserver,
-                        timeout(testTimeout).atLeast(1)) // It fixes if set it to 2, but why???
+                        timeout(testTimeout)
+                                .atLeast(1)) // TODO: it calls more than 1 usually 2, but why?
                 .onNext(fromPbj(PublishStreamResponse.newBuilder().status(endOfStream).build()));
 
         verify(serviceStatus, timeout(testTimeout).times(1)).stopWebServer(any());

--- a/server/src/test/resources/block_service.proto
+++ b/server/src/test/resources/block_service.proto
@@ -126,10 +126,13 @@ enum SubscribeStreamResponseCode {
 
 service BlockStreamService {
 //    rpc serverStatus(ServerStatusRequest) returns (ServerStatusResponse);
-    rpc singleBlock(SingleBlockRequest) returns (SingleBlockResponse);
 //    rpc stateSnapshot(StateSnapshotRequest) returns (StateSnapshotResponse);
     rpc publishBlockStream (stream PublishStreamRequest) returns (stream PublishStreamResponse);
     rpc subscribeBlockStream(SubscribeStreamRequest) returns (stream SubscribeStreamResponse);
+}
+
+service BlockAccessService {
+    rpc singleBlock(SingleBlockRequest) returns (SingleBlockResponse);
 }
 
 // block.proto

--- a/server/src/test/resources/get-block.sh
+++ b/server/src/test/resources/get-block.sh
@@ -15,7 +15,7 @@ echo "Param is: $1"
 
 # Use environment variables or default values
 GRPC_SERVER=${GRPC_SERVER:-"localhost:8080"}
-GRPC_METHOD=${GRPC_METHOD:-"com.hedera.hapi.block.BlockStreamService/singleBlock"}
+GRPC_METHOD=${GRPC_METHOD:-"com.hedera.hapi.block.BlockAccessService/singleBlock"}
 PATH_TO_PROTO="./block_service.proto"
 
 echo "Requesting block $1..."

--- a/server/src/test/resources/producer.sh
+++ b/server/src/test/resources/producer.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# set -x
+
 
 usage_error() {
   echo "Usage: $0 <integer> [positive-integer]"
@@ -100,7 +102,7 @@ event_template=$(cat "templates/event_template.json")
       sleep 0.01
     done
 
-    if [ $iter -eq $2 ]; then
+    if [ "$iter" -eq "$2" ]; then
       exit 0
     fi
     ((iter++))

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -38,17 +38,25 @@ There are 2 configuration sets:
 ### BlockStreamConfig
 Uses the prefix `blockStream` so all properties should start with `blockStream.`
 
+| Key                       | Description                                                                                                                         | Default Value   |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `delayBetweenBlockItems`  | The delay between each block item in nanoseconds, only applicable when streamingMode=CONSTANT_RATE                                  | `1_500_000`     |
+| `maxBlockItemsToStream`   | exit condition for the simulator and the circular implementations such as `BlockAsDir` or `BlockAsFile` implementations             | `10_000`        |
+| `streamingMode`           | can either be `CONSTANT_RATE` or `MILLIS_PER_BLOCK`                                                                                 | `CONSTANT_RATE` |
+| `millisecondsPerBlock`    | if streamingMode is `MILLIS_PER_BLOCK` this will be the time to wait between blocks in milliseconds                                 | `1_000`         |
+| `blockItemsBatchSize`     | the number of block items to send in a single batch, however if a block has less block items, it will send all the items in a block | `1_000`         |
+
+### GeneratorConfig
+Uses the prefix `generator` so all properties should start with `generator.`
 | Key                      | Description                                                                                                                                                               | Default Value                   |
 |--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------|
 | `generationMode`         | The desired generation Mode to use, it can only be `DIR` or `AD_HOC`                                                                                                      | `DIR`                           |
 | `folderRootPath`         | If the generationMode is DIR this will be used as the source of the recording to stream to the Block-Node                                                                 | ``                              |
-| `delayBetweenBlockItems` | The delay between each block item in nanoseconds, only applicable when streamingMode=CONSTANT_RATE                                                                        | `1_500_000`                     |
 | `managerImplementation`  | The desired implementation of the BlockStreamManager to use, it can only be `BlockAsDirBlockStreamManager`, `BlockAsFileBlockStreamManager` or `BlockAsFileLargeDataSets` | `BlockAsFileBlockStreamManager` |
-| `maxBlockItemsToStream`  | exit condition for the simulator and the circular implementations such as `BlockAsDir` or `BlockAsFile` implementations                                                   | `10_000`                        |
 | `paddedLength`           | on the `BlockAsFileLargeDataSets` implementation, the length of the padded left zeroes `000001.blk.gz`                                                                    | 36                              |
 | `fileExtension`          | on the `BlockAsFileLargeDataSets` implementation, the extension of the files to be streamed                                                                               | `.blk.gz`                       |
-| `streamingMode`          | can either be `CONSTANT_RATE` or `MILLIS_PER_BLOCK`, if `CONSTANT_RATE`                                                                                                   | `CONSTANT_RATE`                 |
-| `millisecondsPerBlock`   | if streamingMode is `MILLIS_PER_BLOCK` this will be the time to wait between blocks in milliseconds                                                                       | `1_000`                         |
+
+
 
 ### GrpcConfig
 Uses the prefix `grpc` so all properties should start with `grpc.`

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     id("com.hedera.block.simulator")
 }
 
-dependencies { implementation(project(":common")) }
+// dependencies { implementation(project(":common")) }
 
 description = "Hedera Block Stream Simulator"
 

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -19,6 +19,8 @@ plugins {
     id("com.hedera.block.simulator")
 }
 
+dependencies { implementation(project(":common")) }
+
 description = "Hedera Block Stream Simulator"
 
 application {

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -26,6 +26,7 @@ import com.hedera.hapi.block.stream.BlockItem;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
 
@@ -130,7 +131,7 @@ public class BlockStreamSimulatorApp {
                 break;
             }
 
-            publishStreamGrpcClient.streamBlockItem(blockItem);
+            publishStreamGrpcClient.streamBlockItem(List.of(blockItem));
             blockItemsStreamed++;
 
             Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);

--- a/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.config;
 
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.swirlds.config.api.Configuration;
@@ -49,5 +50,17 @@ public interface ConfigInjectionModule {
     @Provides
     static GrpcConfig provideGrpcConfig(Configuration configuration) {
         return configuration.getConfigData(GrpcConfig.class);
+    }
+
+    /**
+     * Provides the block generator configuration.
+     *
+     * @param configuration the configuration to be used by the block generator
+     * @return the block generator configuration
+     */
+    @Singleton
+    @Provides
+    static BlockGeneratorConfig provideBlockGeneratorConfig(Configuration configuration) {
+        return configuration.getConfigData(BlockGeneratorConfig.class);
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
@@ -17,6 +17,7 @@
 package com.hedera.block.simulator.config;
 
 import com.google.auto.service.AutoService;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.swirlds.config.api.ConfigurationExtension;
@@ -35,6 +36,6 @@ public class SimulatorConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(BlockStreamConfig.class, GrpcConfig.class);
+        return Set.of(BlockStreamConfig.class, GrpcConfig.class, BlockGeneratorConfig.class);
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.data;
+
+import com.hedera.block.simulator.config.types.GenerationMode;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Defines the configuration for the BlockStreamManager (Generator) of blocks in the Hedera Block Simulator.
+ *
+ * @param generationMode the mode of block generation (e.g., directory-based)
+ * @param folderRootPath the root path of the folder containing block files
+ * @param managerImplementation the implementation class name of the block stream manager
+ * @param paddedLength the length to which block identifiers are padded
+ * @param fileExtension the file extension used for block files
+ */
+@ConfigData("generator")
+public record BlockGeneratorConfig(
+        @ConfigProperty(defaultValue = "DIR") GenerationMode generationMode,
+        @ConfigProperty(defaultValue = "") String folderRootPath,
+        @ConfigProperty(defaultValue = "BlockAsFileBlockStreamManager")
+                String managerImplementation,
+        @ConfigProperty(defaultValue = "36") int paddedLength,
+        @ConfigProperty(defaultValue = ".blk.gz") String fileExtension) {
+
+    /**
+     * Constructs a new {@code BlockGeneratorConfig} instance with validation.
+     *
+     * @throws IllegalArgumentException if the folder root path is not absolute or the folder does not exist
+     */
+    public BlockGeneratorConfig {
+        // Verify folderRootPath property
+        Path path = Path.of(folderRootPath);
+
+        // If folderRootPath is empty, set it to the default data directory
+        if (folderRootPath.isEmpty()) {
+            path = Paths.get("").toAbsolutePath().resolve("src/main/resources/block-0.0.3");
+        }
+        // Check if absolute
+        if (!path.isAbsolute()) {
+            throw new IllegalArgumentException(folderRootPath + " Root path must be absolute");
+        }
+        // Check if the folder exists
+        if (Files.notExists(path) && generationMode == GenerationMode.DIR) {
+            throw new IllegalArgumentException("Folder does not exist: " + path);
+        }
+
+        folderRootPath = path.toString();
+    }
+
+    /**
+     * Creates a new {@link Builder} for constructing a {@code BlockGeneratorConfig}.
+     *
+     * @return a new {@code Builder} instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder class for creating instances of {@link BlockGeneratorConfig}.
+     */
+    public static class Builder {
+        private GenerationMode generationMode = GenerationMode.DIR;
+        private String folderRootPath = "";
+        private String managerImplementation = "BlockAsFileBlockStreamManager";
+        private int paddedLength = 36;
+        private String fileExtension = ".blk.gz";
+
+        /**
+         * Creates a new instance of the {@code Builder} class with default configuration values.
+         */
+        public Builder() {
+            // Default constructor
+        }
+
+        /**
+         * Sets the generation mode for block generation.
+         *
+         * @param generationMode the {@link GenerationMode} to use
+         * @return this {@code Builder} instance
+         */
+        public Builder generationMode(GenerationMode generationMode) {
+            this.generationMode = generationMode;
+            return this;
+        }
+
+        /**
+         * Sets the root path of the folder containing block files.
+         *
+         * @param folderRootPath the absolute path to the folder
+         * @return this {@code Builder} instance
+         */
+        public Builder folderRootPath(String folderRootPath) {
+            this.folderRootPath = folderRootPath;
+            return this;
+        }
+
+        /**
+         * Sets the implementation class name of the block stream manager.
+         *
+         * @param managerImplementation the class name of the manager implementation
+         * @return this {@code Builder} instance
+         */
+        public Builder managerImplementation(String managerImplementation) {
+            this.managerImplementation = managerImplementation;
+            return this;
+        }
+
+        /**
+         * Sets the length to which block identifiers are padded.
+         *
+         * @param paddedLength the padded length
+         * @return this {@code Builder} instance
+         */
+        public Builder paddedLength(int paddedLength) {
+            this.paddedLength = paddedLength;
+            return this;
+        }
+
+        /**
+         * Sets the file extension used for block files.
+         *
+         * @param fileExtension the file extension (e.g., ".blk.gz")
+         * @return this {@code Builder} instance
+         */
+        public Builder fileExtension(String fileExtension) {
+            this.fileExtension = fileExtension;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link BlockGeneratorConfig} instance with the configured values.
+         *
+         * @return a new {@code BlockGeneratorConfig}
+         */
+        public BlockGeneratorConfig build() {
+            return new BlockGeneratorConfig(
+                    generationMode,
+                    folderRootPath,
+                    managerImplementation,
+                    paddedLength,
+                    fileExtension);
+        }
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -32,7 +32,7 @@ import com.swirlds.config.api.ConfigProperty;
 @ConfigData("blockStream")
 public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
-        @ConfigProperty(defaultValue = "10_000") int maxBlockItemsToStream,
+        @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
         @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock,
         @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize) {

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -16,64 +16,120 @@
 
 package com.hedera.block.simulator.config.data;
 
-import com.hedera.block.simulator.config.types.GenerationMode;
 import com.hedera.block.simulator.config.types.StreamingMode;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
- * The BlockStreamConfig class defines the configuration data for the block stream.
+ * Defines the configuration data for the block stream in the Hedera Block Simulator.
  *
- * @param generationMode the mode of generation for the block stream
- * @param folderRootPath the root path of the folder containing the block stream
- * @param delayBetweenBlockItems the delay between block items
- * @param managerImplementation the implementation of the block stream manager
- * @param maxBlockItemsToStream the maximum number of block items to stream
- * @param paddedLength the padded length of 0 the block file format
- * @param fileExtension the file extension of the block file format
- * @param streamingMode the mode of streaming for the block stream
- * @param millisecondsPerBlock the milliseconds per block
+ * @param delayBetweenBlockItems the delay in microseconds between streaming each block item
+ * @param maxBlockItemsToStream the maximum number of block items to stream before stopping
+ * @param streamingMode the mode of streaming for the block stream (e.g., time-based, count-based)
+ * @param millisecondsPerBlock the duration in milliseconds for each block when using time-based streaming
+ * @param blockItemsBatchSize the number of block items to stream in each batch
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
-        @ConfigProperty(defaultValue = "DIR") GenerationMode generationMode,
-        @ConfigProperty(defaultValue = "") String folderRootPath,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
-        @ConfigProperty(defaultValue = "BlockAsFileBlockStreamManager")
-                String managerImplementation,
         @ConfigProperty(defaultValue = "10_000") int maxBlockItemsToStream,
-        @ConfigProperty(defaultValue = "36") int paddedLength,
-        @ConfigProperty(defaultValue = ".blk.gz") String fileExtension,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
-        @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock) {
+        @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock,
+        @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize) {
 
     /**
-     * Constructor to set the default root path if not provided, it will be set to the data
-     * directory in the current working directory
+     * Creates a new {@link Builder} instance for constructing a {@code BlockStreamConfig}.
+     *
+     * @return a new {@code Builder}
      */
-    public BlockStreamConfig {
-        // verify rootPath prop
-        Path path = Path.of(folderRootPath);
+    public static Builder builder() {
+        return new Builder();
+    }
 
-        // if rootPath is empty, set it to the default data directory
-        if (folderRootPath.isEmpty()) {
-            path =
-                    Paths.get(folderRootPath)
-                            .toAbsolutePath()
-                            .resolve("src/main/resources/block-0.0.3");
-        }
-        // Check if absolute
-        if (!path.isAbsolute()) {
-            throw new IllegalArgumentException(folderRootPath + " Root path must be absolute");
-        }
-        // Check if the folder exists
-        if (Files.notExists(path) && generationMode == GenerationMode.DIR) {
-            throw new IllegalArgumentException("Folder does not exist: " + path);
+    /**
+     * A builder for creating instances of {@link BlockStreamConfig}.
+     */
+    public static class Builder {
+        private int delayBetweenBlockItems = 1_500_000;
+        private int maxBlockItemsToStream = 10_000;
+        private StreamingMode streamingMode = StreamingMode.MILLIS_PER_BLOCK;
+        private int millisecondsPerBlock = 1000;
+        private int blockItemsBatchSize = 1000;
+
+        /**
+         * Creates a new instance of the {@code Builder} class with default configuration values.
+         */
+        public Builder() {
+            // Default constructor
         }
 
-        folderRootPath = path.toString();
+        /**
+         * Sets the delay between streaming each block item.
+         *
+         * @param delayBetweenBlockItems the delay in microseconds
+         * @return this {@code Builder} instance
+         */
+        public Builder delayBetweenBlockItems(int delayBetweenBlockItems) {
+            this.delayBetweenBlockItems = delayBetweenBlockItems;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of block items to stream.
+         *
+         * @param maxBlockItemsToStream the maximum number of items
+         * @return this {@code Builder} instance
+         */
+        public Builder maxBlockItemsToStream(int maxBlockItemsToStream) {
+            this.maxBlockItemsToStream = maxBlockItemsToStream;
+            return this;
+        }
+
+        /**
+         * Sets the streaming mode for the block stream.
+         *
+         * @param streamingMode the {@link StreamingMode} to use
+         * @return this {@code Builder} instance
+         */
+        public Builder streamingMode(StreamingMode streamingMode) {
+            this.streamingMode = streamingMode;
+            return this;
+        }
+
+        /**
+         * Sets the duration for each block when using time-based streaming.
+         *
+         * @param millisecondsPerBlock the duration in milliseconds
+         * @return this {@code Builder} instance
+         */
+        public Builder millisecondsPerBlock(int millisecondsPerBlock) {
+            this.millisecondsPerBlock = millisecondsPerBlock;
+            return this;
+        }
+
+        /**
+         * Sets the number of block items to stream in each batch.
+         *
+         * @param blockItemsBatchSize the batch size
+         * @return this {@code Builder} instance
+         */
+        public Builder blockItemsBatchSize(int blockItemsBatchSize) {
+            this.blockItemsBatchSize = blockItemsBatchSize;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link BlockStreamConfig} instance with the configured values.
+         *
+         * @return a new {@code BlockStreamConfig}
+         */
+        public BlockStreamConfig build() {
+            return new BlockStreamConfig(
+                    delayBetweenBlockItems,
+                    maxBlockItemsToStream,
+                    streamingMode,
+                    millisecondsPerBlock,
+                    blockItemsBatchSize);
+        }
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
@@ -21,7 +21,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -57,11 +57,11 @@ public class BlockAsDirBlockStreamManager implements BlockStreamManager {
      * Constructor to initialize the BlockAsDirBlockStreamManager with the block stream
      * configuration.
      *
-     * @param blockStreamConfig the block stream configuration
+     * @param blockGeneratorConfig the block stream configuration
      */
     @Inject
-    public BlockAsDirBlockStreamManager(@NonNull BlockStreamConfig blockStreamConfig) {
-        this.rootFolder = blockStreamConfig.folderRootPath();
+    public BlockAsDirBlockStreamManager(@NonNull BlockGeneratorConfig blockGeneratorConfig) {
+        this.rootFolder = blockGeneratorConfig.folderRootPath();
         try {
             this.loadBlocks();
         } catch (IOException | ParseException | IllegalArgumentException e) {

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -21,7 +21,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
@@ -56,7 +56,7 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
      * @param blockStreamConfig the block stream config
      */
     @Inject
-    public BlockAsFileBlockStreamManager(@NonNull BlockStreamConfig blockStreamConfig) {
+    public BlockAsFileBlockStreamManager(@NonNull BlockGeneratorConfig blockStreamConfig) {
         this.rootFolder = blockStreamConfig.folderRootPath();
         try {
             this.loadBlocks();

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -19,7 +19,7 @@ package com.hedera.block.simulator.generator;
 import static com.hedera.block.simulator.generator.Utils.readFileBytes;
 import static java.lang.System.Logger.Level.INFO;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.hapi.block.stream.Block;
@@ -49,7 +49,7 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
      * @param config the block stream configuration
      */
     @Inject
-    public BlockAsFileLargeDataSets(@NonNull BlockStreamConfig config) {
+    public BlockAsFileLargeDataSets(@NonNull BlockGeneratorConfig config) {
         this.blockstreamPath = config.folderRootPath();
         this.formatString = "%0" + config.paddedLength() + "d" + config.fileExtension();
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
@@ -16,7 +16,7 @@
 
 package com.hedera.block.simulator.generator;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import dagger.Module;
 import dagger.Provides;
 import javax.inject.Singleton;
@@ -35,7 +35,7 @@ public interface GeneratorInjectionModule {
      */
     @Singleton
     @Provides
-    static BlockStreamManager providesBlockStreamManager(BlockStreamConfig config) {
+    static BlockStreamManager providesBlockStreamManager(BlockGeneratorConfig config) {
 
         if ("BlockAsDirBlockStreamManager".equalsIgnoreCase(config.managerImplementation())) {
             return new BlockAsDirBlockStreamManager(config);

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -18,6 +18,7 @@ package com.hedera.block.simulator.grpc;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
+import java.util.List;
 
 /**
  * The PublishStreamGrpcClient interface provides the methods to stream the block and block item.
@@ -26,10 +27,10 @@ public interface PublishStreamGrpcClient {
     /**
      * Streams the block item.
      *
-     * @param blockItem the block item to be streamed
+     * @param blockItems list of the block item to be streamed
      * @return true if the block item is streamed successfully, false otherwise
      */
-    boolean streamBlockItem(BlockItem blockItem);
+    boolean streamBlockItem(List<BlockItem> blockItems);
 
     /**
      * Streams the block.

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -89,8 +89,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         }
 
         final int blockItemsNumberOfBatches =
-                block.items().size() % blockStreamConfig.blockItemsBatchSize();
-        for (int i = 0; i < blockItemsNumberOfBatches; i++) {
+                block.items().size() / blockStreamConfig.blockItemsBatchSize();
+        for (int i = 0; i <= blockItemsNumberOfBatches; i++) {
 
             int blockItemsBatchSize = blockStreamConfig.blockItemsBatchSize();
             int startIndexOfBlockItems = i * blockItemsBatchSize;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
@@ -41,7 +41,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     @Override
     public void onError(Throwable throwable) {
         logger.log(Logger.Level.ERROR, "Error: " + throwable.toString());
-        // TODO: Stop the stream, retry, or stop simulation
+        // @todo(286) - handle the error
     }
 
     /** what will the stream observer do when the stream is completed */

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
@@ -41,6 +41,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     @Override
     public void onError(Throwable throwable) {
         logger.log(Logger.Level.ERROR, "Error: " + throwable.toString());
+        // TODO: Stop the stream, retry, or stop simulation
     }
 
     /** what will the stream observer do when the stream is completed */

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module com.hedera.block.simulator {
 
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;
+    requires com.hedera.block.common;
     requires com.hedera.block.stream;
     requires com.google.protobuf;
     requires com.hedera.pbj.runtime;

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -1,7 +1,7 @@
-#generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
-#generator.managerImplementation=BlockAsFileLargeDataSets
-#blockStream.maxBlockItemsToStream=100_000_000
-#blockStream.streamingMode=MILLIS_PER_BLOCK
-#blockStream.millisecondsPerBlock=500
-#blockStream.blockItemsBatchSize=1_000
-#blockStream.delayBetweenBlockItems=3_000_000
+generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
+generator.managerImplementation=BlockAsFileLargeDataSets
+blockStream.maxBlockItemsToStream=100_000_000
+blockStream.streamingMode=MILLIS_PER_BLOCK
+blockStream.millisecondsPerBlock=500
+blockStream.blockItemsBatchSize=1_000
+blockStream.delayBetweenBlockItems=3_000_000

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -1,4 +1,7 @@
-#blockStream.delayBetweenBlockItems=3_000_000
-#blockStream.folderRootPath=/Users/user/Downloads/block-0.0.3-perf1
-#blockStream.managerImplementation=BlockAsFileLargeDataSets
+#generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
+#generator.managerImplementation=BlockAsFileLargeDataSets
 #blockStream.maxBlockItemsToStream=100_000_000
+#blockStream.streamingMode=MILLIS_PER_BLOCK
+#blockStream.millisecondsPerBlock=500
+#blockStream.blockItemsBatchSize=1_000
+#blockStream.delayBetweenBlockItems=3_000_000

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -1,7 +1,7 @@
-generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
-generator.managerImplementation=BlockAsFileLargeDataSets
-blockStream.maxBlockItemsToStream=100_000_000
-blockStream.streamingMode=MILLIS_PER_BLOCK
-blockStream.millisecondsPerBlock=500
-blockStream.blockItemsBatchSize=1_000
-blockStream.delayBetweenBlockItems=3_000_000
+#generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
+#generator.managerImplementation=BlockAsFileLargeDataSets
+#blockStream.maxBlockItemsToStream=100_000_000
+#blockStream.streamingMode=MILLIS_PER_BLOCK
+#blockStream.millisecondsPerBlock=500
+#blockStream.blockItemsBatchSize=1_000
+#blockStream.delayBetweenBlockItems=3_000_000

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -16,7 +16,9 @@
 
 package com.hedera.block.simulator;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
@@ -173,7 +175,7 @@ class BlockStreamSimulatorTest {
 
         // simulate that the first block takes 15ms to stream, when the limit is 10, to force to go
         // over WARN Path.
-        when(publishStreamGrpcClient.streamBlock(block))
+        when(publishStreamGrpcClient.streamBlock(any()))
                 .thenAnswer(
                         invocation -> {
                             Thread.sleep(15);
@@ -184,12 +186,12 @@ class BlockStreamSimulatorTest {
         Configuration configuration =
                 TestUtils.getTestConfiguration(
                         Map.of(
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
                                 "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
+                                "BlockAsFileBlockStreamManager",
                                 "generator.rootPath",
                                 getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                                "blockStream.maxBlockItemsToStream",
+                                "2",
                                 "blockStream.streamingMode",
                                 "MILLIS_PER_BLOCK",
                                 "blockStream.millisecondsPerBlock",
@@ -211,10 +213,7 @@ class BlockStreamSimulatorTest {
                                 logRecord ->
                                         logRecord
                                                 .getMessage()
-                                                .contains(
-                                                        "Block Server is running behind, Streaming"
-                                                            + " took longer than max expected: 10"
-                                                            + " milliseconds"));
+                                                .contains("Block Server is running behind"));
         assertTrue(found_log);
     }
 

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -80,23 +80,33 @@ class BlockStreamSimulatorTest {
     }
 
     @Test
-    void start_exitByBlockNull()
+    void start_constantRateStreaming()
             throws InterruptedException, BlockSimulatorParsingException, IOException {
 
+        BlockItem blockItem =
+                BlockItem.newBuilder()
+                        .blockHeader(BlockHeader.newBuilder().number(1L).build())
+                        .build();
+
+        Block block1 = Block.newBuilder().items(blockItem).build();
+        Block block2 = Block.newBuilder().items(blockItem, blockItem, blockItem).build();
+
         BlockStreamManager blockStreamManager = Mockito.mock(BlockStreamManager.class);
-        when(blockStreamManager.getNextBlockItem()).thenReturn(BlockItem.newBuilder().build());
+        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
 
         Configuration configuration =
                 TestUtils.getTestConfiguration(
                         Map.of(
                                 "blockStream.maxBlockItemsToStream",
                                 "2",
-                                "blockStream.BlockAsFileBlockStreamManager",
+                                "generator.managerImplementation",
                                 "BlockAsFileLargeDataSets",
-                                "blockStream.rootPath",
+                                "generator.rootPath",
                                 getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
                                 "blockStream.streamingMode",
-                                "CONSTANT_RATE"));
+                                "CONSTANT_RATE",
+                                "blockStream.blockItemsBatchSize",
+                                "2"));
 
         BlockStreamSimulatorApp blockStreamSimulator =
                 new BlockStreamSimulatorApp(
@@ -116,7 +126,7 @@ class BlockStreamSimulatorTest {
     }
 
     @Test
-    void start_millisPerSecond()
+    void start_millisPerBlockStreaming()
             throws InterruptedException, IOException, BlockSimulatorParsingException {
         BlockStreamManager blockStreamManager = Mockito.mock(BlockStreamManager.class);
         BlockItem blockItem =
@@ -131,9 +141,9 @@ class BlockStreamSimulatorTest {
                         Map.of(
                                 "blockStream.maxBlockItemsToStream",
                                 "2",
-                                "blockStream.BlockAsFileBlockStreamManager",
+                                "generator.managerImplementation",
                                 "BlockAsFileLargeDataSets",
-                                "blockStream.rootPath",
+                                "generator.rootPath",
                                 getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
                                 "blockStream.streamingMode",
                                 "MILLIS_PER_BLOCK"));
@@ -176,14 +186,16 @@ class BlockStreamSimulatorTest {
                         Map.of(
                                 "blockStream.maxBlockItemsToStream",
                                 "2",
-                                "blockStream.BlockAsFileBlockStreamManager",
+                                "generator.managerImplementation",
                                 "BlockAsFileLargeDataSets",
-                                "blockStream.rootPath",
+                                "generator.rootPath",
                                 getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
                                 "blockStream.streamingMode",
                                 "MILLIS_PER_BLOCK",
                                 "blockStream.millisecondsPerBlock",
-                                "10"));
+                                "10",
+                                "blockStream.blockItemsBatchSize",
+                                "1"));
 
         BlockStreamSimulatorApp blockStreamSimulator =
                 new BlockStreamSimulatorApp(

--- a/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
@@ -17,10 +17,9 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.TestConfigBuilder;
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -41,11 +40,10 @@ public class TestUtils {
         for (Map.Entry<String, String> entry : customProperties.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            testConfigBuilder = testConfigBuilder.withValue(key, value);
+            testConfigBuilder =
+                    testConfigBuilder.withSource(
+                            new SimpleConfigSource(key, value).withOrdinal(500));
         }
-
-        testConfigBuilder = testConfigBuilder.withConfigDataType(BlockStreamConfig.class);
-        testConfigBuilder = testConfigBuilder.withConfigDataType(GrpcConfig.class);
 
         return testConfigBuilder.getOrCreateConfig();
     }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.config;
 
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.swirlds.config.api.Configuration;
@@ -61,5 +62,15 @@ class ConfigInjectionModuleTest {
         Assertions.assertNotNull(grpcConfig);
         Assertions.assertEquals("localhost", grpcConfig.serverAddress());
         Assertions.assertEquals(8080, grpcConfig.port());
+    }
+
+    @Test
+    void provideBlockGeneratorConfig() {
+        BlockGeneratorConfig blockGeneratorConfig =
+                ConfigInjectionModule.provideBlockGeneratorConfig(configuration);
+
+        Assertions.assertNotNull(blockGeneratorConfig);
+        Assertions.assertEquals(
+                "BlockAsFileBlockStreamManager", blockGeneratorConfig.managerImplementation());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -16,16 +16,16 @@
 
 package com.hedera.block.simulator.config;
 
+import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
-import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
-import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,11 +38,12 @@ class ConfigInjectionModuleTest {
     static void setUpAll() throws IOException {
         configuration =
                 ConfigurationBuilder.create()
-                        .withSource(SystemEnvironmentConfigSource.getInstance())
-                        .withSource(SystemPropertiesConfigSource.getInstance())
                         .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
                         .autoDiscoverExtensions()
                         .build();
+        configuration =
+                TestUtils.getTestConfiguration(
+                        Map.of("generator.managerImplementation", "BlockAsFileBlockStreamManager"));
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -18,7 +18,6 @@ package com.hedera.block.simulator.config;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
-import com.hedera.block.simulator.config.types.GenerationMode;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
@@ -52,7 +51,7 @@ class ConfigInjectionModuleTest {
                 ConfigInjectionModule.provideBlockStreamConfig(configuration);
 
         Assertions.assertNotNull(blockStreamConfig);
-        Assertions.assertEquals(GenerationMode.DIR, blockStreamConfig.generationMode());
+        Assertions.assertEquals(1000, blockStreamConfig.blockItemsBatchSize());
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -27,16 +27,45 @@ import org.junit.jupiter.api.Test;
 
 class BlockStreamConfigTest {
 
-    private final int delayBetweenBlockItems = 1_500_000;
-    private final String blockStreamManagerImplementation = "BlockAsFileBlockStreamManager";
-    private final int maxBlockItemsToStream = 10_000;
-    private final int paddedLength = 36;
-    private final String fileExtension = ".blk";
-    private final StreamingMode streamingMode = StreamingMode.CONSTANT_RATE;
-    private final int millisPerBlock = 1000;
-
     private String getAbsoluteFolder(String relativePath) {
         return Paths.get(relativePath).toAbsolutePath().toString();
+    }
+
+    private BlockStreamConfig.Builder getBlockStreamConfigBuilder() {
+        final StreamingMode streamingMode = StreamingMode.CONSTANT_RATE;
+        final int delayBetweenBlockItems = 1_500_000;
+        final int maxBlockItemsToStream = 10_000;
+        final int millisPerBlock = 1000;
+        final int blockItemsBatchSize = 1000;
+
+        return BlockStreamConfig.builder()
+                .delayBetweenBlockItems(delayBetweenBlockItems)
+                .maxBlockItemsToStream(maxBlockItemsToStream)
+                .streamingMode(streamingMode)
+                .millisecondsPerBlock(millisPerBlock)
+                .blockItemsBatchSize(blockItemsBatchSize);
+    }
+
+    private BlockGeneratorConfig.Builder getBlockGeneratorConfigBuilder() {
+        String folderRootPath = "src/main/resources/block-0.0.3/";
+        GenerationMode generationMode = GenerationMode.DIR;
+
+        String blockStreamManagerImplementation = "BlockAsFileBlockStreamManager";
+        int paddedLength = 36;
+        String fileExtension = ".blk";
+        return BlockGeneratorConfig.builder()
+                .generationMode(generationMode)
+                .folderRootPath(folderRootPath)
+                .managerImplementation(blockStreamManagerImplementation)
+                .paddedLength(paddedLength)
+                .fileExtension(fileExtension);
+    }
+
+    @Test
+    void testStreamConfigBuilder() {
+        BlockStreamConfig config = getBlockStreamConfigBuilder().build();
+        // assert
+        assertEquals(StreamingMode.CONSTANT_RATE, config.streamingMode());
     }
 
     @Test
@@ -51,17 +80,11 @@ class BlockStreamConfigTest {
         assertTrue(Files.exists(path), "The folder must exist for this test.");
 
         // No exception should be thrown
-        BlockStreamConfig config =
-                new BlockStreamConfig(
-                        generationMode,
-                        folderRootPath,
-                        delayBetweenBlockItems,
-                        blockStreamManagerImplementation,
-                        maxBlockItemsToStream,
-                        paddedLength,
-                        fileExtension,
-                        streamingMode,
-                        millisPerBlock);
+        BlockGeneratorConfig config =
+                getBlockGeneratorConfigBuilder()
+                        .folderRootPath(folderRootPath)
+                        .generationMode(generationMode)
+                        .build();
 
         assertEquals(folderRootPath, config.folderRootPath());
         assertEquals(GenerationMode.DIR, config.generationMode());
@@ -72,19 +95,12 @@ class BlockStreamConfigTest {
         // Setup empty folder root path and generation mode
         String folderRootPath = "";
         GenerationMode generationMode = GenerationMode.DIR;
+        BlockGeneratorConfig.Builder builder =
+                getBlockGeneratorConfigBuilder()
+                        .folderRootPath(folderRootPath)
+                        .generationMode(generationMode);
 
-        // No exception should be thrown, and the default folder should be used
-        BlockStreamConfig config =
-                new BlockStreamConfig(
-                        generationMode,
-                        folderRootPath,
-                        delayBetweenBlockItems,
-                        blockStreamManagerImplementation,
-                        maxBlockItemsToStream,
-                        paddedLength,
-                        fileExtension,
-                        streamingMode,
-                        millisPerBlock);
+        BlockGeneratorConfig config = builder.build();
 
         // Verify that the path is set to the default
         Path expectedPath = Paths.get("src/main/resources/block-0.0.3/").toAbsolutePath();
@@ -103,16 +119,10 @@ class BlockStreamConfigTest {
                 assertThrows(
                         IllegalArgumentException.class,
                         () ->
-                                new BlockStreamConfig(
-                                        generationMode,
-                                        relativeFolderPath,
-                                        delayBetweenBlockItems,
-                                        blockStreamManagerImplementation,
-                                        maxBlockItemsToStream,
-                                        paddedLength,
-                                        fileExtension,
-                                        streamingMode,
-                                        millisPerBlock));
+                                getBlockGeneratorConfigBuilder()
+                                        .folderRootPath(relativeFolderPath)
+                                        .generationMode(generationMode)
+                                        .build());
 
         // Verify the exception message
         assertEquals(relativeFolderPath + " Root path must be absolute", exception.getMessage());
@@ -133,16 +143,10 @@ class BlockStreamConfigTest {
                 assertThrows(
                         IllegalArgumentException.class,
                         () ->
-                                new BlockStreamConfig(
-                                        generationMode,
-                                        folderRootPath,
-                                        delayBetweenBlockItems,
-                                        blockStreamManagerImplementation,
-                                        maxBlockItemsToStream,
-                                        paddedLength,
-                                        fileExtension,
-                                        streamingMode,
-                                        millisPerBlock));
+                                getBlockGeneratorConfigBuilder()
+                                        .folderRootPath(folderRootPath)
+                                        .generationMode(generationMode)
+                                        .build());
 
         // Verify the exception message
         assertEquals("Folder does not exist: " + path, exception.getMessage());
@@ -155,17 +159,11 @@ class BlockStreamConfigTest {
         GenerationMode generationMode = GenerationMode.ADHOC;
 
         // No exception should be thrown because generation mode is not DIR
-        BlockStreamConfig config =
-                new BlockStreamConfig(
-                        generationMode,
-                        folderRootPath,
-                        delayBetweenBlockItems,
-                        blockStreamManagerImplementation,
-                        maxBlockItemsToStream,
-                        paddedLength,
-                        fileExtension,
-                        streamingMode,
-                        millisPerBlock);
+        BlockGeneratorConfig config =
+                getBlockGeneratorConfigBuilder()
+                        .folderRootPath(folderRootPath)
+                        .generationMode(generationMode)
+                        .build();
 
         // Verify that the configuration was created successfully
         assertEquals(folderRootPath, config.folderRootPath());

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
@@ -20,9 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
-import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -75,17 +74,10 @@ class BlockAsDirBlockStreamManagerTest {
     }
 
     private BlockStreamManager getBlockAsDirBlockStreamManager(String rootFolder) {
-        BlockStreamConfig blockStreamConfig =
-                new BlockStreamConfig(
-                        GenerationMode.DIR,
-                        rootFolder,
-                        1_500_000,
-                        "BlockAsDirBlockStreamManager",
-                        10_000,
-                        36,
-                        ".blk",
-                        StreamingMode.CONSTANT_RATE,
-                        1000);
-        return new BlockAsDirBlockStreamManager(blockStreamConfig);
+        final BlockGeneratorConfig blockGeneratorConfig =
+                new BlockGeneratorConfig(
+                        GenerationMode.DIR, rootFolder, "BlockAsDirBlockStreamManager", 36, ".blk");
+
+        return new BlockAsDirBlockStreamManager(blockGeneratorConfig);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
@@ -18,9 +18,8 @@ package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
-import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -77,17 +76,16 @@ class BlockAsFileBlockStreamManagerTest {
     }
 
     private BlockAsFileBlockStreamManager getBlockAsFileBlockStreamManager(String rootFolder) {
-        BlockStreamConfig blockStreamConfig =
-                new BlockStreamConfig(
-                        GenerationMode.DIR,
-                        rootFolder,
-                        1_500_000,
-                        "BlockAsFileBlockStreamManager",
-                        10_000,
-                        36,
-                        ".blk",
-                        StreamingMode.CONSTANT_RATE,
-                        1000);
-        return new BlockAsFileBlockStreamManager(blockStreamConfig);
+
+        BlockGeneratorConfig blockGeneratorConfig =
+                BlockGeneratorConfig.builder()
+                        .generationMode(GenerationMode.DIR)
+                        .folderRootPath(rootFolder)
+                        .managerImplementation("BlockAsFileBlockStreamManager")
+                        .paddedLength(36)
+                        .fileExtension(".blk")
+                        .build();
+
+        return new BlockAsFileBlockStreamManager(blockGeneratorConfig);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
@@ -18,9 +18,8 @@ package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.types.GenerationMode;
-import com.hedera.block.simulator.config.types.StreamingMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.File;
@@ -96,19 +95,17 @@ class BlockAsFileLargeDataSetsTest {
         byte[] invalidData = "invalid block data".getBytes();
         Files.write(currentBlockFilePath, invalidData);
 
-        BlockStreamConfig blockStreamConfig =
-                new BlockStreamConfig(
-                        GenerationMode.DIR,
-                        blockDirPath.toString(),
-                        1_500_000,
-                        "BlockAsFileBlockStreamManager",
-                        10_000,
-                        36,
-                        ".blk",
-                        StreamingMode.CONSTANT_RATE,
-                        1000);
+        final BlockGeneratorConfig blockGeneratorConfig =
+                BlockGeneratorConfig.builder()
+                        .generationMode(GenerationMode.DIR)
+                        .folderRootPath(blockDirPath.toString())
+                        .managerImplementation("BlockAsFileBlockStreamManager")
+                        .paddedLength(36)
+                        .fileExtension(".blk")
+                        .build();
+
         BlockAsFileLargeDataSets blockStreamManager =
-                new BlockAsFileLargeDataSets(blockStreamConfig);
+                new BlockAsFileLargeDataSets(blockGeneratorConfig);
 
         assertThrows(
                 BlockSimulatorParsingException.class,
@@ -118,18 +115,17 @@ class BlockAsFileLargeDataSetsTest {
 
     private BlockAsFileLargeDataSets getBlockAsFileLargeDatasetsBlockStreamManager(
             String rootFolder) {
-        BlockStreamConfig blockStreamConfig =
-                new BlockStreamConfig(
-                        GenerationMode.DIR,
-                        rootFolder,
-                        1_500_000,
-                        "BlockAsFileBlockStreamManager",
-                        10_000,
-                        36,
-                        ".blk",
-                        StreamingMode.CONSTANT_RATE,
-                        1000);
-        return new BlockAsFileLargeDataSets(blockStreamConfig);
+
+        final BlockGeneratorConfig blockGeneratorConfig =
+                BlockGeneratorConfig.builder()
+                        .generationMode(GenerationMode.DIR)
+                        .folderRootPath(rootFolder)
+                        .managerImplementation("BlockAsFileBlockStreamManager")
+                        .paddedLength(36)
+                        .fileExtension(".blk")
+                        .build();
+
+        return new BlockAsFileLargeDataSets(blockGeneratorConfig);
     }
 
     private static String getAbsoluteFolder(String relativePath) {

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -19,7 +19,7 @@ package com.hedera.block.simulator.generator;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.TestUtils;
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import java.io.IOException;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -29,15 +29,15 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_AsFileLargeDataSets() throws IOException {
 
-        BlockStreamConfig blockStreamConfig =
+        BlockGeneratorConfig blockGeneratorConfig =
                 TestUtils.getTestConfiguration(
                                 Map.of(
-                                        "blockStream.managerImplementation",
+                                        "generator.managerImplementation",
                                         "BlockAsFileLargeDataSets"))
-                        .getConfigData(BlockStreamConfig.class);
+                        .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockStreamConfig);
+                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
         assertEquals(
                 blockStreamManager.getClass().getName(), BlockAsFileLargeDataSets.class.getName());
@@ -45,11 +45,11 @@ class GeneratorInjectionModuleTest {
 
     @Test
     void providesBlockStreamManager_AsFile() throws IOException {
-        BlockStreamConfig blockStreamConfig =
-                TestUtils.getTestConfiguration().getConfigData(BlockStreamConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig =
+                TestUtils.getTestConfiguration().getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockStreamConfig);
+                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
         assertEquals(
                 blockStreamManager.getClass().getName(),
@@ -58,29 +58,29 @@ class GeneratorInjectionModuleTest {
 
     @Test
     void providesBlockStreamManager_AsDir() throws IOException {
-        BlockStreamConfig blockStreamConfig =
+        BlockGeneratorConfig blockGeneratorConfig =
                 TestUtils.getTestConfiguration(
                                 Map.of(
-                                        "blockStream.managerImplementation",
+                                        "generator.managerImplementation",
                                         "BlockAsDirBlockStreamManager"))
-                        .getConfigData(BlockStreamConfig.class);
+                        .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockStreamConfig);
+                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
         assertEquals(
-                blockStreamManager.getClass().getName(),
-                BlockAsDirBlockStreamManager.class.getName());
+                BlockAsDirBlockStreamManager.class.getName(),
+                blockStreamManager.getClass().getName());
     }
 
     @Test
     void providesBlockStreamManager_default() throws IOException {
-        BlockStreamConfig blockStreamConfig =
-                TestUtils.getTestConfiguration(Map.of("blockStream.managerImplementation", ""))
-                        .getConfigData(BlockStreamConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig =
+                TestUtils.getTestConfiguration(Map.of("generator.managerImplementation", ""))
+                        .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
-                GeneratorInjectionModule.providesBlockStreamManager(blockStreamConfig);
+                GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
         assertEquals(
                 blockStreamManager.getClass().getName(),

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -46,7 +46,13 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_AsFile() throws IOException {
         BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration().getConfigData(BlockGeneratorConfig.class);
+                TestUtils.getTestConfiguration(
+                                Map.of(
+                                        "generator.managerImplementation",
+                                        "BlockAsFileBlockStreamManager",
+                                        "generator.folderRootPath",
+                                        ""))
+                        .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
@@ -76,7 +82,12 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_default() throws IOException {
         BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration(Map.of("generator.managerImplementation", ""))
+                TestUtils.getTestConfiguration(
+                                Map.of(
+                                        "generator.managerImplementation",
+                                        "",
+                                        "generator.folderRootPath",
+                                        ""))
                         .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -19,11 +19,13 @@ package com.hedera.block.simulator.grpc;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.TestUtils;
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,11 +33,15 @@ import org.junit.jupiter.api.Test;
 class PublishStreamGrpcClientImplTest {
 
     GrpcConfig grpcConfig;
+    BlockStreamConfig blockStreamConfig;
 
     @BeforeEach
     void setUp() throws IOException {
 
         grpcConfig = TestUtils.getTestConfiguration().getConfigData(GrpcConfig.class);
+        blockStreamConfig =
+                TestUtils.getTestConfiguration(Map.of("blockStream.blockItemsBatchSize", "2"))
+                        .getConfigData(BlockStreamConfig.class);
     }
 
     @AfterEach
@@ -45,7 +51,7 @@ class PublishStreamGrpcClientImplTest {
     void streamBlockItem() {
         BlockItem blockItem = BlockItem.newBuilder().build();
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
-                new PublishStreamGrpcClientImpl(grpcConfig);
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
         boolean result = publishStreamGrpcClient.streamBlockItem(List.of(blockItem));
         assertTrue(result);
     }
@@ -55,9 +61,15 @@ class PublishStreamGrpcClientImplTest {
         BlockItem blockItem = BlockItem.newBuilder().build();
         Block block = Block.newBuilder().items(blockItem).build();
 
+        Block block1 = Block.newBuilder().items(blockItem, blockItem, blockItem).build();
+
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
-                new PublishStreamGrpcClientImpl(grpcConfig);
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
+
         boolean result = publishStreamGrpcClient.streamBlock(block);
         assertTrue(result);
+
+        boolean result1 = publishStreamGrpcClient.streamBlock(block1);
+        assertTrue(result1);
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -23,6 +23,7 @@ import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class PublishStreamGrpcClientImplTest {
         BlockItem blockItem = BlockItem.newBuilder().build();
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
                 new PublishStreamGrpcClientImpl(grpcConfig);
-        boolean result = publishStreamGrpcClient.streamBlockItem(blockItem);
+        boolean result = publishStreamGrpcClient.streamBlockItem(List.of(blockItem));
         assertTrue(result);
     }
 

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -33,10 +33,10 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.cloneHederaProtobufs {
     // uncomment below to use a specific tag
     // tag = "v0.53.0" or a specific commit like "0047255"
-    tag = "d5e6988"
+    // tag = "d5e6988"
 
     // uncomment below to use a specific branch
-    // branch = "main"
+    branch = "block-repeated-fix-tss-message"
 }
 
 sourceSets {

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -71,6 +71,8 @@ public abstract class BaseSuite {
      * Setup method to be executed before all tests.
      *
      * <p>This method initializes the Block Node server container using Testcontainers.
+     *
+     * @throws IOException if an I/O error occurs
      */
     @BeforeAll
     public static void setup() throws IOException {

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -19,6 +19,7 @@ package com.hedera.block.suites.persistence.positive;
 import com.hedera.block.suites.BaseSuite;
 import org.junit.jupiter.api.DisplayName;
 
+/** Positive Data Persistence Tests */
 @DisplayName("Positive Data Persistence Tests")
 public class PositiveDataPersistenceTests extends BaseSuite {
     /** Default constructor for the {@link PositiveDataPersistenceTests} class. */


### PR DESCRIPTION
**Description**:

This PR changes the version of `hedera-protobuf` and refactors all the project due to 2 fundamental changes to the API spec.

1. Service was changed from 1 single service called `BlockStreamService` to 4 different services: `BlockStreamService`, `BlockAccessService`, `BlockNodeService`, `StateService`.
2. `BlockStreamService` --> `publishBlockStream` and `subscribeBlockStream` to use a repeated set of `block_items` per request instead of a single `block_item`.

Changes done to support the change:
1. Updated `stream` branch/commit to use a ~temporal~ temporary branch until is merged to main.
2. Changes to the simulator to steam by batch
3. Changes to Helidon Interfaces and Internal Services
4. Fixing Unit Tests to reflect changes
5. Refactored `BlockStreamService` to extract `BlockStreamAccess` methods.
6. Add `BlockStreamAccesss` Grpc Service to start-up routes.
7. Added new and missing UTs
8. Updated Configuration and Documentation 


**Related issue(s)**:

Fixes #261
Fixes #262 
Fixes #268 
Fixes #276 
Fixes #277 
Fixes #278 

**Notes for reviewer**:
Main refactor is completed, at least is compiling :)


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
