### PR TITLE
feat: add error handling in publisher

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
@@ -18,6 +18,8 @@ package com.hedera.block.simulator.grpc;
 
 import dagger.Binds;
 import dagger.Module;
+import dagger.Provides;
+import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Singleton;
 
 /** The module used to inject the gRPC client. */
@@ -32,6 +34,16 @@ public interface GrpcInjectionModule {
      */
     @Singleton
     @Binds
-    PublishStreamGrpcClient bindPublishStreamGrpcClient(
-            PublishStreamGrpcClientImpl publishStreamGrpcClient);
+    PublishStreamGrpcClient bindPublishStreamGrpcClient(PublishStreamGrpcClientImpl publishStreamGrpcClient);
+
+    /**
+     * Provides the stream enabled flag
+     *
+     * @return the stream enabled flag
+     */
+    @Singleton
+    @Provides
+    static AtomicBoolean provideStreamEnabledFlag() {
+        return new AtomicBoolean(true);
+    }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamObserver.java
@@ -16,6 +16,8 @@
 
 package com.hedera.block.simulator.grpc;
 
+import static java.util.Objects.requireNonNull;
+
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.Status;
@@ -36,8 +38,8 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
      *
      * @param streamEnabled is responsible for signaling, whether streaming should continue
      */
-    public PublishStreamObserver(final AtomicBoolean streamEnabled) {
-        this.streamEnabled = streamEnabled;
+    public PublishStreamObserver(@NonNull final AtomicBoolean streamEnabled) {
+        this.streamEnabled = requireNonNull(streamEnabled);
     }
 
     /** what will the stream observer do with the response from the server */
@@ -51,10 +53,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     public void onError(@NonNull final Throwable streamError) {
         streamEnabled.set(false);
         Status status = Status.fromThrowable(streamError);
-        logger.log(
-                Logger.Level.ERROR,
-                "Error %s with status code %s.".formatted(status.getCode(), streamError),
-                streamError);
+        logger.log(Logger.Level.ERROR, "Error %s with status %s.".formatted(streamError, status), streamError);
     }
 
     /** what will the stream observer do when the stream is completed */

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -85,8 +85,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
         Block nextBlock = blockStreamManager.getNextBlock();
         while (nextBlock != null) {
             long startTime = System.nanoTime();
-            final boolean streamSuccess = publishStreamGrpcClient.streamBlock(nextBlock);
-            if (!streamSuccess) {
+            if (!publishStreamGrpcClient.streamBlock(nextBlock)) {
                 LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator stopped streaming due to errors.");
                 break;
             }
@@ -122,12 +121,11 @@ public class PublisherModeHandler implements SimulatorModeHandler {
                 LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has reached the end of the block items");
                 break;
             }
-
-            final boolean streamSuccess = publishStreamGrpcClient.streamBlock(block);
-            if (!streamSuccess) {
+            if (!publishStreamGrpcClient.streamBlock(block)) {
                 LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator stopped streaming due to errors.");
                 break;
             }
+
             blockItemsStreamed += block.items().size();
 
             Thread.sleep(delayMSBetweenBlockItems, delayNSBetweenBlockItems);

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -83,7 +83,7 @@ class PublishStreamGrpcClientImplTest {
         Block block1 = Block.newBuilder().items(blockItem, blockItem, blockItem).build();
 
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
-        new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
 
         publishStreamGrpcClient.init();
         boolean result = publishStreamGrpcClient.streamBlock(block);
@@ -94,12 +94,12 @@ class PublishStreamGrpcClientImplTest {
     }
 
     @Test
-    void streamBlockReturnsFalse() throws NoSuchFieldException, IllegalAccessException {
+    void streamBlockReturnsFalse() {
         BlockItem blockItem = BlockItem.newBuilder().build();
         Block block = Block.newBuilder().items(blockItem).build();
         streamEnabled.set(false);
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
-                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, streamEnabled);
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
         publishStreamGrpcClient.init();
 
         boolean result = publishStreamGrpcClient.streamBlock(block);
@@ -109,7 +109,7 @@ class PublishStreamGrpcClientImplTest {
     @Test
     void testShutdown() throws Exception {
         PublishStreamGrpcClientImpl publishStreamGrpcClient =
-        new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
         publishStreamGrpcClient.init();
 
         Field channelField = PublishStreamGrpcClientImpl.class.getDeclaredField("channel");

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -17,6 +17,7 @@
 package com.hedera.block.simulator.grpc;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +88,28 @@ class PublishStreamGrpcClientImplTest {
 
         boolean result1 = publishStreamGrpcClient.streamBlock(block1);
         assertTrue(result1);
+    }
+
+    @Test
+    void streamBlockReturnsFalse() throws NoSuchFieldException, IllegalAccessException {
+        BlockItem blockItem = BlockItem.newBuilder().build();
+        Block block = Block.newBuilder().items(blockItem).build();
+
+        PublishStreamGrpcClientImpl publishStreamGrpcClient =
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig);
+        publishStreamGrpcClient.init();
+        Field allowNextField = PublishStreamGrpcClientImpl.class.getDeclaredField("allowNext");
+
+        try {
+            allowNextField.setAccessible(true);
+            AtomicBoolean allowNext = (AtomicBoolean) allowNextField.get(publishStreamGrpcClient);
+            allowNext.set(false);
+        } finally {
+            allowNextField.setAccessible(false);
+        }
+
+        boolean result = publishStreamGrpcClient.streamBlock(block);
+        assertFalse(result);
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
@@ -28,28 +28,28 @@ class PublishStreamObserverTest {
     @Test
     void onNext() {
         PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
-        AtomicBoolean allowNext = new AtomicBoolean(true);
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
 
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
         publishStreamObserver.onNext(response);
-        assertTrue(allowNext.get(), "allowNext should remain true after onCompleted");
+        assertTrue(streamEnabled.get(), "allowNext should remain true after onCompleted");
     }
 
     @Test
     void onError() {
-        AtomicBoolean allowNext = new AtomicBoolean(true);
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
 
         publishStreamObserver.onError(new Throwable());
-        assertFalse(allowNext.get(), "allowNext should be set to false after onError");
+        assertFalse(streamEnabled.get(), "allowNext should be set to false after onError");
     }
 
     @Test
     void onCompleted() {
-        AtomicBoolean allowNext = new AtomicBoolean(true);
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
 
         publishStreamObserver.onCompleted();
-        assertTrue(allowNext.get(), "allowNext should remain true after onCompleted");
+        assertTrue(streamEnabled.get(), "allowNext should remain true after onCompleted");
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
@@ -16,7 +16,11 @@
 
 package com.hedera.block.simulator.grpc;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class PublishStreamObserverTest {
@@ -24,19 +28,28 @@ class PublishStreamObserverTest {
     @Test
     void onNext() {
         PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver();
+        AtomicBoolean allowNext = new AtomicBoolean(true);
+
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
         publishStreamObserver.onNext(response);
+        assertTrue(allowNext.get(), "allowNext should remain true after onCompleted");
     }
 
     @Test
     void onError() {
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver();
+        AtomicBoolean allowNext = new AtomicBoolean(true);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
+
         publishStreamObserver.onError(new Throwable());
+        assertFalse(allowNext.get(), "allowNext should be set to false after onError");
     }
 
     @Test
     void onCompleted() {
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver();
+        AtomicBoolean allowNext = new AtomicBoolean(true);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(allowNext);
+
         publishStreamObserver.onCompleted();
+        assertTrue(allowNext.get(), "allowNext should remain true after onCompleted");
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -72,6 +72,9 @@ public class PublisherModeHandlerTest {
                 .thenReturn(block2)
                 .thenReturn(null);
 
+        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
+
         publisherModeHandler.start();
 
         verify(publishStreamGrpcClient).streamBlock(block1);
@@ -117,6 +120,9 @@ public class PublisherModeHandlerTest {
                 .thenReturn(block1)
                 .thenReturn(block2)
                 .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(true);
 
         publisherModeHandler.start();
 

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -154,4 +154,63 @@ public class PublisherModeHandlerTest {
         verifyNoMoreInteractions(publishStreamGrpcClient);
         verifyNoMoreInteractions(blockStreamManager);
     }
+
+    @Test
+    void testMillisPerBlockStreaming_streamSuccessBecomesFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.MILLIS_PER_BLOCK);
+        when(blockStreamConfig.millisecondsPerBlock()).thenReturn(1000);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient, blockStreamManager);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
+
+        publisherModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(2)).getNextBlock();
+    }
+
+    @Test
+    void testConstantRateStreaming_streamSuccessBecomesFalse() throws Exception {
+        when(blockStreamConfig.streamingMode()).thenReturn(StreamingMode.CONSTANT_RATE);
+        when(blockStreamConfig.delayBetweenBlockItems()).thenReturn(0);
+        when(blockStreamConfig.maxBlockItemsToStream()).thenReturn(100);
+
+        publisherModeHandler = new PublisherModeHandler(blockStreamConfig, publishStreamGrpcClient, blockStreamManager);
+
+        Block block1 = mock(Block.class);
+        Block block2 = mock(Block.class);
+
+        BlockItem blockItem1 = mock(BlockItem.class);
+        BlockItem blockItem2 = mock(BlockItem.class);
+
+        when(block1.items()).thenReturn(Arrays.asList(blockItem1));
+        when(block2.items()).thenReturn(Arrays.asList(blockItem2));
+
+        when(blockStreamManager.getNextBlock())
+                .thenReturn(block1)
+                .thenReturn(block2)
+                .thenReturn(null);
+
+        when(publishStreamGrpcClient.streamBlock(block1)).thenReturn(true);
+        when(publishStreamGrpcClient.streamBlock(block2)).thenReturn(false);
+
+        publisherModeHandler.start();
+
+        verify(publishStreamGrpcClient).streamBlock(block1);
+        verify(publishStreamGrpcClient).streamBlock(block2);
+        verifyNoMoreInteractions(publishStreamGrpcClient);
+        verify(blockStreamManager, times(2)).getNextBlock();
+    }
 }


### PR DESCRIPTION
**Description**:
This PR adds simple error handling mechanism in the publisher, when onError is invoked.

**Related issue(s)**:

Fixes #315 

**Notes for reviewer**:
This change is probably a very first version of the error handling mechanism that we want to have. We'd probably want to add checks and do different things, depending on the error. But as we are still in the early stage, this will do for now.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
