### PR TITLE
feat: Move out concrete working implementation and add working modes

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -46,7 +46,7 @@ public class BlockStreamSimulator {
     public static void main(String[] args)
             throws IOException, InterruptedException, BlockSimulatorParsingException {
 
-        LOGGER.log(INFO, "Starting Block Stream Simulator");
+        LOGGER.log(INFO, "Starting Block Stream Simulator!");
 
         ConfigurationBuilder configurationBuilder =
                 ConfigurationBuilder.create()

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -17,11 +17,14 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
-import com.hedera.hapi.block.stream.Block;
+import com.hedera.block.simulator.mode.CombinedModeHandler;
+import com.hedera.block.simulator.mode.ConsumerModeHandler;
+import com.hedera.block.simulator.mode.PublisherModeHandler;
+import com.hedera.block.simulator.mode.SimulatorModeHandler;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -37,10 +40,7 @@ public class BlockStreamSimulatorApp {
     private final BlockStreamManager blockStreamManager;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final BlockStreamConfig blockStreamConfig;
-    private final StreamingMode streamingMode;
-
-    private final int delayBetweenBlockItems;
-    private final int millisecondsPerBlock;
+    private final SimulatorModeHandler simulatorModeHandler;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     /**
@@ -60,9 +60,15 @@ public class BlockStreamSimulatorApp {
 
         blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
 
-        streamingMode = blockStreamConfig.streamingMode();
-        millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
-        delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+        SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
+        if (simulatorMode == SimulatorMode.PUBLISHER) {
+            simulatorModeHandler =
+                    new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+        } else if (simulatorMode == SimulatorMode.CONSUMER) {
+            simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig);
+        } else {
+            simulatorModeHandler = new CombinedModeHandler(blockStreamConfig);
+        }
     }
 
     /**
@@ -73,77 +79,13 @@ public class BlockStreamSimulatorApp {
      * @throws IOException if an I/O error occurs
      */
     public void start() throws InterruptedException, BlockSimulatorParsingException, IOException {
-
+        LOGGER.log(
+                System.Logger.Level.INFO,
+                "Block Stream Simulator started initializing components...");
+        publishStreamGrpcClient.init();
         isRunning.set(true);
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has started");
 
-        if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
-            millisPerBlockStreaming();
-        } else {
-            constantRateStreaming();
-        }
-
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
-    }
-
-    private void millisPerBlockStreaming()
-            throws IOException, InterruptedException, BlockSimulatorParsingException {
-
-        final long secondsPerBlockNanos = millisecondsPerBlock * 1_000_000L;
-
-        Block nextBlock = blockStreamManager.getNextBlock();
-        while (nextBlock != null) {
-            long startTime = System.nanoTime();
-            publishStreamGrpcClient.streamBlock(nextBlock);
-            long elapsedTime = System.nanoTime() - startTime;
-            long timeToDelay = secondsPerBlockNanos - elapsedTime;
-            if (timeToDelay > 0) {
-                Thread.sleep(timeToDelay / 1_000_000, (int) (timeToDelay % 1_000_000));
-            } else {
-                LOGGER.log(
-                        System.Logger.Level.WARNING,
-                        "Block Server is running behind. Streaming took: "
-                                + (elapsedTime / 1_000_000)
-                                + "ms - Longer than max expected of: "
-                                + millisecondsPerBlock
-                                + " milliseconds");
-            }
-            nextBlock = blockStreamManager.getNextBlock();
-        }
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
-    }
-
-    private void constantRateStreaming()
-            throws InterruptedException, IOException, BlockSimulatorParsingException {
-        int delayMSBetweenBlockItems = delayBetweenBlockItems / 1_000_000;
-        int delayNSBetweenBlockItems = delayBetweenBlockItems % 1_000_000;
-        boolean streamBlockItem = true;
-        int blockItemsStreamed = 0;
-
-        while (streamBlockItem) {
-            // get block
-            Block block = blockStreamManager.getNextBlock();
-
-            if (block == null) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the end of the block items");
-                break;
-            }
-
-            publishStreamGrpcClient.streamBlock(block);
-            blockItemsStreamed += block.items().size();
-
-            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
-
-            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the maximum number of block items to"
-                                + " stream");
-                streamBlockItem = false;
-            }
-        }
+        simulatorModeHandler.start(this.blockStreamManager);
     }
 
     /**
@@ -155,8 +97,9 @@ public class BlockStreamSimulatorApp {
         return isRunning.get();
     }
 
-    /** Stops the block stream simulator. */
+    /** Stops the Block Stream Simulator and closes off all grpc channels. */
     public void stop() {
+        publishStreamGrpcClient.shutdown();
         isRunning.set(false);
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.config.data;
 
+import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.config.types.StreamingMode;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
@@ -23,6 +24,7 @@ import com.swirlds.config.api.ConfigProperty;
 /**
  * Defines the configuration data for the block stream in the Hedera Block Simulator.
  *
+ * @param simulatorMode the mode of the simulator, in terms of publishing, consuming or both
  * @param delayBetweenBlockItems the delay in microseconds between streaming each block item
  * @param maxBlockItemsToStream the maximum number of block items to stream before stopping
  * @param streamingMode the mode of streaming for the block stream (e.g., time-based, count-based)
@@ -31,6 +33,7 @@ import com.swirlds.config.api.ConfigProperty;
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
+        @ConfigProperty(defaultValue = "PUBLISHER") SimulatorMode simulatorMode,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
@@ -50,6 +53,7 @@ public record BlockStreamConfig(
      * A builder for creating instances of {@link BlockStreamConfig}.
      */
     public static class Builder {
+        private SimulatorMode simulatorMode = SimulatorMode.PUBLISHER;
         private int delayBetweenBlockItems = 1_500_000;
         private int maxBlockItemsToStream = 10_000;
         private StreamingMode streamingMode = StreamingMode.MILLIS_PER_BLOCK;
@@ -61,6 +65,17 @@ public record BlockStreamConfig(
          */
         public Builder() {
             // Default constructor
+        }
+
+        /**
+         * Sets the simulator mode for the block stream.
+         *
+         * @param simulatorMode the {@link SimulatorMode} to use
+         * @return this {@code Builder} instance
+         */
+        public Builder streamingMode(SimulatorMode simulatorMode) {
+            this.simulatorMode = simulatorMode;
+            return this;
         }
 
         /**
@@ -125,6 +140,7 @@ public record BlockStreamConfig(
          */
         public BlockStreamConfig build() {
             return new BlockStreamConfig(
+                    simulatorMode,
                     delayBetweenBlockItems,
                     maxBlockItemsToStream,
                     streamingMode,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.types;
+
+/** The SimulatorMode enum defines the work modes of the block stream simulator. */
+public enum SimulatorMode {
+    /**
+     * Indicates a work mode in which the simulator is working as both consumer and publisher.
+     */
+    BOTH,
+    /**
+     * Indicates a work mode in which the simulator is working in consumer mode.
+     */
+    CONSUMER,
+    /**
+     * Indicates a work mode in which the simulator is working in publisher mode.
+     */
+    PUBLISHER
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -25,6 +25,11 @@ import java.util.List;
  */
 public interface PublishStreamGrpcClient {
     /**
+     * Initialize, opens a gRPC channel and creates the needed stubs with the passed configuration.
+     */
+    void init();
+
+    /**
      * Streams the block item.
      *
      * @param blockItems list of the block item to be streamed
@@ -39,4 +44,9 @@ public interface PublishStreamGrpcClient {
      * @return true if the block is streamed successfully, false otherwise
      */
     boolean streamBlock(Block block);
+
+    /**
+     * Shutdowns the channel.
+     */
+    void shutdown();
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The {@code CombinedModeHandler} class implements the {@link SimulatorModeHandler} interface
+ * and provides the behavior for a mode where both consuming and publishing of block data
+ * occur simultaneously.
+ *
+ * <p>This mode handles dual operations in the block streaming process, utilizing the
+ * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
+ * the simulator needs to handle both the consumption and publication of blocks in parallel.
+ *
+ * <p>For now, the actual start behavior is not implemented, as indicated by the
+ * {@link UnsupportedOperationException}.
+ */
+public class CombinedModeHandler implements SimulatorModeHandler {
+    private final BlockStreamConfig blockStreamConfig;
+
+    /**
+     * Constructs a new {@code CombinedModeHandler} with the specified block stream configuration.
+     *
+     * @param blockStreamConfig the configuration data for managing block streams
+     */
+    public CombinedModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
+        requireNonNull(blockStreamConfig);
+        this.blockStreamConfig = blockStreamConfig;
+    }
+
+    /**
+     * Starts the simulator in combined mode, handling both consumption and publication
+     * of block stream. However, this method is currently not implemented, and will throw
+     * an {@link UnsupportedOperationException}.
+     *
+     * @param blockStreamManager the {@link BlockStreamManager} responsible for managing block streams
+     * @throws UnsupportedOperationException as the method is not yet implemented
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The {@code ConsumerModeHandler} class implements the {@link SimulatorModeHandler} interface
+ * and provides the behavior for a mode where only consumption of block data
+ * occurs.
+ *
+ * <p>This mode handles dual operations in the block streaming process, utilizing the
+ * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
+ * the simulator needs to handle both the consumption and publication of blocks in parallel.
+ *
+ * <p>For now, the actual start behavior is not implemented, as indicated by the
+ * {@link UnsupportedOperationException}.
+ */
+public class ConsumerModeHandler implements SimulatorModeHandler {
+
+    private final BlockStreamConfig blockStreamConfig;
+
+    /**
+     * Constructs a new {@code ConsumerModeHandler} with the specified block stream configuration.
+     *
+     * @param blockStreamConfig the configuration data for managing block streams
+     */
+    public ConsumerModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
+        requireNonNull(blockStreamConfig);
+        this.blockStreamConfig = blockStreamConfig;
+    }
+
+    /**
+     * Starts the simulator and initiate streaming, depending on the working mode.
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.hapi.block.stream.Block;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+public class PublisherModeHandler implements SimulatorModeHandler {
+    private static final System.Logger LOGGER =
+            System.getLogger(PublisherModeHandler.class.getName());
+
+    private final BlockStreamConfig blockStreamConfig;
+    private final PublishStreamGrpcClient publishStreamGrpcClient;
+    private final StreamingMode streamingMode;
+    private final int delayBetweenBlockItems;
+    private final int millisecondsPerBlock;
+    private final int NANOS_PER_MILLI = 1_000_000;
+
+    public PublisherModeHandler(
+            @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {
+        requireNonNull(blockStreamConfig);
+        requireNonNull(publishStreamGrpcClient);
+        this.blockStreamConfig = blockStreamConfig;
+        this.publishStreamGrpcClient = publishStreamGrpcClient;
+
+        streamingMode = blockStreamConfig.streamingMode();
+        delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+        millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
+    }
+
+    /**
+     * Starts the simulator and initiate streaming, depending on the working mode.
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager)
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
+        requireNonNull(blockStreamManager);
+
+        if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
+            millisPerBlockStreaming(blockStreamManager);
+        } else {
+            constantRateStreaming(blockStreamManager);
+        }
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped streaming.");
+    }
+
+    private void millisPerBlockStreaming(@NonNull BlockStreamManager blockStreamManager)
+            throws IOException, InterruptedException, BlockSimulatorParsingException {
+
+        final long secondsPerBlockNanos = (long) millisecondsPerBlock * NANOS_PER_MILLI;
+
+        Block nextBlock = blockStreamManager.getNextBlock();
+        while (nextBlock != null) {
+            long startTime = System.nanoTime();
+            publishStreamGrpcClient.streamBlock(nextBlock);
+            long elapsedTime = System.nanoTime() - startTime;
+            long timeToDelay = secondsPerBlockNanos - elapsedTime;
+            if (timeToDelay > 0) {
+                Thread.sleep(timeToDelay / NANOS_PER_MILLI, (int) (timeToDelay % NANOS_PER_MILLI));
+            } else {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "Block Server is running behind. Streaming took: "
+                                + (elapsedTime / 1_000_000)
+                                + "ms - Longer than max expected of: "
+                                + millisecondsPerBlock
+                                + " milliseconds");
+            }
+            nextBlock = blockStreamManager.getNextBlock();
+        }
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
+    }
+
+    private void constantRateStreaming(@NonNull BlockStreamManager blockStreamManager)
+            throws InterruptedException, IOException, BlockSimulatorParsingException {
+        int delayMSBetweenBlockItems = delayBetweenBlockItems / NANOS_PER_MILLI;
+        int delayNSBetweenBlockItems = delayBetweenBlockItems % NANOS_PER_MILLI;
+        boolean streamBlockItem = true;
+        int blockItemsStreamed = 0;
+
+        while (streamBlockItem) {
+            // get block
+            Block block = blockStreamManager.getNextBlock();
+
+            if (block == null) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the end of the block items");
+                break;
+            }
+
+            publishStreamGrpcClient.streamBlock(block);
+            blockItemsStreamed += block.items().size();
+
+            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
+
+            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the maximum number of block items to"
+                                + " stream");
+                streamBlockItem = false;
+            }
+        }
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+/**
+ * The {@code SimulatorModeHandler} interface defines the contract for implementing different
+ * working modes of the Block Stream Simulator. Implementations of this interface handle
+ * specific behaviors for starting the simulator and managing the streaming process,
+ * depending on the selected mode.
+ *
+ * <p>Examples of working modes include:
+ * <ul>
+ *   <li>Consumer mode: The simulator consumes data from the block stream.</li>
+ *   <li>Publisher mode: The simulator publishes data to the block stream.</li>
+ *   <li>Combined mode: The simulator handles both consuming and publishing.</li>
+ * </ul>
+ *
+ * <p>The {@code SimulatorModeHandler} is responsible for managing the simulator lifecycle,
+ * starting and stopping the streaming of blocks and handling any exceptions that may arise
+ * during the process.
+ */
+public interface SimulatorModeHandler {
+
+    /**
+     * Starts the simulator and initiates the streaming process, based on the
+     * configuration. The behavior
+     * of this method depends on the specific working mode (e.g., consumer, publisher, both).
+     *
+     * @param blockStreamManager the {@link BlockStreamManager} responsible for handling the block stream
+     * @throws BlockSimulatorParsingException if an error occurs while parsing blocks
+     * @throws IOException if an I/O error occurs during block streaming
+     * @throws InterruptedException if the thread running the simulator is interrupted
+     */
+    void start(@NonNull BlockStreamManager blockStreamManager)
+            throws BlockSimulatorParsingException, IOException, InterruptedException;
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.block.simulator.mode.PublisherModeHandler;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.output.BlockHeader;
@@ -219,7 +220,7 @@ class BlockStreamSimulatorTest {
 
     private List<LogRecord> captureLogs() {
         // Capture logs
-        Logger logger = Logger.getLogger(BlockStreamSimulatorApp.class.getName());
+        Logger logger = Logger.getLogger(PublisherModeHandler.class.getName());
         final List<LogRecord> logRecords = new ArrayList<>();
 
         // Custom handler to capture logs

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -52,6 +52,7 @@ class PublishStreamGrpcClientImplTest {
         BlockItem blockItem = BlockItem.newBuilder().build();
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
                 new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
+        publishStreamGrpcClient.init();
         boolean result = publishStreamGrpcClient.streamBlockItem(List.of(blockItem));
         assertTrue(result);
     }
@@ -65,7 +66,7 @@ class PublishStreamGrpcClientImplTest {
 
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
                 new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
-
+        publishStreamGrpcClient.init();
         boolean result = publishStreamGrpcClient.streamBlock(block);
         assertTrue(result);
 

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CombinedModeHandlerTest {
+
+    @Mock private BlockStreamConfig blockStreamConfig;
+
+    private CombinedModeHandler combinedModeHandler;
+
+    @Test
+    void testStartThrowsUnsupportedOperationException() {
+        MockitoAnnotations.openMocks(this);
+        combinedModeHandler = new CombinedModeHandler(blockStreamConfig);
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> combinedModeHandler.start(blockStreamManager));
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ConsumerModeHandlerTest {
+
+    @Mock private BlockStreamConfig blockStreamConfig;
+
+    private ConsumerModeHandler consumerModeHandler;
+
+    @Test
+    void testStartThrowsUnsupportedOperationException() {
+        MockitoAnnotations.openMocks(this);
+        consumerModeHandler = new ConsumerModeHandler(blockStreamConfig);
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> consumerModeHandler.start(blockStreamManager));
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -1,0 +1,136 @@
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class PublisherModeHandlerTest {
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
+
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+
+    @Mock
+    private BlockStreamManager blockStreamManager;
+
+    private PublisherModeHandler publisherModeHandler;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
+        // Configure blockStreamConfig
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+        BlockItem blockItem3 = mock(BlockItem.class);
+        BlockItem blockItem4 = mock(BlockItem.class);
+
+        when(block1.items()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+        when(block2.items()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithExceptionDuringStreaming() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock())
+                .thenThrow(new IOException("Test exception"));
+
+        assertThrows(IOException.class, () -> publisherModeHandler.start(blockStreamManager));
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verifyNoMoreInteractions(blockStreamManager);
+    }
+}

--- a/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
@@ -45,13 +45,13 @@ public class NegativeServerAvailabilityTests extends BaseSuite {
      * Clean up method executed after each test.
      *
      * <p>This method stops the running container, resets the container configuration by retrieving
-     * a new one through {@link BaseSuite#getConfiguration()}, and then starts the Block Node
+     * a new one through {@link BaseSuite#getContainer()} ()}, and then starts the Block Node
      * container again.
      */
     @AfterEach
     public void cleanUp() {
         blockNodeContainer.stop();
-        blockNodeContainer = getConfiguration();
+        blockNodeContainer = getContainer();
         blockNodeContainer.start();
     }
 

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -16,12 +16,95 @@
 
 package com.hedera.block.suites.persistence.positive;
 
-import com.hedera.block.suites.BaseSuite;
-import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Positive Data Persistence Tests */
+import com.hedera.block.simulator.BlockStreamSimulatorApp;
+import com.hedera.block.simulator.BlockStreamSimulatorInjectionComponent;
+import com.hedera.block.simulator.DaggerBlockStreamSimulatorInjectionComponent;
+import com.hedera.block.suites.BaseSuite;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * Test class for verifying the positive scenarios for data persistence.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
 @DisplayName("Positive Data Persistence Tests")
 public class PositiveDataPersistenceTests extends BaseSuite {
+    private final String[] GET_BLOCKS_COMMAND = new String[] {"ls", "data", "-1"};
+
+    private Thread simulatorThread;
+
     /** Default constructor for the {@link PositiveDataPersistenceTests} class. */
     public PositiveDataPersistenceTests() {}
+
+    @BeforeEach
+    void setupEnvironment() throws IOException {
+        BlockStreamSimulatorInjectionComponent DIComponent =
+                DaggerBlockStreamSimulatorInjectionComponent.factory()
+                        .create(loadSimulatorDefaultConfiguration());
+
+        blockStreamSimulatorApp = DIComponent.getBlockStreamSimulatorApp();
+        simulatorThread = setupSimulatorThread(blockStreamSimulatorApp);
+    }
+
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorThread.interrupt();
+    }
+
+    /**
+     * Verifies that block data is saved in the correct directory by comparing the count of saved
+     * blocks before and after running the simulator. The test asserts that the number of saved
+     * blocks increases after the simulator runs.
+     *
+     * @throws IOException if an I/O error occurs during execution in the container
+     * @throws InterruptedException if the thread is interrupted while sleeping or executing
+     *     commands
+     */
+    @Test
+    public void verifyBlockDataSavedInCorrectDirectory() throws InterruptedException, IOException {
+        String savedBlocksFolderBefore = getContainerCommandResult(GET_BLOCKS_COMMAND);
+        int savedBlocksCountBefore = getSavedBlocksCount(savedBlocksFolderBefore);
+
+        simulatorThread.start();
+        Thread.sleep(5000);
+        blockStreamSimulatorApp.stop();
+
+        String savedBlocksFolderAfter = getContainerCommandResult(GET_BLOCKS_COMMAND);
+        int savedBlocksCountAfter = getSavedBlocksCount(savedBlocksFolderAfter);
+
+        assertTrue(savedBlocksFolderBefore.isEmpty());
+        assertFalse(savedBlocksFolderAfter.isEmpty());
+        assertTrue(savedBlocksCountAfter > savedBlocksCountBefore);
+    }
+
+    private Thread setupSimulatorThread(BlockStreamSimulatorApp blockStreamSimulatorAppInstance) {
+        return new Thread(
+                () -> {
+                    try {
+                        blockStreamSimulatorAppInstance.start();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    private int getSavedBlocksCount(String blocksFolders) {
+        String[] blocksArray = blocksFolders.split("\\n");
+        return blocksArray.length;
+    }
+
+    private String getContainerCommandResult(String[] command)
+            throws IOException, InterruptedException {
+        Container.ExecResult result = blockNodeContainer.execInContainer(command);
+        return result.getStdout();
+    }
 }


### PR DESCRIPTION
**Description**:
WIP -> missing unit tests

This PR aims mainly to make the maintanence and using of simulator (as test driver) easier. It moves away the implementation of the working modes and exposes only abstractions. So that all concrete implementations can be refactored (if needed), without the main application, knowing or caring about it. 
Main simulator app should only be responsible for starting the processes and nothing more. Wherther the simulator will work in publisher or consumer mode, or both is not responsibility of the main class.

Also adds E2E test for data persistence.

**Related issue(s)**:

Fixes #239 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
