### PR TITLE
feat: setup metrics in the simulator to report block items sent

### DIFF
--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -27,8 +27,11 @@ services:
       - ./metrics/prometheus.yml:/etc/prometheus/prometheus.yml
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
+    # Exposing Prometheus outside the stack can create issues with
+    # the MetricsService in the Simulator. Here it's exposed within
+    # the stack.
     ports:
-      - "9090:9090"
+      - "9090"
 
   grafana:
     image: grafana/grafana

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -41,7 +41,6 @@ testModuleInfo {
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
     requiresStatic("com.github.spotbugs.annotations")
-    requires("com.swirlds.common")
 }
 
 tasks.register<Copy>("untarTestBlockStream") {

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator;
 
+import static java.lang.System.Logger.Level.INFO;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
@@ -23,6 +24,7 @@ import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
+import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.block.simulator.mode.CombinedModeHandler;
 import com.hedera.block.simulator.mode.ConsumerModeHandler;
 import com.hedera.block.simulator.mode.PublisherModeHandler;
@@ -37,9 +39,11 @@ import javax.inject.Inject;
 public class BlockStreamSimulatorApp {
 
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final SimulatorModeHandler simulatorModeHandler;
     private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final MetricsService metricsService;
 
     /**
      * Creates a new BlockStreamSimulatorApp instance.
@@ -47,14 +51,18 @@ public class BlockStreamSimulatorApp {
      * @param configuration the configuration to be used by the block stream simulator
      * @param blockStreamManager the block stream manager to be used by the block stream simulator
      * @param publishStreamGrpcClient the gRPC client to be used by the block stream simulator
+     * @param metricsService the metrics service to be used by the block stream simulator
      */
     @Inject
     public BlockStreamSimulatorApp(
             @NonNull Configuration configuration,
             @NonNull BlockStreamManager blockStreamManager,
-            @NonNull PublishStreamGrpcClient publishStreamGrpcClient) {
-        requireNonNull(blockStreamManager);
+            @NonNull PublishStreamGrpcClient publishStreamGrpcClient,
+            @NonNull MetricsService metricsService) {
 
+        requireNonNull(configuration);
+        requireNonNull(blockStreamManager);
+        this.metricsService = requireNonNull(metricsService);
         this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
         final BlockStreamConfig blockStreamConfig =
                 requireNonNull(configuration.getConfigData(BlockStreamConfig.class));
@@ -97,6 +105,6 @@ public class BlockStreamSimulatorApp {
     public void stop() {
         publishStreamGrpcClient.shutdown();
         isRunning.set(false);
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has stopped");
+        LOGGER.log(INFO, "Block Stream Simulator has stopped");
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator;
 import com.hedera.block.simulator.config.ConfigInjectionModule;
 import com.hedera.block.simulator.generator.GeneratorInjectionModule;
 import com.hedera.block.simulator.grpc.GrpcInjectionModule;
+import com.hedera.block.simulator.metrics.MetricsInjectionModule;
 import com.swirlds.config.api.Configuration;
 import dagger.BindsInstance;
 import dagger.Component;
@@ -28,6 +29,7 @@ import javax.inject.Singleton;
 @Singleton
 @Component(
         modules = {
+            MetricsInjectionModule.class,
             ConfigInjectionModule.class,
             GeneratorInjectionModule.class,
             GrpcInjectionModule.class,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator.config;
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.Configuration;
 import dagger.Module;
 import dagger.Provides;
@@ -62,5 +63,17 @@ public interface ConfigInjectionModule {
     @Provides
     static BlockGeneratorConfig provideBlockGeneratorConfig(Configuration configuration) {
         return configuration.getConfigData(BlockGeneratorConfig.class);
+    }
+
+    /**
+     * Provides a Prometheus configuration singleton using the configuration.
+     *
+     * @param configuration is the configuration singleton
+     * @return a Prometheus configuration singleton
+     */
+    @Singleton
+    @Provides
+    static PrometheusConfig providePrometheusConfig(Configuration configuration) {
+        return configuration.getConfigData(PrometheusConfig.class);
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
@@ -20,6 +20,8 @@ import com.google.auto.service.AutoService;
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.swirlds.common.metrics.config.MetricsConfig;
+import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.ConfigurationExtension;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Set;
@@ -36,6 +38,11 @@ public class SimulatorConfigExtension implements ConfigurationExtension {
     @NonNull
     @Override
     public Set<Class<? extends Record>> getConfigDataTypes() {
-        return Set.of(BlockStreamConfig.class, GrpcConfig.class, BlockGeneratorConfig.class);
+        return Set.of(
+                BlockStreamConfig.class,
+                GrpcConfig.class,
+                BlockGeneratorConfig.class,
+                MetricsConfig.class,
+                PrometheusConfig.class);
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsInjectionModule.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import com.swirlds.common.metrics.platform.DefaultMetricsProvider;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
+import dagger.Binds;
+import dagger.Module;
+import dagger.Provides;
+import javax.inject.Singleton;
+
+/** The module used to inject the metrics service and metrics into the application. */
+@Module
+public interface MetricsInjectionModule {
+
+    /**
+     * Provides the metrics service.
+     *
+     * @param metricsService the metrics service to be used
+     * @return the metrics service
+     */
+    @Singleton
+    @Binds
+    MetricsService bindMetricsService(MetricsServiceImpl metricsService);
+
+    /**
+     * Provides the metrics.
+     *
+     * @param configuration the configuration to be used by the metrics
+     * @return the metrics
+     */
+    @Singleton
+    @Provides
+    static Metrics provideMetrics(Configuration configuration) {
+        final DefaultMetricsProvider metricsProvider = new DefaultMetricsProvider(configuration);
+        final Metrics metrics = metricsProvider.createGlobalMetrics();
+        metricsProvider.start();
+        return metrics;
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsService.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import com.swirlds.metrics.api.Counter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/** Use member variables of this class to update metric data for the Hedera Block Node. */
+public interface MetricsService {
+    /**
+     * Use this method to get a specific counter for the given metric type.
+     *
+     * @param key to get a specific counter
+     * @return the counter
+     */
+    Counter get(@NonNull SimulatorMetricTypes.Counter key);
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsServiceImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsServiceImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.Metrics;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.EnumMap;
+import javax.inject.Inject;
+
+/**
+ * Use member variables of this class to update metric data for the Hedera Block Node.
+ *
+ * <p>Metrics are updated by calling the appropriate method on the metric object instance. For
+ * example, to increment a counter, call {@link Counter#increment()}.
+ */
+public class MetricsServiceImpl implements MetricsService {
+
+    private static final String CATEGORY = "hedera_block_node_simulator";
+
+    private final EnumMap<SimulatorMetricTypes.Counter, Counter> counters =
+            new EnumMap<>(SimulatorMetricTypes.Counter.class);
+
+    /**
+     * Create singleton instance of metrics service to be used throughout the application.
+     *
+     * @param metrics the metrics instance
+     */
+    @Inject
+    public MetricsServiceImpl(@NonNull final Metrics metrics) {
+        // Initialize the counters
+        for (SimulatorMetricTypes.Counter counter : SimulatorMetricTypes.Counter.values()) {
+            counters.put(
+                    counter,
+                    metrics.getOrCreate(new Counter.Config(CATEGORY, counter.grafanaLabel())
+                            .withDescription(counter.description())));
+        }
+    }
+
+    /**
+     * Use this method to get a specific counter for the given metric type.
+     *
+     * @param key to get a specific counter
+     * @return the counter
+     */
+    @NonNull
+    @Override
+    public Counter get(@NonNull SimulatorMetricTypes.Counter key) {
+        return counters.get(key);
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * The BlockNodeMetricNames class contains the names of the metrics used by the BlockNode.
+ *
+ * <p>These names are used to register the metrics with the metrics service.
+ */
+public final class SimulatorMetricTypes {
+    private SimulatorMetricTypes() {}
+
+    /**
+     * Add new counting metrics to this enum to automatically register them with the metrics
+     * service.
+     *
+     * <p>Each enum value should have a unique grafana label and meaningful description. These
+     * counters can capture data on standard operations or errors.
+     */
+    public enum Counter implements MetricMetadata {
+        // Standard counters
+        /** The number of live block items sent by the simulator . */
+        LiveBlockItemsSent("live_block_items_sent", "Live Block Items Sent");
+
+        private final String grafanaLabel;
+        private final String description;
+
+        Counter(String grafanaLabel, String description) {
+            this.grafanaLabel = grafanaLabel;
+            this.description = description;
+        }
+
+        @Override
+        @NonNull
+        public String grafanaLabel() {
+            return grafanaLabel;
+        }
+
+        @Override
+        @NonNull
+        public String description() {
+            return description;
+        }
+    }
+
+    private interface MetricMetadata {
+        String grafanaLabel();
+
+        String description();
+    }
+}

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -5,6 +5,11 @@ module com.hedera.block.simulator {
     exports com.hedera.block.simulator.config.data;
     exports com.hedera.block.simulator.exception;
     exports com.hedera.block.simulator;
+    exports com.hedera.block.simulator.config.types;
+    exports com.hedera.block.simulator.config;
+    exports com.hedera.block.simulator.grpc;
+    exports com.hedera.block.simulator.generator;
+    exports com.hedera.block.simulator.metrics;
 
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;
@@ -12,8 +17,10 @@ module com.hedera.block.simulator {
     requires com.hedera.block.stream;
     requires com.google.protobuf;
     requires com.hedera.pbj.runtime;
+    requires com.swirlds.common;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
+    requires com.swirlds.metrics.api;
     requires dagger;
     requires io.grpc.stub;
     requires io.grpc;

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -1,3 +1,12 @@
+# The prometheus endpoint is used by the
+# MetricsService to track different metrics.
+# This is disabled by default to avoid port
+# conflicts with the server prometheus endpoint.
+# We might consider enabling this on a different
+# port to track simulator metrics from a
+# dashboard.
+prometheus.endpointEnabled=false
+
 #generator.folderRootPath=/Users/user/Downloads/block-0.0.3-perf
 #generator.managerImplementation=BlockAsFileLargeDataSets
 #blockStream.maxBlockItemsToStream=100_000_000

--- a/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
@@ -17,9 +17,11 @@
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.TestConfigBuilder;
+import com.swirlds.common.metrics.platform.DefaultMetricsProvider;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -29,20 +31,15 @@ public class TestUtils {
 
     private static final String TEST_APP_PROPERTIES_FILE = "app.properties";
 
-    public static Configuration getTestConfiguration(@NonNull Map<String, String> customProperties)
-            throws IOException {
+    public static Configuration getTestConfiguration(@NonNull Map<String, String> customProperties) throws IOException {
         // create test configuration
-        TestConfigBuilder testConfigBuilder =
-                new TestConfigBuilder(true)
-                        .withSource(
-                                new ClasspathFileConfigSource(Path.of(TEST_APP_PROPERTIES_FILE)));
+        TestConfigBuilder testConfigBuilder = new TestConfigBuilder(true)
+                .withSource(new ClasspathFileConfigSource(Path.of(TEST_APP_PROPERTIES_FILE)));
 
         for (Map.Entry<String, String> entry : customProperties.entrySet()) {
             String key = entry.getKey();
             String value = entry.getValue();
-            testConfigBuilder =
-                    testConfigBuilder.withSource(
-                            new SimpleConfigSource(key, value).withOrdinal(500));
+            testConfigBuilder = testConfigBuilder.withSource(new SimpleConfigSource(key, value).withOrdinal(500));
         }
 
         return testConfigBuilder.getOrCreateConfig();
@@ -50,5 +47,12 @@ public class TestUtils {
 
     public static Configuration getTestConfiguration() throws IOException {
         return getTestConfiguration(Map.of());
+    }
+
+    public static Metrics getTestMetrics(@NonNull Configuration configuration) {
+        final DefaultMetricsProvider metricsProvider = new DefaultMetricsProvider(configuration);
+        final Metrics metrics = metricsProvider.createGlobalMetrics();
+        metricsProvider.start();
+        return metrics;
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -16,17 +16,21 @@
 
 package com.hedera.block.simulator.config;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -36,42 +40,46 @@ class ConfigInjectionModuleTest {
 
     @BeforeAll
     static void setUpAll() throws IOException {
-        configuration =
-                ConfigurationBuilder.create()
-                        .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
-                        .autoDiscoverExtensions()
-                        .build();
-        configuration =
-                TestUtils.getTestConfiguration(
-                        Map.of("generator.managerImplementation", "BlockAsFileBlockStreamManager"));
+        configuration = ConfigurationBuilder.create()
+                .withSource(new ClasspathFileConfigSource(Path.of("app.properties")))
+                .autoDiscoverExtensions()
+                .build();
+        configuration = TestUtils.getTestConfiguration(
+                Map.of("generator.managerImplementation", "BlockAsFileBlockStreamManager"));
     }
 
     @Test
     void provideBlockStreamConfig() {
 
-        BlockStreamConfig blockStreamConfig =
-                ConfigInjectionModule.provideBlockStreamConfig(configuration);
+        BlockStreamConfig blockStreamConfig = ConfigInjectionModule.provideBlockStreamConfig(configuration);
 
-        Assertions.assertNotNull(blockStreamConfig);
-        Assertions.assertEquals(1000, blockStreamConfig.blockItemsBatchSize());
+        assertNotNull(blockStreamConfig);
+        assertEquals(1000, blockStreamConfig.blockItemsBatchSize());
     }
 
     @Test
     void provideGrpcConfig() {
         GrpcConfig grpcConfig = ConfigInjectionModule.provideGrpcConfig(configuration);
 
-        Assertions.assertNotNull(grpcConfig);
-        Assertions.assertEquals("localhost", grpcConfig.serverAddress());
-        Assertions.assertEquals(8080, grpcConfig.port());
+        assertNotNull(grpcConfig);
+        assertEquals("localhost", grpcConfig.serverAddress());
+        assertEquals(8080, grpcConfig.port());
     }
 
     @Test
     void provideBlockGeneratorConfig() {
-        BlockGeneratorConfig blockGeneratorConfig =
-                ConfigInjectionModule.provideBlockGeneratorConfig(configuration);
+        BlockGeneratorConfig blockGeneratorConfig = ConfigInjectionModule.provideBlockGeneratorConfig(configuration);
 
-        Assertions.assertNotNull(blockGeneratorConfig);
-        Assertions.assertEquals(
-                "BlockAsFileBlockStreamManager", blockGeneratorConfig.managerImplementation());
+        assertNotNull(blockGeneratorConfig);
+        assertEquals("BlockAsFileBlockStreamManager", blockGeneratorConfig.managerImplementation());
+    }
+
+    @Test
+    void providePrometheusConfig() {
+        PrometheusConfig prometheusConfig = ConfigInjectionModule.providePrometheusConfig(configuration);
+
+        assertNotNull(prometheusConfig);
+        assertFalse(prometheusConfig.endpointEnabled());
+        assertEquals(9999, prometheusConfig.endpointPortNumber());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsInjectionModuleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.hedera.block.simulator.TestUtils;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class MetricsInjectionModuleTest {
+
+    @Test
+    void testProvideMetrics() throws IOException {
+        Configuration configuration = TestUtils.getTestConfiguration();
+
+        // Call the method under test
+        Metrics providedMetrics = MetricsInjectionModule.provideMetrics(configuration);
+
+        assertNotNull(providedMetrics);
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.metrics;
+
+import static com.hedera.block.simulator.TestUtils.getTestMetrics;
+import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlockItemsSent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.block.simulator.TestUtils;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MetricsServiceTest {
+
+    private MetricsService metricsService;
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        Configuration config = TestUtils.getTestConfiguration();
+        metricsService = new MetricsServiceImpl(getTestMetrics(config));
+    }
+
+    @Test
+    void MetricsService_verifyLiveBlockItemsSentCounter() {
+
+        for (int i = 0; i < 10; i++) {
+            metricsService.get(LiveBlockItemsSent).increment();
+        }
+
+        assertEquals(
+                LiveBlockItemsSent.grafanaLabel(),
+                metricsService.get(LiveBlockItemsSent).getName());
+        assertEquals(
+                LiveBlockItemsSent.description(),
+                metricsService.get(LiveBlockItemsSent).getDescription());
+        assertEquals(10, metricsService.get(LiveBlockItemsSent).get());
+    }
+}


### PR DESCRIPTION
**Description**:
* Introduced the MetricsService into the simulator subproject
* Changed the docker-compose.yml to make the prometheus port internal only to the stack
* Added tests

Running simulator output now contains the total block item count:
```
INFO: Loading block: 000000000000000000000000000000000028.blk.gz
Oct 29, 2024 1:25:57 PM com.hedera.block.simulator.generator.BlockAsFileLargeDataSets getNextBlock
INFO: block loaded with items size= 13
Oct 29, 2024 1:25:57 PM com.hedera.block.simulator.grpc.PublishStreamGrpcClientImpl streamBlock
INFO: Total Block items sent: 374
Oct 29, 2024 1:25:57 PM com.hedera.block.simulator.grpc.PublishStreamObserver onNext
```

**Related issue(s)**:

Fixes #314 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
