### PR TITLE
feat: Move out concrete working implementation and add working modes

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -47,7 +47,7 @@ public class BlockStreamSimulator {
     public static void main(final String[] args)
             throws IOException, InterruptedException, BlockSimulatorParsingException {
 
-        LOGGER.log(INFO, "Starting Block Stream Simulator");
+        LOGGER.log(INFO, "Starting Block Stream Simulator!");
 
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSource(SystemEnvironmentConfigSource.getInstance())

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -61,8 +61,7 @@ public class BlockStreamSimulatorApp {
         SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
         switch (simulatorMode) {
             case PUBLISHER:
-                simulatorModeHandler =
-                        new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+                simulatorModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
                 break;
             case CONSUMER:
                 simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig);
@@ -83,9 +82,7 @@ public class BlockStreamSimulatorApp {
      * @throws IOException if an I/O error occurs
      */
     public void start() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        LOGGER.log(
-                System.Logger.Level.INFO,
-                "Block Stream Simulator started initializing components...");
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator started initializing components...");
         publishStreamGrpcClient.init();
         isRunning.set(true);
 

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -17,11 +17,14 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
-import com.hedera.hapi.block.stream.Block;
+import com.hedera.block.simulator.mode.CombinedModeHandler;
+import com.hedera.block.simulator.mode.ConsumerModeHandler;
+import com.hedera.block.simulator.mode.PublisherModeHandler;
+import com.hedera.block.simulator.mode.SimulatorModeHandler;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -37,10 +40,7 @@ public class BlockStreamSimulatorApp {
     private final BlockStreamManager blockStreamManager;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final BlockStreamConfig blockStreamConfig;
-    private final StreamingMode streamingMode;
-
-    private final int delayBetweenBlockItems;
-    private final int millisecondsPerBlock;
+    private final SimulatorModeHandler simulatorModeHandler;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
     /**
@@ -60,9 +60,15 @@ public class BlockStreamSimulatorApp {
 
         blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
 
-        streamingMode = blockStreamConfig.streamingMode();
-        millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
-        delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+        SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
+        if (simulatorMode == SimulatorMode.PUBLISHER) {
+            simulatorModeHandler =
+                    new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+        } else if (simulatorMode == SimulatorMode.CONSUMER) {
+            simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig);
+        } else {
+            simulatorModeHandler = new CombinedModeHandler(blockStreamConfig);
+        }
     }
 
     /**
@@ -73,77 +79,13 @@ public class BlockStreamSimulatorApp {
      * @throws IOException if an I/O error occurs
      */
     public void start() throws InterruptedException, BlockSimulatorParsingException, IOException {
-
+        LOGGER.log(
+                System.Logger.Level.INFO,
+                "Block Stream Simulator started initializing components...");
+        publishStreamGrpcClient.init();
         isRunning.set(true);
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has started");
 
-        if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
-            millisPerBlockStreaming();
-        } else {
-            constantRateStreaming();
-        }
-
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
-    }
-
-    private void millisPerBlockStreaming()
-            throws IOException, InterruptedException, BlockSimulatorParsingException {
-
-        final long secondsPerBlockNanos = millisecondsPerBlock * 1_000_000L;
-
-        Block nextBlock = blockStreamManager.getNextBlock();
-        while (nextBlock != null) {
-            long startTime = System.nanoTime();
-            publishStreamGrpcClient.streamBlock(nextBlock);
-            long elapsedTime = System.nanoTime() - startTime;
-            long timeToDelay = secondsPerBlockNanos - elapsedTime;
-            if (timeToDelay > 0) {
-                Thread.sleep(timeToDelay / 1_000_000, (int) (timeToDelay % 1_000_000));
-            } else {
-                LOGGER.log(
-                        System.Logger.Level.WARNING,
-                        "Block Server is running behind. Streaming took: "
-                                + (elapsedTime / 1_000_000)
-                                + "ms - Longer than max expected of: "
-                                + millisecondsPerBlock
-                                + " milliseconds");
-            }
-            nextBlock = blockStreamManager.getNextBlock();
-        }
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
-    }
-
-    private void constantRateStreaming()
-            throws InterruptedException, IOException, BlockSimulatorParsingException {
-        int delayMSBetweenBlockItems = delayBetweenBlockItems / 1_000_000;
-        int delayNSBetweenBlockItems = delayBetweenBlockItems % 1_000_000;
-        boolean streamBlockItem = true;
-        int blockItemsStreamed = 0;
-
-        while (streamBlockItem) {
-            // get block
-            Block block = blockStreamManager.getNextBlock();
-
-            if (block == null) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the end of the block items");
-                break;
-            }
-
-            publishStreamGrpcClient.streamBlock(block);
-            blockItemsStreamed += block.items().size();
-
-            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
-
-            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the maximum number of block items to"
-                                + " stream");
-                streamBlockItem = false;
-            }
-        }
+        simulatorModeHandler.start(this.blockStreamManager);
     }
 
     /**
@@ -155,8 +97,9 @@ public class BlockStreamSimulatorApp {
         return isRunning.get();
     }
 
-    /** Stops the block stream simulator. */
+    /** Stops the Block Stream Simulator and closes off all grpc channels. */
     public void stop() {
+        publishStreamGrpcClient.shutdown();
         isRunning.set(false);
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -34,9 +34,7 @@ import javax.inject.Inject;
 /** BlockStream Simulator App */
 public class BlockStreamSimulatorApp {
 
-    private static final System.Logger LOGGER =
-            System.getLogger(BlockStreamSimulatorApp.class.getName());
-
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
     private final BlockStreamManager blockStreamManager;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final BlockStreamConfig blockStreamConfig;
@@ -61,13 +59,19 @@ public class BlockStreamSimulatorApp {
         blockStreamConfig = configuration.getConfigData(BlockStreamConfig.class);
 
         SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
-        if (simulatorMode == SimulatorMode.PUBLISHER) {
-            simulatorModeHandler =
-                    new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
-        } else if (simulatorMode == SimulatorMode.CONSUMER) {
-            simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig);
-        } else {
-            simulatorModeHandler = new CombinedModeHandler(blockStreamConfig);
+        switch (simulatorMode) {
+            case PUBLISHER:
+                simulatorModeHandler =
+                        new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+                break;
+            case CONSUMER:
+                simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig);
+                break;
+            case BOTH:
+                simulatorModeHandler = new CombinedModeHandler(blockStreamConfig);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown SimulatorMode: " + simulatorMode);
         }
     }
 

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -37,9 +37,7 @@ import javax.inject.Inject;
 public class BlockStreamSimulatorApp {
 
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
-    private final BlockStreamManager blockStreamManager;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
-    private final BlockStreamConfig blockStreamConfig;
     private final SimulatorModeHandler simulatorModeHandler;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
 
@@ -55,12 +53,13 @@ public class BlockStreamSimulatorApp {
             @NonNull Configuration configuration,
             @NonNull BlockStreamManager blockStreamManager,
             @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {
-        this.blockStreamManager = requireNonNull(blockStreamManager);
+        requireNonNull(blockStreamManager);
+
         this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
+        final BlockStreamConfig blockStreamConfig =
+                requireNonNull(configuration.getConfigData(BlockStreamConfig.class));
 
-        blockStreamConfig = requireNonNull(configuration.getConfigData(BlockStreamConfig.class));
-
-        SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
+        final SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
         switch (simulatorMode) {
             case PUBLISHER -> simulatorModeHandler =
                     new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient, blockStreamManager);

--- a/simulator/src/main/java/com/hedera/block/simulator/Constants.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/Constants.java
@@ -24,10 +24,11 @@ public final class Constants {
     /** postfix for gzip files */
     public static final String GZ_EXTENSION = ".gz";
 
-    /** Constructor to prevent instantiation. this is only a utility class */
-    private Constants() {}
     /**
      * Used for converting nanoseconds to milliseconds and vice versa
      */
     public static final int NANOS_PER_MILLI = 1_000_000;
+
+    /** Constructor to prevent instantiation. this is only a utility class */
+    private Constants() {}
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/Constants.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/Constants.java
@@ -26,4 +26,8 @@ public final class Constants {
 
     /** Constructor to prevent instantiation. this is only a utility class */
     private Constants() {}
+    /**
+     * Used for converting nanoseconds to milliseconds and vice versa
+     */
+    public static final int NANOS_PER_MILLI = 1_000_000;
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -73,7 +73,7 @@ public record BlockStreamConfig(
          * @param simulatorMode the {@link SimulatorMode} to use
          * @return this {@code Builder} instance
          */
-        public Builder streamingMode(SimulatorMode simulatorMode) {
+        public Builder simulatorMode(SimulatorMode simulatorMode) {
             this.simulatorMode = simulatorMode;
             return this;
         }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.config.data;
 
+import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.config.types.StreamingMode;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
@@ -23,6 +24,7 @@ import com.swirlds.config.api.ConfigProperty;
 /**
  * Defines the configuration data for the block stream in the Hedera Block Simulator.
  *
+ * @param simulatorMode the mode of the simulator, in terms of publishing, consuming or both
  * @param delayBetweenBlockItems the delay in microseconds between streaming each block item
  * @param maxBlockItemsToStream the maximum number of block items to stream before stopping
  * @param streamingMode the mode of streaming for the block stream (e.g., time-based, count-based)
@@ -31,6 +33,7 @@ import com.swirlds.config.api.ConfigProperty;
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
+        @ConfigProperty(defaultValue = "PUBLISHER") SimulatorMode simulatorMode,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
@@ -50,6 +53,7 @@ public record BlockStreamConfig(
      * A builder for creating instances of {@link BlockStreamConfig}.
      */
     public static class Builder {
+        private SimulatorMode simulatorMode = SimulatorMode.PUBLISHER;
         private int delayBetweenBlockItems = 1_500_000;
         private int maxBlockItemsToStream = 10_000;
         private StreamingMode streamingMode = StreamingMode.MILLIS_PER_BLOCK;
@@ -61,6 +65,17 @@ public record BlockStreamConfig(
          */
         public Builder() {
             // Default constructor
+        }
+
+        /**
+         * Sets the simulator mode for the block stream.
+         *
+         * @param simulatorMode the {@link SimulatorMode} to use
+         * @return this {@code Builder} instance
+         */
+        public Builder streamingMode(SimulatorMode simulatorMode) {
+            this.simulatorMode = simulatorMode;
+            return this;
         }
 
         /**
@@ -125,6 +140,7 @@ public record BlockStreamConfig(
          */
         public BlockStreamConfig build() {
             return new BlockStreamConfig(
+                    simulatorMode,
                     delayBetweenBlockItems,
                     maxBlockItemsToStream,
                     streamingMode,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.types;
+
+/** The SimulatorMode enum defines the work modes of the block stream simulator. */
+public enum SimulatorMode {
+    /**
+     * Indicates a work mode in which the simulator is working as both consumer and publisher.
+     */
+    BOTH,
+    /**
+     * Indicates a work mode in which the simulator is working in consumer mode.
+     */
+    CONSUMER,
+    /**
+     * Indicates a work mode in which the simulator is working in publisher mode.
+     */
+    PUBLISHER
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -25,6 +25,11 @@ import java.util.List;
  */
 public interface PublishStreamGrpcClient {
     /**
+     * Initialize, opens a gRPC channel and creates the needed stubs with the passed configuration.
+     */
+    void init();
+
+    /**
      * Streams the block item.
      *
      * @param blockItems list of the block item to be streamed
@@ -39,4 +44,9 @@ public interface PublishStreamGrpcClient {
      * @return true if the block is streamed successfully, false otherwise
      */
     boolean streamBlock(Block block);
+
+    /**
+     * Shutdowns the channel.
+     */
+    void shutdown();
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -16,6 +16,8 @@
 
 package com.hedera.block.simulator.grpc;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.block.common.utils.ChunkUtils;
 import com.hedera.block.simulator.Translator;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
@@ -49,9 +51,10 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      * @param blockStreamConfig the block stream configuration
      */
     @Inject
-    public PublishStreamGrpcClientImpl(@NonNull GrpcConfig grpcConfig, @NonNull BlockStreamConfig blockStreamConfig) {
-        this.grpcConfig = grpcConfig;
-        this.blockStreamConfig = blockStreamConfig;
+    public PublishStreamGrpcClientImpl(
+            @NonNull final GrpcConfig grpcConfig, @NonNull final BlockStreamConfig blockStreamConfig) {
+        this.grpcConfig = requireNonNull(grpcConfig);
+        this.blockStreamConfig = requireNonNull(blockStreamConfig);
     }
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -54,7 +54,6 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
             @NonNull GrpcConfig grpcConfig, @NonNull BlockStreamConfig blockStreamConfig) {
         this.grpcConfig = grpcConfig;
         this.blockStreamConfig = blockStreamConfig;
-
     }
 
     /**
@@ -62,7 +61,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      */
     @Override
     public void init() {
-         channel =
+        channel =
                 ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
                         .usePlaintext()
                         .build();

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -37,7 +37,6 @@ import javax.inject.Inject;
  */
 public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
-    private BlockStreamServiceGrpc.BlockStreamServiceStub stub;
     private StreamObserver<PublishStreamRequest> requestStreamObserver;
     private final BlockStreamConfig blockStreamConfig;
     private final GrpcConfig grpcConfig;
@@ -65,7 +64,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
                         .usePlaintext()
                         .build();
-        stub = BlockStreamServiceGrpc.newStub(channel);
+        BlockStreamServiceGrpc.BlockStreamServiceStub stub =
+                BlockStreamServiceGrpc.newStub(channel);
         PublishStreamObserver publishStreamObserver = new PublishStreamObserver();
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -49,8 +49,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      * @param blockStreamConfig the block stream configuration
      */
     @Inject
-    public PublishStreamGrpcClientImpl(
-            @NonNull GrpcConfig grpcConfig, @NonNull BlockStreamConfig blockStreamConfig) {
+    public PublishStreamGrpcClientImpl(@NonNull GrpcConfig grpcConfig, @NonNull BlockStreamConfig blockStreamConfig) {
         this.grpcConfig = grpcConfig;
         this.blockStreamConfig = blockStreamConfig;
     }
@@ -60,12 +59,10 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      */
     @Override
     public void init() {
-        channel =
-                ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
-                        .usePlaintext()
-                        .build();
-        BlockStreamServiceGrpc.BlockStreamServiceStub stub =
-                BlockStreamServiceGrpc.newStub(channel);
+        channel = ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
+                .usePlaintext()
+                .build();
+        BlockStreamServiceGrpc.BlockStreamServiceStub stub = BlockStreamServiceGrpc.newStub(channel);
         PublishStreamObserver publishStreamObserver = new PublishStreamObserver();
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
     }
@@ -82,8 +79,9 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
             blockItemsProtoc.add(Translator.fromPbj(blockItem));
         }
 
-        requestStreamObserver.onNext(
-                PublishStreamRequest.newBuilder().addAllBlockItems(blockItemsProtoc).build());
+        requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
+                .addAllBlockItems(blockItemsProtoc)
+                .build());
 
         return true;
     }
@@ -101,10 +99,10 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
         List<List<com.hedera.hapi.block.stream.protoc.BlockItem>> streamingBatches =
                 ChunkUtils.chunkify(blockItemsProtoc, blockStreamConfig.blockItemsBatchSize());
-        for (List<com.hedera.hapi.block.stream.protoc.BlockItem> streamingBatch :
-                streamingBatches) {
-            requestStreamObserver.onNext(
-                    PublishStreamRequest.newBuilder().addAllBlockItems(streamingBatch).build());
+        for (List<com.hedera.hapi.block.stream.protoc.BlockItem> streamingBatch : streamingBatches) {
+            requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
+                    .addAllBlockItems(streamingBatch)
+                    .build());
         }
 
         return true;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -19,7 +19,6 @@ package com.hedera.block.simulator.mode;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.generator.BlockStreamManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -43,8 +42,7 @@ public class CombinedModeHandler implements SimulatorModeHandler {
      * @param blockStreamConfig the configuration data for managing block streams
      */
     public CombinedModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
-        requireNonNull(blockStreamConfig);
-        this.blockStreamConfig = blockStreamConfig;
+        this.blockStreamConfig = requireNonNull(blockStreamConfig);
     }
 
     /**
@@ -52,11 +50,10 @@ public class CombinedModeHandler implements SimulatorModeHandler {
      * of block stream. However, this method is currently not implemented, and will throw
      * an {@link UnsupportedOperationException}.
      *
-     * @param blockStreamManager the {@link BlockStreamManager} responsible for managing block streams
      * @throws UnsupportedOperationException as the method is not yet implemented
      */
     @Override
-    public void start(@NonNull BlockStreamManager blockStreamManager) {
+    public void start() {
         throw new UnsupportedOperationException();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The {@code CombinedModeHandler} class implements the {@link SimulatorModeHandler} interface
+ * and provides the behavior for a mode where both consuming and publishing of block data
+ * occur simultaneously.
+ *
+ * <p>This mode handles dual operations in the block streaming process, utilizing the
+ * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
+ * the simulator needs to handle both the consumption and publication of blocks in parallel.
+ *
+ * <p>For now, the actual start behavior is not implemented, as indicated by the
+ * {@link UnsupportedOperationException}.
+ */
+public class CombinedModeHandler implements SimulatorModeHandler {
+    private final BlockStreamConfig blockStreamConfig;
+
+    /**
+     * Constructs a new {@code CombinedModeHandler} with the specified block stream configuration.
+     *
+     * @param blockStreamConfig the configuration data for managing block streams
+     */
+    public CombinedModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
+        requireNonNull(blockStreamConfig);
+        this.blockStreamConfig = blockStreamConfig;
+    }
+
+    /**
+     * Starts the simulator in combined mode, handling both consumption and publication
+     * of block stream. However, this method is currently not implemented, and will throw
+     * an {@link UnsupportedOperationException}.
+     *
+     * @param blockStreamManager the {@link BlockStreamManager} responsible for managing block streams
+     * @throws UnsupportedOperationException as the method is not yet implemented
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -19,7 +19,6 @@ package com.hedera.block.simulator.mode;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.generator.BlockStreamManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -44,15 +43,14 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
      * @param blockStreamConfig the configuration data for managing block streams
      */
     public ConsumerModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
-        requireNonNull(blockStreamConfig);
-        this.blockStreamConfig = blockStreamConfig;
+        this.blockStreamConfig = requireNonNull(blockStreamConfig);
     }
 
     /**
      * Starts the simulator and initiate streaming, depending on the working mode.
      */
     @Override
-    public void start(@NonNull BlockStreamManager blockStreamManager) {
+    public void start() {
         throw new UnsupportedOperationException();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The {@code ConsumerModeHandler} class implements the {@link SimulatorModeHandler} interface
+ * and provides the behavior for a mode where only consumption of block data
+ * occurs.
+ *
+ * <p>This mode handles dual operations in the block streaming process, utilizing the
+ * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
+ * the simulator needs to handle both the consumption and publication of blocks in parallel.
+ *
+ * <p>For now, the actual start behavior is not implemented, as indicated by the
+ * {@link UnsupportedOperationException}.
+ */
+public class ConsumerModeHandler implements SimulatorModeHandler {
+
+    private final BlockStreamConfig blockStreamConfig;
+
+    /**
+     * Constructs a new {@code ConsumerModeHandler} with the specified block stream configuration.
+     *
+     * @param blockStreamConfig the configuration data for managing block streams
+     */
+    public ConsumerModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
+        requireNonNull(blockStreamConfig);
+        this.blockStreamConfig = blockStreamConfig;
+    }
+
+    /**
+     * Starts the simulator and initiate streaming, depending on the working mode.
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -27,9 +27,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * and provides the behavior for a mode where only consumption of block data
  * occurs.
  *
- * <p>This mode handles dual operations in the block streaming process, utilizing the
+ * <p>This mode handles single operation in the block streaming process, utilizing the
  * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
- * the simulator needs to handle both the consumption and publication of blocks in parallel.
+ * the simulator needs to handle the consumption of blocks.
  *
  * <p>For now, the actual start behavior is not implemented, as indicated by the
  * {@link UnsupportedOperationException}.

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -27,6 +27,15 @@ import com.hedera.hapi.block.stream.Block;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
+/**
+ * The {@code PublisherModeHandler} class implements the {@link SimulatorModeHandler} interface
+ * and provides the behavior for a mode where only publishing of block data
+ * occurs.
+ *
+ * <p>This mode handles single operation in the block streaming process, utilizing the
+ * {@link BlockStreamConfig} for configuration settings. It is designed for scenarios where
+ * the simulator needs to handle publication of blocks.
+ */
 public class PublisherModeHandler implements SimulatorModeHandler {
     private static final System.Logger LOGGER =
             System.getLogger(PublisherModeHandler.class.getName());
@@ -38,6 +47,11 @@ public class PublisherModeHandler implements SimulatorModeHandler {
     private final int millisecondsPerBlock;
     private final int NANOS_PER_MILLI = 1_000_000;
 
+    /**
+     * Constructs a new {@code PublisherModeHandler} with the specified block stream configuration and publisher client.
+     *
+     * @param blockStreamConfig the configuration data for managing block streams
+     */
     public PublisherModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,
             @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -39,6 +39,7 @@ import java.io.IOException;
  */
 public class PublisherModeHandler implements SimulatorModeHandler {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
+    private final BlockStreamManager blockStreamManager;
     private final BlockStreamConfig blockStreamConfig;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final StreamingMode streamingMode;
@@ -53,11 +54,11 @@ public class PublisherModeHandler implements SimulatorModeHandler {
      */
     public PublisherModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,
-            @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {
-        requireNonNull(blockStreamConfig);
-        requireNonNull(publishStreamGrpcClient);
-        this.blockStreamConfig = blockStreamConfig;
-        this.publishStreamGrpcClient = publishStreamGrpcClient;
+            @NonNull final PublishStreamGrpcClient publishStreamGrpcClient,
+            @NonNull final BlockStreamManager blockStreamManager) {
+        this.blockStreamConfig = requireNonNull(blockStreamConfig);
+        this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
+        this.blockStreamManager = requireNonNull(blockStreamManager);
 
         streamingMode = blockStreamConfig.streamingMode();
         delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
@@ -68,20 +69,16 @@ public class PublisherModeHandler implements SimulatorModeHandler {
      * Starts the simulator and initiate streaming, depending on the working mode.
      */
     @Override
-    public void start(@NonNull BlockStreamManager blockStreamManager)
-            throws BlockSimulatorParsingException, IOException, InterruptedException {
-        requireNonNull(blockStreamManager);
-
+    public void start() throws BlockSimulatorParsingException, IOException, InterruptedException {
         if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
-            millisPerBlockStreaming(blockStreamManager);
+            millisPerBlockStreaming();
         } else {
-            constantRateStreaming(blockStreamManager);
+            constantRateStreaming();
         }
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped streaming.");
     }
 
-    private void millisPerBlockStreaming(@NonNull BlockStreamManager blockStreamManager)
-            throws IOException, InterruptedException, BlockSimulatorParsingException {
+    private void millisPerBlockStreaming() throws IOException, InterruptedException, BlockSimulatorParsingException {
 
         final long secondsPerBlockNanos = (long) millisecondsPerBlock * NANOS_PER_MILLI;
 
@@ -107,8 +104,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
         LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
     }
 
-    private void constantRateStreaming(@NonNull BlockStreamManager blockStreamManager)
-            throws InterruptedException, IOException, BlockSimulatorParsingException {
+    private void constantRateStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
         int delayMSBetweenBlockItems = delayBetweenBlockItems / NANOS_PER_MILLI;
         int delayNSBetweenBlockItems = delayBetweenBlockItems % NANOS_PER_MILLI;
         boolean streamBlockItem = true;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.hapi.block.stream.Block;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+public class PublisherModeHandler implements SimulatorModeHandler {
+    private static final System.Logger LOGGER =
+            System.getLogger(PublisherModeHandler.class.getName());
+
+    private final BlockStreamConfig blockStreamConfig;
+    private final PublishStreamGrpcClient publishStreamGrpcClient;
+    private final StreamingMode streamingMode;
+    private final int delayBetweenBlockItems;
+    private final int millisecondsPerBlock;
+    private final int NANOS_PER_MILLI = 1_000_000;
+
+    public PublisherModeHandler(
+            @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {
+        requireNonNull(blockStreamConfig);
+        requireNonNull(publishStreamGrpcClient);
+        this.blockStreamConfig = blockStreamConfig;
+        this.publishStreamGrpcClient = publishStreamGrpcClient;
+
+        streamingMode = blockStreamConfig.streamingMode();
+        delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
+        millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
+    }
+
+    /**
+     * Starts the simulator and initiate streaming, depending on the working mode.
+     */
+    @Override
+    public void start(@NonNull BlockStreamManager blockStreamManager)
+            throws BlockSimulatorParsingException, IOException, InterruptedException {
+        requireNonNull(blockStreamManager);
+
+        if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
+            millisPerBlockStreaming(blockStreamManager);
+        } else {
+            constantRateStreaming(blockStreamManager);
+        }
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped streaming.");
+    }
+
+    private void millisPerBlockStreaming(@NonNull BlockStreamManager blockStreamManager)
+            throws IOException, InterruptedException, BlockSimulatorParsingException {
+
+        final long secondsPerBlockNanos = (long) millisecondsPerBlock * NANOS_PER_MILLI;
+
+        Block nextBlock = blockStreamManager.getNextBlock();
+        while (nextBlock != null) {
+            long startTime = System.nanoTime();
+            publishStreamGrpcClient.streamBlock(nextBlock);
+            long elapsedTime = System.nanoTime() - startTime;
+            long timeToDelay = secondsPerBlockNanos - elapsedTime;
+            if (timeToDelay > 0) {
+                Thread.sleep(timeToDelay / NANOS_PER_MILLI, (int) (timeToDelay % NANOS_PER_MILLI));
+            } else {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "Block Server is running behind. Streaming took: "
+                                + (elapsedTime / 1_000_000)
+                                + "ms - Longer than max expected of: "
+                                + millisecondsPerBlock
+                                + " milliseconds");
+            }
+            nextBlock = blockStreamManager.getNextBlock();
+        }
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
+    }
+
+    private void constantRateStreaming(@NonNull BlockStreamManager blockStreamManager)
+            throws InterruptedException, IOException, BlockSimulatorParsingException {
+        int delayMSBetweenBlockItems = delayBetweenBlockItems / NANOS_PER_MILLI;
+        int delayNSBetweenBlockItems = delayBetweenBlockItems % NANOS_PER_MILLI;
+        boolean streamBlockItem = true;
+        int blockItemsStreamed = 0;
+
+        while (streamBlockItem) {
+            // get block
+            Block block = blockStreamManager.getNextBlock();
+
+            if (block == null) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the end of the block items");
+                break;
+            }
+
+            publishStreamGrpcClient.streamBlock(block);
+            blockItemsStreamed += block.items().size();
+
+            Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);
+
+            if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
+                LOGGER.log(
+                        System.Logger.Level.INFO,
+                        "Block Stream Simulator has reached the maximum number of block items to"
+                                + " stream");
+                streamBlockItem = false;
+            }
+        }
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -51,6 +51,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
      *
      * @param blockStreamConfig the configuration data for managing block streams
      * @param publishStreamGrpcClient the grpc client used for streaming blocks
+     * @param blockStreamManager the block stream manager, responsible for generating blocks
      */
     public PublisherModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -119,9 +119,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
             Block block = blockStreamManager.getNextBlock();
 
             if (block == null) {
-                LOGGER.log(
-                        System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the end of the block items");
+                LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has reached the end of the block items");
                 break;
             }
 
@@ -133,8 +131,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
             if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
                 LOGGER.log(
                         System.Logger.Level.INFO,
-                        "Block Stream Simulator has reached the maximum number of block items to"
-                                + " stream");
+                        "Block Stream Simulator has reached the maximum number of block items to" + " stream");
                 streamBlockItem = false;
             }
         }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.mode;
 
+import static com.hedera.block.simulator.Constants.NANOS_PER_MILLI;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
@@ -37,20 +38,18 @@ import java.io.IOException;
  * the simulator needs to handle publication of blocks.
  */
 public class PublisherModeHandler implements SimulatorModeHandler {
-    private static final System.Logger LOGGER =
-            System.getLogger(PublisherModeHandler.class.getName());
-
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
     private final BlockStreamConfig blockStreamConfig;
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final StreamingMode streamingMode;
     private final int delayBetweenBlockItems;
     private final int millisecondsPerBlock;
-    private final int NANOS_PER_MILLI = 1_000_000;
 
     /**
      * Constructs a new {@code PublisherModeHandler} with the specified block stream configuration and publisher client.
      *
      * @param blockStreamConfig the configuration data for managing block streams
+     * @param publishStreamGrpcClient the grpc client used for streaming blocks
      */
     public PublisherModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -17,8 +17,6 @@
 package com.hedera.block.simulator.mode;
 
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
-import com.hedera.block.simulator.generator.BlockStreamManager;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 
 /**
@@ -45,11 +43,9 @@ public interface SimulatorModeHandler {
      * configuration. The behavior
      * of this method depends on the specific working mode (e.g., consumer, publisher, both).
      *
-     * @param blockStreamManager the {@link BlockStreamManager} responsible for handling the block stream
      * @throws BlockSimulatorParsingException if an error occurs while parsing blocks
      * @throws IOException if an I/O error occurs during block streaming
      * @throws InterruptedException if the thread running the simulator is interrupted
      */
-    void start(@NonNull BlockStreamManager blockStreamManager)
-            throws BlockSimulatorParsingException, IOException, InterruptedException;
+    void start() throws BlockSimulatorParsingException, IOException, InterruptedException;
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+/**
+ * The {@code SimulatorModeHandler} interface defines the contract for implementing different
+ * working modes of the Block Stream Simulator. Implementations of this interface handle
+ * specific behaviors for starting the simulator and managing the streaming process,
+ * depending on the selected mode.
+ *
+ * <p>Examples of working modes include:
+ * <ul>
+ *   <li>Consumer mode: The simulator consumes data from the block stream.</li>
+ *   <li>Publisher mode: The simulator publishes data to the block stream.</li>
+ *   <li>Combined mode: The simulator handles both consuming and publishing.</li>
+ * </ul>
+ *
+ * <p>The {@code SimulatorModeHandler} is responsible for managing the simulator lifecycle,
+ * starting and stopping the streaming of blocks and handling any exceptions that may arise
+ * during the process.
+ */
+public interface SimulatorModeHandler {
+
+    /**
+     * Starts the simulator and initiates the streaming process, based on the
+     * configuration. The behavior
+     * of this method depends on the specific working mode (e.g., consumer, publisher, both).
+     *
+     * @param blockStreamManager the {@link BlockStreamManager} responsible for handling the block stream
+     * @throws BlockSimulatorParsingException if an error occurs while parsing blocks
+     * @throws IOException if an I/O error occurs during block streaming
+     * @throws InterruptedException if the thread running the simulator is interrupted
+     */
+    void start(@NonNull BlockStreamManager blockStreamManager)
+            throws BlockSimulatorParsingException, IOException, InterruptedException;
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -17,6 +17,8 @@
 package com.hedera.block.simulator;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -126,6 +128,7 @@ class BlockStreamSimulatorTest {
     @Test
     void stop_doesNotThrowException() {
         assertDoesNotThrow(() -> blockStreamSimulator.stop());
+        assertFalse(blockStreamSimulator.isRunning());
     }
 
     @Test
@@ -216,6 +219,26 @@ class BlockStreamSimulatorTest {
                                                 .getMessage()
                                                 .contains("Block Server is running behind"));
         assertTrue(found_log);
+    }
+
+    @Test
+    void start_withBothMode_throwsUnsupportedOperationException() throws Exception {
+        Configuration configuration =
+                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "BOTH"));
+        blockStreamSimulator =
+                new BlockStreamSimulatorApp(
+                        configuration, blockStreamManager, publishStreamGrpcClient);
+        assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
+    }
+
+    @Test
+    void start_withConsumerMode_throwsUnsupportedOperationException() throws Exception {
+        Configuration configuration =
+                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+        blockStreamSimulator =
+                new BlockStreamSimulatorApp(
+                        configuration, blockStreamManager, publishStreamGrpcClient);
+        assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
     }
 
     private List<LogRecord> captureLogs() {

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -51,26 +51,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BlockStreamSimulatorTest {
 
-    @Mock private BlockStreamManager blockStreamManager;
+    @Mock
+    private BlockStreamManager blockStreamManager;
 
-    @Mock private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
 
     private BlockStreamSimulatorApp blockStreamSimulator;
 
     @BeforeEach
     void setUp() throws IOException {
 
-        Configuration configuration =
-                TestUtils.getTestConfiguration(
-                        Map.of(
-                                "blockStream.maxBlockItemsToStream",
-                                "100",
-                                "blockStream.streamingMode",
-                                "CONSTANT_RATE"));
+        Configuration configuration = TestUtils.getTestConfiguration(
+                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
 
-        blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+        blockStreamSimulator = new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
     }
 
     @AfterEach
@@ -79,20 +74,17 @@ class BlockStreamSimulatorTest {
     }
 
     @Test
-    void start_logsStartedMessage()
-            throws InterruptedException, BlockSimulatorParsingException, IOException {
+    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
     }
 
     @Test
-    void start_constantRateStreaming()
-            throws InterruptedException, BlockSimulatorParsingException, IOException {
+    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
 
-        BlockItem blockItem =
-                BlockItem.newBuilder()
-                        .blockHeader(BlockHeader.newBuilder().number(1L).build())
-                        .build();
+        BlockItem blockItem = BlockItem.newBuilder()
+                .blockHeader(BlockHeader.newBuilder().number(1L).build())
+                .build();
 
         Block block1 = Block.newBuilder().items(blockItem).build();
         Block block2 = Block.newBuilder().items(blockItem, blockItem, blockItem).build();
@@ -100,23 +92,20 @@ class BlockStreamSimulatorTest {
         BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
         when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
 
-        Configuration configuration =
-                TestUtils.getTestConfiguration(
-                        Map.of(
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.streamingMode",
-                                "CONSTANT_RATE",
-                                "blockStream.blockItemsBatchSize",
-                                "2"));
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "CONSTANT_RATE",
+                "blockStream.blockItemsBatchSize",
+                "2"));
 
         BlockStreamSimulatorApp blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+                new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
 
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
@@ -133,31 +122,26 @@ class BlockStreamSimulatorTest {
     }
 
     @Test
-    void start_millisPerBlockStreaming()
-            throws InterruptedException, IOException, BlockSimulatorParsingException {
+    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
         BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-        BlockItem blockItem =
-                BlockItem.newBuilder()
-                        .blockHeader(BlockHeader.newBuilder().number(1L).build())
-                        .build();
+        BlockItem blockItem = BlockItem.newBuilder()
+                .blockHeader(BlockHeader.newBuilder().number(1L).build())
+                .build();
         Block block = Block.newBuilder().items(blockItem).build();
         when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
 
-        Configuration configuration =
-                TestUtils.getTestConfiguration(
-                        Map.of(
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.streamingMode",
-                                "MILLIS_PER_BLOCK"));
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK"));
 
         BlockStreamSimulatorApp blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+                new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
 
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
@@ -169,10 +153,9 @@ class BlockStreamSimulatorTest {
         List<LogRecord> logRecords = captureLogs();
 
         BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-        BlockItem blockItem =
-                BlockItem.newBuilder()
-                        .blockHeader(BlockHeader.newBuilder().number(1L).build())
-                        .build();
+        BlockItem blockItem = BlockItem.newBuilder()
+                .blockHeader(BlockHeader.newBuilder().number(1L).build())
+                .build();
         Block block = Block.newBuilder().items(blockItem).build();
         when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
         PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
@@ -180,64 +163,49 @@ class BlockStreamSimulatorTest {
         // simulate that the first block takes 15ms to stream, when the limit is 10, to force to go
         // over WARN Path.
         when(publishStreamGrpcClient.streamBlock(any()))
-                .thenAnswer(
-                        invocation -> {
-                            Thread.sleep(15);
-                            return true;
-                        })
+                .thenAnswer(invocation -> {
+                    Thread.sleep(15);
+                    return true;
+                })
                 .thenReturn(true);
 
-        Configuration configuration =
-                TestUtils.getTestConfiguration(
-                        Map.of(
-                                "generator.managerImplementation",
-                                "BlockAsFileBlockStreamManager",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "blockStream.streamingMode",
-                                "MILLIS_PER_BLOCK",
-                                "blockStream.millisecondsPerBlock",
-                                "10",
-                                "blockStream.blockItemsBatchSize",
-                                "1"));
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "generator.managerImplementation",
+                "BlockAsFileBlockStreamManager",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK",
+                "blockStream.millisecondsPerBlock",
+                "10",
+                "blockStream.blockItemsBatchSize",
+                "1"));
 
         BlockStreamSimulatorApp blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+                new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
 
         blockStreamSimulator.start();
         assertTrue(blockStreamSimulator.isRunning());
 
         // Assert log exists
-        boolean found_log =
-                logRecords.stream()
-                        .anyMatch(
-                                logRecord ->
-                                        logRecord
-                                                .getMessage()
-                                                .contains("Block Server is running behind"));
+        boolean found_log = logRecords.stream()
+                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
         assertTrue(found_log);
     }
 
     @Test
     void start_withBothMode_throwsUnsupportedOperationException() throws Exception {
-        Configuration configuration =
-                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "BOTH"));
-        blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "BOTH"));
+        blockStreamSimulator = new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
         assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
     }
 
     @Test
     void start_withConsumerMode_throwsUnsupportedOperationException() throws Exception {
-        Configuration configuration =
-                TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
-        blockStreamSimulator =
-                new BlockStreamSimulatorApp(
-                        configuration, blockStreamManager, publishStreamGrpcClient);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+        blockStreamSimulator = new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
         assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
     }
 
@@ -249,12 +217,9 @@ class BlockStreamSimulatorTest {
         when(configuration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
         when(blockStreamConfig.simulatorMode()).thenReturn(null);
 
-        assertThrows(
-                NullPointerException.class,
-                () -> {
-                    new BlockStreamSimulatorApp(
-                            configuration, blockStreamManager, publishStreamGrpcClient);
-                });
+        assertThrows(NullPointerException.class, () -> {
+            new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient);
+        });
     }
 
     private List<LogRecord> captureLogs() {
@@ -263,19 +228,18 @@ class BlockStreamSimulatorTest {
         final List<LogRecord> logRecords = new ArrayList<>();
 
         // Custom handler to capture logs
-        Handler handler =
-                new Handler() {
-                    @Override
-                    public void publish(LogRecord record) {
-                        logRecords.add(record);
-                    }
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
 
-                    @Override
-                    public void flush() {}
+            @Override
+            public void flush() {}
 
-                    @Override
-                    public void close() throws SecurityException {}
-                };
+            @Override
+            public void close() throws SecurityException {}
+        };
 
         // Add handler to logger
         logger.addHandler(handler);

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.block.simulator.mode.PublisherModeHandler;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.output.BlockHeader;
@@ -219,7 +220,7 @@ class BlockStreamSimulatorTest {
 
     private List<LogRecord> captureLogs() {
         // Capture logs
-        Logger logger = Logger.getLogger(BlockStreamSimulatorApp.class.getName());
+        Logger logger = Logger.getLogger(PublisherModeHandler.class.getName());
         final List<LogRecord> logRecords = new ArrayList<>();
 
         // Custom handler to capture logs

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -71,8 +71,9 @@ class BlockStreamConfigTest {
 
     @Test
     void testSimulatorMode() {
-        BlockStreamConfig config =
-                getBlockStreamConfigBuilder().simulatorMode(SimulatorMode.PUBLISHER).build();
+        BlockStreamConfig config = getBlockStreamConfigBuilder()
+                .simulatorMode(SimulatorMode.PUBLISHER)
+                .build();
 
         assertEquals(SimulatorMode.PUBLISHER, config.simulatorMode());
     }
@@ -89,11 +90,10 @@ class BlockStreamConfigTest {
         assertTrue(Files.exists(path), "The folder must exist for this test.");
 
         // No exception should be thrown
-        BlockGeneratorConfig config =
-                getBlockGeneratorConfigBuilder()
-                        .folderRootPath(folderRootPath)
-                        .generationMode(generationMode)
-                        .build();
+        BlockGeneratorConfig config = getBlockGeneratorConfigBuilder()
+                .folderRootPath(folderRootPath)
+                .generationMode(generationMode)
+                .build();
 
         assertEquals(folderRootPath, config.folderRootPath());
         assertEquals(GenerationMode.DIR, config.generationMode());
@@ -105,9 +105,7 @@ class BlockStreamConfigTest {
         String folderRootPath = "";
         GenerationMode generationMode = GenerationMode.DIR;
         BlockGeneratorConfig.Builder builder =
-                getBlockGeneratorConfigBuilder()
-                        .folderRootPath(folderRootPath)
-                        .generationMode(generationMode);
+                getBlockGeneratorConfigBuilder().folderRootPath(folderRootPath).generationMode(generationMode);
 
         BlockGeneratorConfig config = builder.build();
 
@@ -125,13 +123,10 @@ class BlockStreamConfigTest {
 
         // An exception should be thrown because the path is not absolute
         IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () ->
-                                getBlockGeneratorConfigBuilder()
-                                        .folderRootPath(relativeFolderPath)
-                                        .generationMode(generationMode)
-                                        .build());
+                assertThrows(IllegalArgumentException.class, () -> getBlockGeneratorConfigBuilder()
+                        .folderRootPath(relativeFolderPath)
+                        .generationMode(generationMode)
+                        .build());
 
         // Verify the exception message
         assertEquals(relativeFolderPath + " Root path must be absolute", exception.getMessage());
@@ -149,13 +144,10 @@ class BlockStreamConfigTest {
 
         // An exception should be thrown because the folder does not exist
         IllegalArgumentException exception =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () ->
-                                getBlockGeneratorConfigBuilder()
-                                        .folderRootPath(folderRootPath)
-                                        .generationMode(generationMode)
-                                        .build());
+                assertThrows(IllegalArgumentException.class, () -> getBlockGeneratorConfigBuilder()
+                        .folderRootPath(folderRootPath)
+                        .generationMode(generationMode)
+                        .build());
 
         // Verify the exception message
         assertEquals("Folder does not exist: " + path, exception.getMessage());
@@ -168,11 +160,10 @@ class BlockStreamConfigTest {
         GenerationMode generationMode = GenerationMode.ADHOC;
 
         // No exception should be thrown because generation mode is not DIR
-        BlockGeneratorConfig config =
-                getBlockGeneratorConfigBuilder()
-                        .folderRootPath(folderRootPath)
-                        .generationMode(generationMode)
-                        .build();
+        BlockGeneratorConfig config = getBlockGeneratorConfigBuilder()
+                .folderRootPath(folderRootPath)
+                .generationMode(generationMode)
+                .build();
 
         // Verify that the configuration was created successfully
         assertEquals(folderRootPath, config.folderRootPath());

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator.config.data;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.block.simulator.config.types.GenerationMode;
+import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.config.types.StreamingMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,6 +67,14 @@ class BlockStreamConfigTest {
         BlockStreamConfig config = getBlockStreamConfigBuilder().build();
         // assert
         assertEquals(StreamingMode.CONSTANT_RATE, config.streamingMode());
+    }
+
+    @Test
+    void testSimulatorMode() {
+        BlockStreamConfig config =
+                getBlockStreamConfigBuilder().simulatorMode(SimulatorMode.PUBLISHER).build();
+
+        assertEquals(SimulatorMode.PUBLISHER, config.simulatorMode());
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -52,6 +52,7 @@ class PublishStreamGrpcClientImplTest {
         BlockItem blockItem = BlockItem.newBuilder().build();
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
                 new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
+        publishStreamGrpcClient.init();
         boolean result = publishStreamGrpcClient.streamBlockItem(List.of(blockItem));
         assertTrue(result);
     }
@@ -65,7 +66,7 @@ class PublishStreamGrpcClientImplTest {
 
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
                 new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
-
+        publishStreamGrpcClient.init();
         boolean result = publishStreamGrpcClient.streamBlock(block);
         assertTrue(result);
 

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -16,14 +16,18 @@
 
 package com.hedera.block.simulator.grpc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
+import io.grpc.ManagedChannel;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
@@ -72,5 +76,22 @@ class PublishStreamGrpcClientImplTest {
 
         boolean result1 = publishStreamGrpcClient.streamBlock(block1);
         assertTrue(result1);
+    }
+
+    @Test
+    void testShutdown() throws Exception {
+        PublishStreamGrpcClientImpl publishStreamGrpcClient =
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
+        publishStreamGrpcClient.init();
+
+        Field channelField = PublishStreamGrpcClientImpl.class.getDeclaredField("channel");
+        channelField.setAccessible(true);
+
+        ManagedChannel mockChannel = mock(ManagedChannel.class);
+        channelField.set(publishStreamGrpcClient, mockChannel);
+        publishStreamGrpcClient.shutdown();
+
+        // Verify that channel.shutdown() was called
+        verify(mockChannel).shutdown();
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -43,9 +43,8 @@ class PublishStreamGrpcClientImplTest {
     void setUp() throws IOException {
 
         grpcConfig = TestUtils.getTestConfiguration().getConfigData(GrpcConfig.class);
-        blockStreamConfig =
-                TestUtils.getTestConfiguration(Map.of("blockStream.blockItemsBatchSize", "2"))
-                        .getConfigData(BlockStreamConfig.class);
+        blockStreamConfig = TestUtils.getTestConfiguration(Map.of("blockStream.blockItemsBatchSize", "2"))
+                .getConfigData(BlockStreamConfig.class);
     }
 
     @AfterEach

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -84,10 +84,14 @@ class PublishStreamGrpcClientImplTest {
         publishStreamGrpcClient.init();
 
         Field channelField = PublishStreamGrpcClientImpl.class.getDeclaredField("channel");
-        channelField.setAccessible(true);
-
         ManagedChannel mockChannel = mock(ManagedChannel.class);
-        channelField.set(publishStreamGrpcClient, mockChannel);
+
+        try {
+            channelField.setAccessible(true);
+            channelField.set(publishStreamGrpcClient, mockChannel);
+        } finally {
+            channelField.setAccessible(false);
+        }
         publishStreamGrpcClient.shutdown();
 
         // Verify that channel.shutdown() was called

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class CombinedModeHandlerTest {
+
+    @Mock private BlockStreamConfig blockStreamConfig;
+
+    private CombinedModeHandler combinedModeHandler;
+
+    @Test
+    void testStartThrowsUnsupportedOperationException() {
+        MockitoAnnotations.openMocks(this);
+        combinedModeHandler = new CombinedModeHandler(blockStreamConfig);
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> combinedModeHandler.start(blockStreamManager));
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -17,10 +17,8 @@
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.generator.BlockStreamManager;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -36,8 +34,7 @@ public class CombinedModeHandlerTest {
     void testStartThrowsUnsupportedOperationException() {
         MockitoAnnotations.openMocks(this);
         combinedModeHandler = new CombinedModeHandler(blockStreamConfig);
-        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
 
-        assertThrows(UnsupportedOperationException.class, () -> combinedModeHandler.start(blockStreamManager));
+        assertThrows(UnsupportedOperationException.class, () -> combinedModeHandler.start());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -27,7 +27,8 @@ import org.mockito.MockitoAnnotations;
 
 public class CombinedModeHandlerTest {
 
-    @Mock private BlockStreamConfig blockStreamConfig;
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
 
     private CombinedModeHandler combinedModeHandler;
 
@@ -37,8 +38,6 @@ public class CombinedModeHandlerTest {
         combinedModeHandler = new CombinedModeHandler(blockStreamConfig);
         BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
 
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> combinedModeHandler.start(blockStreamManager));
+        assertThrows(UnsupportedOperationException.class, () -> combinedModeHandler.start(blockStreamManager));
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -27,7 +27,8 @@ import org.mockito.MockitoAnnotations;
 
 public class ConsumerModeHandlerTest {
 
-    @Mock private BlockStreamConfig blockStreamConfig;
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
 
     private ConsumerModeHandler consumerModeHandler;
 
@@ -37,8 +38,6 @@ public class ConsumerModeHandlerTest {
         consumerModeHandler = new ConsumerModeHandler(blockStreamConfig);
         BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
 
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> consumerModeHandler.start(blockStreamManager));
+        assertThrows(UnsupportedOperationException.class, () -> consumerModeHandler.start(blockStreamManager));
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -17,10 +17,8 @@
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import com.hedera.block.simulator.generator.BlockStreamManager;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -36,8 +34,7 @@ public class ConsumerModeHandlerTest {
     void testStartThrowsUnsupportedOperationException() {
         MockitoAnnotations.openMocks(this);
         consumerModeHandler = new ConsumerModeHandler(blockStreamConfig);
-        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
 
-        assertThrows(UnsupportedOperationException.class, () -> consumerModeHandler.start(blockStreamManager));
+        assertThrows(UnsupportedOperationException.class, () -> consumerModeHandler.start());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ConsumerModeHandlerTest {
+
+    @Mock private BlockStreamConfig blockStreamConfig;
+
+    private ConsumerModeHandler consumerModeHandler;
+
+    @Test
+    void testStartThrowsUnsupportedOperationException() {
+        MockitoAnnotations.openMocks(this);
+        consumerModeHandler = new ConsumerModeHandler(blockStreamConfig);
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> consumerModeHandler.start(blockStreamManager));
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -1,0 +1,136 @@
+package com.hedera.block.simulator.mode;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.types.StreamingMode;
+import com.hedera.block.simulator.generator.BlockStreamManager;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+public class PublisherModeHandlerTest {
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
+
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
+
+    @Mock
+    private BlockStreamManager blockStreamManager;
+
+    private PublisherModeHandler publisherModeHandler;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_WithBlocks() throws Exception {
+        // Configure blockStreamConfig
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(0); // No delay for testing
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithMillisPerBlockStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_WithinMaxItems() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(5);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+        BlockItem blockItem3 = mock(BlockItem.class);
+        BlockItem blockItem4 = mock(BlockItem.class);
+
+        when(block1.items()).thenReturn(Arrays.asList(blockItem1, blockItem2));
+        when(block2.items()).thenReturn(Arrays.asList(blockItem3, blockItem4));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(3)).getNextBlock();
+    }
+
+    @Test
+    void testStartWithConstantRateStreaming_NoBlocks() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock()).thenReturn(null);
+
+        publisherModeHandler.start(blockStreamManager);
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+    }
+
+    @Test
+    void testStartWithExceptionDuringStreaming() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
+
+        when(blockStreamManager.getNextBlock())
+                .thenThrow(new IOException("Test exception"));
+
+        assertThrows(IOException.class, () -> publisherModeHandler.start(blockStreamManager));
+
+        verify(publishStreamGrpcClient, never()).streamBlock(any(Block.class));
+        verify(blockStreamManager).getNextBlock();
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verifyNoMoreInteractions(blockStreamManager);
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -33,11 +33,14 @@ import org.mockito.*;
 
 public class PublisherModeHandlerTest {
 
-    @Mock private BlockStreamConfig blockStreamConfig;
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
 
-    @Mock private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
 
-    @Mock private BlockStreamManager blockStreamManager;
+    @Mock
+    private BlockStreamManager blockStreamManager;
 
     private PublisherModeHandler publisherModeHandler;
 

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,23 +25,19 @@ import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
+import java.io.IOException;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 
-import java.io.IOException;
-import java.util.Arrays;
-
 public class PublisherModeHandlerTest {
 
-    @Mock
-    private BlockStreamConfig blockStreamConfig;
+    @Mock private BlockStreamConfig blockStreamConfig;
 
-    @Mock
-    private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock private PublishStreamGrpcClient publishStreamGrpcClient;
 
-    @Mock
-    private BlockStreamManager blockStreamManager;
+    @Mock private BlockStreamManager blockStreamManager;
 
     private PublisherModeHandler publisherModeHandler;
 
@@ -123,8 +135,7 @@ public class PublisherModeHandlerTest {
 
         publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient);
 
-        when(blockStreamManager.getNextBlock())
-                .thenThrow(new IOException("Test exception"));
+        when(blockStreamManager.getNextBlock()).thenThrow(new IOException("Test exception"));
 
         assertThrows(IOException.class, () -> publisherModeHandler.start(blockStreamManager));
 

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -74,7 +74,7 @@ public abstract class BaseSuite {
      */
     @BeforeAll
     public static void setup() {
-        blockNodeContainer = getContainer();
+        blockNodeContainer = createContainer();
         blockNodeContainer.start();
     }
 
@@ -107,7 +107,7 @@ public abstract class BaseSuite {
      *
      * @return a configured {@link GenericContainer} instance for the Block Node server
      */
-    protected static GenericContainer<?> getContainer() {
+    protected static GenericContainer<?> createContainer() {
         String blockNodeVersion = BaseSuite.getBlockNodeVersion();
         blockNodePort = 8080;
         List<String> portBindings = new ArrayList<>();

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -114,7 +114,7 @@ public abstract class BaseSuite {
         portBindings.add(String.format("%d:%2d", blockNodePort, blockNodePort));
         blockNodeContainer =
                 new GenericContainer<>(
-                        DockerImageName.parse("block-node-server:" + blockNodeVersion))
+                                DockerImageName.parse("block-node-server:" + blockNodeVersion))
                         .withExposedPorts(blockNodePort)
                         .withEnv("VERSION", blockNodeVersion)
                         .waitingFor(Wait.forListeningPort())

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -112,13 +112,11 @@ public abstract class BaseSuite {
         blockNodePort = 8080;
         List<String> portBindings = new ArrayList<>();
         portBindings.add(String.format("%d:%2d", blockNodePort, blockNodePort));
-        blockNodeContainer =
-                new GenericContainer<>(
-                                DockerImageName.parse("block-node-server:" + blockNodeVersion))
-                        .withExposedPorts(blockNodePort)
-                        .withEnv("VERSION", blockNodeVersion)
-                        .waitingFor(Wait.forListeningPort())
-                        .waitingFor(Wait.forHealthcheck());
+        blockNodeContainer = new GenericContainer<>(DockerImageName.parse("block-node-server:" + blockNodeVersion))
+                .withExposedPorts(blockNodePort)
+                .withEnv("VERSION", blockNodeVersion)
+                .waitingFor(Wait.forListeningPort())
+                .waitingFor(Wait.forHealthcheck());
         blockNodeContainer.setPortBindings(portBindings);
         return blockNodeContainer;
     }
@@ -130,12 +128,11 @@ public abstract class BaseSuite {
      * @throws IOException if an I/O error occurs
      */
     protected static Configuration loadSimulatorDefaultConfiguration() throws IOException {
-        ConfigurationBuilder configurationBuilder =
-                ConfigurationBuilder.create()
-                        .withSource(SystemEnvironmentConfigSource.getInstance())
-                        .withSource(SystemPropertiesConfigSource.getInstance())
-                        .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
-                        .autoDiscoverExtensions();
+        ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
+                .withSource(SystemEnvironmentConfigSource.getInstance())
+                .withSource(SystemPropertiesConfigSource.getInstance())
+                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
+                .autoDiscoverExtensions();
 
         return configurationBuilder.build();
     }
@@ -150,7 +147,10 @@ public abstract class BaseSuite {
      * @return the version of the Block Node server as a string
      */
     private static String getBlockNodeVersion() {
-        Dotenv dotenv = Dotenv.configure().directory("../server/docker").filename(".env").load();
+        Dotenv dotenv = Dotenv.configure()
+                .directory("../server/docker")
+                .filename(".env")
+                .load();
 
         return dotenv.get("VERSION");
     }

--- a/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
@@ -45,13 +45,13 @@ public class NegativeServerAvailabilityTests extends BaseSuite {
      * Clean up method executed after each test.
      *
      * <p>This method stops the running container, resets the container configuration by retrieving
-     * a new one through {@link BaseSuite#getContainer()} ()}, and then starts the Block Node
+     * a new one through {@link BaseSuite#createContainer()}, and then starts the Block Node
      * container again.
      */
     @AfterEach
     public void cleanUp() {
         blockNodeContainer.stop();
-        blockNodeContainer = getContainer();
+        blockNodeContainer = createContainer();
         blockNodeContainer.start();
     }
 

--- a/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
@@ -45,13 +45,13 @@ public class NegativeServerAvailabilityTests extends BaseSuite {
      * Clean up method executed after each test.
      *
      * <p>This method stops the running container, resets the container configuration by retrieving
-     * a new one through {@link BaseSuite#getConfiguration()}, and then starts the Block Node
+     * a new one through {@link BaseSuite#getContainer()} ()}, and then starts the Block Node
      * container again.
      */
     @AfterEach
     public void cleanUp() {
         blockNodeContainer.stop();
-        blockNodeContainer = getConfiguration();
+        blockNodeContainer = getContainer();
         blockNodeContainer.start();
     }
 

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -85,20 +85,18 @@ public class PositiveDataPersistenceTests extends BaseSuite {
 
     private BlockStreamSimulatorApp createBlockSimulator() throws IOException {
         BlockStreamSimulatorInjectionComponent DIComponent =
-                DaggerBlockStreamSimulatorInjectionComponent.factory()
-                        .create(loadSimulatorDefaultConfiguration());
+                DaggerBlockStreamSimulatorInjectionComponent.factory().create(loadSimulatorDefaultConfiguration());
         return DIComponent.getBlockStreamSimulatorApp();
     }
 
     private void startSimulatorThread(BlockStreamSimulatorApp blockStreamSimulatorAppInstance) {
-        executorService.submit(
-                () -> {
-                    try {
-                        blockStreamSimulatorAppInstance.start();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+        executorService.submit(() -> {
+            try {
+                blockStreamSimulatorAppInstance.start();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     private int getSavedBlocksCount(String blocksFolders) {
@@ -106,8 +104,7 @@ public class PositiveDataPersistenceTests extends BaseSuite {
         return blocksArray.length;
     }
 
-    private String getContainerCommandResult(String[] command)
-            throws IOException, InterruptedException {
+    private String getContainerCommandResult(String[] command) throws IOException, InterruptedException {
         Container.ExecResult result = blockNodeContainer.execInContainer(command);
         return result.getStdout();
     }

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -16,12 +16,95 @@
 
 package com.hedera.block.suites.persistence.positive;
 
-import com.hedera.block.suites.BaseSuite;
-import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Positive Data Persistence Tests */
+import com.hedera.block.simulator.BlockStreamSimulatorApp;
+import com.hedera.block.simulator.BlockStreamSimulatorInjectionComponent;
+import com.hedera.block.simulator.DaggerBlockStreamSimulatorInjectionComponent;
+import com.hedera.block.suites.BaseSuite;
+import java.io.IOException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+
+/**
+ * Test class for verifying the positive scenarios for data persistence.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
 @DisplayName("Positive Data Persistence Tests")
 public class PositiveDataPersistenceTests extends BaseSuite {
+    private final String[] GET_BLOCKS_COMMAND = new String[] {"ls", "data", "-1"};
+
+    private Thread simulatorThread;
+
     /** Default constructor for the {@link PositiveDataPersistenceTests} class. */
     public PositiveDataPersistenceTests() {}
+
+    @BeforeEach
+    void setupEnvironment() throws IOException {
+        BlockStreamSimulatorInjectionComponent DIComponent =
+                DaggerBlockStreamSimulatorInjectionComponent.factory()
+                        .create(loadSimulatorDefaultConfiguration());
+
+        blockStreamSimulatorApp = DIComponent.getBlockStreamSimulatorApp();
+        simulatorThread = setupSimulatorThread(blockStreamSimulatorApp);
+    }
+
+    @AfterEach
+    void teardownEnvironment() {
+        simulatorThread.interrupt();
+    }
+
+    /**
+     * Verifies that block data is saved in the correct directory by comparing the count of saved
+     * blocks before and after running the simulator. The test asserts that the number of saved
+     * blocks increases after the simulator runs.
+     *
+     * @throws IOException if an I/O error occurs during execution in the container
+     * @throws InterruptedException if the thread is interrupted while sleeping or executing
+     *     commands
+     */
+    @Test
+    public void verifyBlockDataSavedInCorrectDirectory() throws InterruptedException, IOException {
+        String savedBlocksFolderBefore = getContainerCommandResult(GET_BLOCKS_COMMAND);
+        int savedBlocksCountBefore = getSavedBlocksCount(savedBlocksFolderBefore);
+
+        simulatorThread.start();
+        Thread.sleep(5000);
+        blockStreamSimulatorApp.stop();
+
+        String savedBlocksFolderAfter = getContainerCommandResult(GET_BLOCKS_COMMAND);
+        int savedBlocksCountAfter = getSavedBlocksCount(savedBlocksFolderAfter);
+
+        assertTrue(savedBlocksFolderBefore.isEmpty());
+        assertFalse(savedBlocksFolderAfter.isEmpty());
+        assertTrue(savedBlocksCountAfter > savedBlocksCountBefore);
+    }
+
+    private Thread setupSimulatorThread(BlockStreamSimulatorApp blockStreamSimulatorAppInstance) {
+        return new Thread(
+                () -> {
+                    try {
+                        blockStreamSimulatorAppInstance.start();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    private int getSavedBlocksCount(String blocksFolders) {
+        String[] blocksArray = blocksFolders.split("\\n");
+        return blocksArray.length;
+    }
+
+    private String getContainerCommandResult(String[] command)
+            throws IOException, InterruptedException {
+        Container.ExecResult result = blockNodeContainer.execInContainer(command);
+        return result.getStdout();
+    }
 }


### PR DESCRIPTION
**Description**:
This PR aims mainly to make the maintanence and using of simulator (as test driver) easier. It moves away the implementation of the working modes and exposes only abstractions. So that all concrete implementations can be refactored (if needed), without the main application, knowing or caring about it. 
Main simulator app should only be responsible for starting the processes and nothing more. Wherther the simulator will work in publisher or consumer mode, or both is not responsibility of the main class.

Also adds E2E test for data persistence.

**Related issue(s)**:

Fixes #239 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
