### PR TITLE
test: Add E2E test and enhance simulator flexibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,8 @@ server/src/test/resources/test_output/
 
 # simulator files, this files are un-tarred before build
 /simulator/src/main/resources/block-0.0.3/
+/common/bin
+/server/bin
+/simulator/bin
+/stream/bin
+/suites/bin

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
+bin/
 
 # Package Files #
 *.jar
@@ -58,8 +59,3 @@ server/src/test/resources/test_output/
 
 # simulator files, this files are un-tarred before build
 /simulator/src/main/resources/block-0.0.3/
-/common/bin
-/server/bin
-/simulator/bin
-/stream/bin
-/suites/bin

--- a/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
+++ b/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
@@ -76,6 +76,42 @@ public final class Preconditions {
     }
 
     /**
+     * This method asserts a given long is a whole number. A long is whole
+     * if it is greater or equal to zero.
+     *
+     * @param toCheck the long to check if it is a whole number
+     * @return the number to check if it is whole number
+     * @throws IllegalArgumentException if the input number to check is not
+     * positive
+     */
+    public static long requireWhole(final long toCheck) {
+        return requireWhole(toCheck, null);
+    }
+
+    /**
+     * This method asserts a given long is a whole number. A long is whole
+     * if it is greater or equal to zero.
+     *
+     * @param toCheck the long to check if it is a whole number
+     * @param errorMessage the error message to be used in the exception if the
+     * input long to check is not a whole number, if null, a default message will
+     * be used
+     * @return the number to check if it is whole number
+     * @throws IllegalArgumentException if the input number to check is not
+     * positive
+     */
+    public static long requireWhole(final long toCheck, final String errorMessage) {
+        if (toCheck >= 0) {
+            return toCheck;
+        }
+
+        final String message = Objects.isNull(errorMessage)
+                ? "The input integer [%d] is required be whole.".formatted(toCheck)
+                : errorMessage;
+        throw new IllegalArgumentException(message);
+    }
+
+    /**
      * This method asserts a given integer is a positive. An integer is positive
      * if it is NOT equal to zero and is greater than zero.
      *

--- a/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
+++ b/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
@@ -183,11 +183,17 @@ public final class CommonsTestUtility {
     }
 
     /**
-     * Zero and some negative integers.
+     * Some whole numbers.
      */
-    public static Stream<Arguments> zeroAndNegativeIntegers() {
+    public static Stream<Arguments> wholeNumbers() {
+        return Stream.concat(Stream.of(Arguments.of(0)), positiveIntegers());
+    }
+
+    /**
+     * Some negative integers.
+     */
+    public static Stream<Arguments> negativeIntegers() {
         return Stream.of(
-                Arguments.of(0),
                 Arguments.of(-1),
                 Arguments.of(-2),
                 Arguments.of(-3),
@@ -199,6 +205,13 @@ public final class CommonsTestUtility {
                 Arguments.of(-100_000),
                 Arguments.of(-1_000_000),
                 Arguments.of(-10_000_000));
+    }
+
+    /**
+     * Zero and some negative integers.
+     */
+    public static Stream<Arguments> zeroAndNegativeIntegers() {
+        return Stream.concat(Stream.of(Arguments.of(0)), negativeIntegers());
     }
 
     private CommonsTestUtility() {}

--- a/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
@@ -69,6 +69,45 @@ class PreconditionsTest {
 
     /**
      * This test aims to verify that the
+     * {@link Preconditions#requireWhole(long)} will return the input 'toTest'
+     * parameter if the positive check passes. Test includes overloads.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#wholeNumbers")
+    void testRequireWholePass(final int toTest) {
+        final Consumer<Integer> asserts =
+                actual -> assertThat(actual).isGreaterThanOrEqualTo(0).isEqualTo(toTest);
+
+        final int actual = (int) Preconditions.requireWhole(toTest);
+        assertThat(actual).satisfies(asserts);
+
+        final int actualOverload = (int) Preconditions.requireWhole(toTest, "test error message");
+        assertThat(actualOverload).satisfies(asserts);
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link Preconditions#requireWhole(long)} will throw an
+     * {@link IllegalArgumentException} if the positive check fails. Test
+     * includes overloads.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#negativeIntegers")
+    void testRequireWholeFail(final int toTest) {
+        assertThatIllegalArgumentException().isThrownBy(() -> Preconditions.requireWhole(toTest));
+
+        final String testErrorMessage = "test error message";
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> Preconditions.requireWhole(toTest, testErrorMessage))
+                .withMessage(testErrorMessage);
+    }
+
+    /**
+     * This test aims to verify that the
      * {@link Preconditions#requirePositive(int)} will return the input 'toTest'
      * parameter if the positive check passes. Test includes overloads.
      *

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -20,6 +20,7 @@ import static java.lang.System.Logger.Level.INFO;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.StreamStatus;
 import com.hedera.block.simulator.config.types.SimulatorMode;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
@@ -102,9 +103,25 @@ public class BlockStreamSimulatorApp {
     }
 
     /** Stops the Block Stream Simulator and closes off all grpc channels. */
-    public void stop() {
+    public void stop() throws InterruptedException {
+        simulatorModeHandler.stop();
+        publishStreamGrpcClient.completeStreaming();
+
         publishStreamGrpcClient.shutdown();
         isRunning.set(false);
+
         LOGGER.log(INFO, "Block Stream Simulator has stopped");
+    }
+
+    /**
+     * Gets the stream status from both the publisher and the consumer.
+     *
+     * @return the stream status
+     */
+    public StreamStatus getStreamStatus() {
+        return StreamStatus.builder()
+                .publishedBlocks(publishStreamGrpcClient.getPublishedBlocks())
+                .lastKnownPublisherStatuses(publishStreamGrpcClient.getLastKnownStatuses())
+                .build();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -102,7 +102,11 @@ public class BlockStreamSimulatorApp {
         return isRunning.get();
     }
 
-    /** Stops the Block Stream Simulator and closes off all grpc channels. */
+    /**
+     * Stops the Block Stream Simulator and closes off all grpc channels.
+     *
+     * @throws InterruptedException if the thread is interrupted
+     */
     public void stop() throws InterruptedException {
         simulatorModeHandler.stop();
         publishStreamGrpcClient.completeStreaming();

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -19,6 +19,8 @@ package com.hedera.block.simulator.config.data;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents the status of the stream.
  *
@@ -87,7 +89,8 @@ public record StreamStatus(
          * @return the builder instance
          */
         public Builder lastKnownPublisherStatuses(List<String> lastKnownPublisherStatuses) {
-            this.lastKnownPublisherStatuses = lastKnownPublisherStatuses;
+            requireNonNull(lastKnownPublisherStatuses);
+            this.lastKnownPublisherStatuses = new ArrayList<>(lastKnownPublisherStatuses);
             return this;
         }
 
@@ -98,7 +101,8 @@ public record StreamStatus(
          * @return the builder instance
          */
         public Builder lastKnownConsumersStatuses(List<String> lastKnownConsumersStatuses) {
-            this.lastKnownConsumersStatuses = lastKnownConsumersStatuses;
+            requireNonNull(lastKnownConsumersStatuses);
+            this.lastKnownConsumersStatuses = new ArrayList<>(lastKnownConsumersStatuses);
             return this;
         }
 

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the status of the stream.
+ *
+ * @param publishedBlocks the number of published blocks
+ * @param consumedBlocks the number of consumed blocks
+ * @param lastKnownPublisherStatuses the last known publisher statuses
+ * @param lastKnownConsumersStatuses the last known consumers statuses
+ */
+public record StreamStatus(
+        int publishedBlocks,
+        int consumedBlocks,
+        List<String> lastKnownPublisherStatuses,
+        List<String> lastKnownConsumersStatuses) {
+
+    /**
+     * Creates a new {@link Builder} instance for constructing a {@code StreamStatus}.
+     *
+     * @return a new {@code Builder}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * A builder for creating instances of {@link StreamStatus}.
+     */
+    public static class Builder {
+        private int publishedBlocks = 0;
+        private int consumedBlocks = 0;
+        private List<String> lastKnownPublisherStatuses = new ArrayList<>();
+        private List<String> lastKnownConsumersStatuses = new ArrayList<>();
+
+        /**
+         * Creates a new instance of the {@code Builder} class with default configuration values.
+         */
+        public Builder() {
+            // Default constructor
+        }
+
+        /**
+         * Sets the number of published blocks.
+         *
+         * @param publishedBlocks the number of published blocks
+         * @return the builder instance
+         */
+        public Builder publishedBlocks(int publishedBlocks) {
+            this.publishedBlocks = publishedBlocks;
+            return this;
+        }
+
+        /**
+         * Sets the number of consumed blocks.
+         *
+         * @param consumedBlocks the number of consumed blocks
+         * @return the builder instance
+         */
+        public Builder consumedBlocks(int consumedBlocks) {
+            this.consumedBlocks = consumedBlocks;
+            return this;
+        }
+
+        /**
+         * Sets the last known publisher statuses.
+         *
+         * @param lastKnownPublisherStatuses the last known publisher statuses
+         * @return the builder instance
+         */
+        public Builder lastKnownPublisherStatuses(List<String> lastKnownPublisherStatuses) {
+            this.lastKnownPublisherStatuses = lastKnownPublisherStatuses;
+            return this;
+        }
+
+        /**
+         * Sets the last known consumers statuses.
+         *
+         * @param lastKnownConsumersStatuses the last known consumers statuses
+         * @return the builder instance
+         */
+        public Builder lastKnownConsumersStatuses(List<String> lastKnownConsumersStatuses) {
+            this.lastKnownConsumersStatuses = lastKnownConsumersStatuses;
+            return this;
+        }
+
+        /**
+         * Builds a new {@link StreamStatus} instance.
+         *
+         * @return a new {@link StreamStatus} instance
+         */
+        public StreamStatus build() {
+            return new StreamStatus(
+                    publishedBlocks, consumedBlocks, lastKnownPublisherStatuses, lastKnownConsumersStatuses);
+        }
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -16,13 +16,11 @@
 
 package com.hedera.block.simulator.config.data;
 
-import com.hedera.block.common.utils.Preconditions;
+import static com.hedera.block.common.utils.Preconditions.requirePositive;
+import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.hedera.block.common.utils.Preconditions.requirePositive;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Represents the status of the stream.

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -16,7 +16,7 @@
 
 package com.hedera.block.simulator.config.data;
 
-import static com.hedera.block.common.utils.Preconditions.requirePositive;
+import static com.hedera.block.common.utils.Preconditions.requireWhole;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -31,8 +31,8 @@ import java.util.List;
  * @param lastKnownConsumersStatuses the last known consumers statuses
  */
 public record StreamStatus(
-        int publishedBlocks,
-        int consumedBlocks,
+        long publishedBlocks,
+        long consumedBlocks,
         List<String> lastKnownPublisherStatuses,
         List<String> lastKnownConsumersStatuses) {
 
@@ -49,8 +49,8 @@ public record StreamStatus(
      * A builder for creating instances of {@link StreamStatus}.
      */
     public static class Builder {
-        private int publishedBlocks = 0;
-        private int consumedBlocks = 0;
+        private long publishedBlocks = 0;
+        private long consumedBlocks = 0;
         private List<String> lastKnownPublisherStatuses = new ArrayList<>();
         private List<String> lastKnownConsumersStatuses = new ArrayList<>();
 
@@ -67,8 +67,8 @@ public record StreamStatus(
          * @param publishedBlocks the number of published blocks
          * @return the builder instance
          */
-        public Builder publishedBlocks(int publishedBlocks) {
-            requirePositive(publishedBlocks);
+        public Builder publishedBlocks(long publishedBlocks) {
+            requireWhole(publishedBlocks);
             this.publishedBlocks = publishedBlocks;
             return this;
         }
@@ -79,8 +79,8 @@ public record StreamStatus(
          * @param consumedBlocks the number of consumed blocks
          * @return the builder instance
          */
-        public Builder consumedBlocks(int consumedBlocks) {
-            requirePositive(consumedBlocks);
+        public Builder consumedBlocks(long consumedBlocks) {
+            requireWhole(consumedBlocks);
             this.consumedBlocks = consumedBlocks;
             return this;
         }

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -16,9 +16,12 @@
 
 package com.hedera.block.simulator.config.data;
 
+import com.hedera.block.common.utils.Preconditions;
+
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.hedera.block.common.utils.Preconditions.requirePositive;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -67,6 +70,7 @@ public record StreamStatus(
          * @return the builder instance
          */
         public Builder publishedBlocks(int publishedBlocks) {
+            requirePositive(publishedBlocks);
             this.publishedBlocks = publishedBlocks;
             return this;
         }
@@ -78,6 +82,7 @@ public record StreamStatus(
          * @return the builder instance
          */
         public Builder consumedBlocks(int consumedBlocks) {
+            requirePositive(consumedBlocks);
             this.consumedBlocks = consumedBlocks;
             return this;
         }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -57,7 +57,7 @@ public interface PublishStreamGrpcClient {
      *
      * @return the number of published blocks
      */
-    int getPublishedBlocks();
+    long getPublishedBlocks();
 
     /**
      * Gets the last known statuses.

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -46,6 +46,27 @@ public interface PublishStreamGrpcClient {
     boolean streamBlock(Block block);
 
     /**
+     * Sends a onCompleted message to the server and waits for a short period of time to ensure the message is sent.
+     *
+     * @throws InterruptedException if the thread is interrupted
+     */
+    void completeStreaming() throws InterruptedException;
+
+    /**
+     * Gets the number of published blocks.
+     *
+     * @return the number of published blocks
+     */
+    int getPublishedBlocks();
+
+    /**
+     * Gets the last known statuses.
+     *
+     * @return the last known statuses
+     */
+    List<String> getLastKnownStatuses();
+
+    /**
      * Shutdowns the channel.
      */
     void shutdown();

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -35,6 +35,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
@@ -45,151 +46,149 @@ import javax.inject.Inject;
  */
 public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
-        private final System.Logger LOGGER = System.getLogger(getClass().getName());
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
-        private StreamObserver<PublishStreamRequest> requestStreamObserver;
-        private final BlockStreamConfig blockStreamConfig;
-        private final GrpcConfig grpcConfig;
-        private final AtomicBoolean streamEnabled;
-        private ManagedChannel channel;
-        private final MetricsService metricsService;
-        private final List<String> lastKnownStatuses;
-        private int publishedBlocks;
+    private StreamObserver<PublishStreamRequest> requestStreamObserver;
+    private final BlockStreamConfig blockStreamConfig;
+    private final GrpcConfig grpcConfig;
+    private final AtomicBoolean streamEnabled;
+    private ManagedChannel channel;
+    private final MetricsService metricsService;
+    private final List<String> lastKnownStatuses = new ArrayList<>();
+    private int publishedBlocks;
 
-        /**
-         * Creates a new PublishStreamGrpcClientImpl instance.
-         *
-         * @param grpcConfig        the gRPC configuration
-         * @param blockStreamConfig the block stream configuration
-         * @param metricsService    the metrics service
-         * @param streamEnabled     the flag responsible for enabling and disabling of
-         *                          the streaming
-         */
-        @Inject
-        public PublishStreamGrpcClientImpl(
-                        @NonNull final GrpcConfig grpcConfig,
-                        @NonNull final BlockStreamConfig blockStreamConfig,
-                        @NonNull final MetricsService metricsService,
-                        @NonNull final AtomicBoolean streamEnabled) {
-                this.grpcConfig = requireNonNull(grpcConfig);
-                this.blockStreamConfig = requireNonNull(blockStreamConfig);
-                this.metricsService = requireNonNull(metricsService);
-                this.streamEnabled = requireNonNull(streamEnabled);
+    /**
+     * Creates a new PublishStreamGrpcClientImpl instance.
+     *
+     * @param grpcConfig        the gRPC configuration
+     * @param blockStreamConfig the block stream configuration
+     * @param metricsService    the metrics service
+     * @param streamEnabled     the flag responsible for enabling and disabling of
+     *                          the streaming
+     */
+    @Inject
+    public PublishStreamGrpcClientImpl(
+            @NonNull final GrpcConfig grpcConfig,
+            @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull final MetricsService metricsService,
+            @NonNull final AtomicBoolean streamEnabled) {
+        this.grpcConfig = requireNonNull(grpcConfig);
+        this.blockStreamConfig = requireNonNull(blockStreamConfig);
+        this.metricsService = requireNonNull(metricsService);
+        this.streamEnabled = requireNonNull(streamEnabled);
+    }
 
-                lastKnownStatuses = new ArrayList<>();
-                publishedBlocks = 0;
+    /**
+     * Initialize the channel and stub for publishBlockStream with the desired
+     * configuration.
+     */
+    @Override
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
+                .usePlaintext()
+                .build();
+        BlockStreamServiceGrpc.BlockStreamServiceStub stub = BlockStreamServiceGrpc.newStub(channel);
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
+        requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
+        lastKnownStatuses.clear();
+        publishedBlocks = 0;
+    }
+
+    /**
+     * The PublishStreamObserver class implements the StreamObserver interface to
+     * observe the
+     * stream.
+     */
+    @Override
+    public boolean streamBlockItem(List<BlockItem> blockItems) {
+
+        if (streamEnabled.get()) {
+            requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
+                    .setBlockItems(BlockItemSet.newBuilder()
+                            .addAllBlockItems(blockItems)
+                            .build())
+                    .build());
+
+            metricsService.get(LiveBlockItemsSent).add(blockItems.size());
+            LOGGER.log(
+                    INFO,
+                    "Number of block items sent: "
+                            + metricsService.get(LiveBlockItemsSent).get());
+        } else {
+            LOGGER.log(ERROR, "Not allowed to send next batch of block items");
         }
 
-        /**
-         * Initialize the channel and stub for publishBlockStream with the desired
-         * configuration.
-         */
-        @Override
-        public void init() {
-                channel = ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
-                                .usePlaintext()
-                                .build();
-                BlockStreamServiceGrpc.BlockStreamServiceStub stub = BlockStreamServiceGrpc.newStub(channel);
-                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
-                                lastKnownStatuses);
-                requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
+        return streamEnabled.get();
+    }
+
+    /**
+     * The PublishStreamObserver class implements the StreamObserver interface to
+     * observe the
+     * stream.
+     */
+    @Override
+    public boolean streamBlock(Block block) {
+
+        List<List<BlockItem>> streamingBatches =
+                ChunkUtils.chunkify(block.getItemsList(), blockStreamConfig.blockItemsBatchSize());
+        for (List<BlockItem> streamingBatch : streamingBatches) {
+            if (streamEnabled.get()) {
+                requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
+                        .setBlockItems(BlockItemSet.newBuilder()
+                                .addAllBlockItems(streamingBatch)
+                                .build())
+                        .build());
+                metricsService.get(LiveBlockItemsSent).add(streamingBatch.size());
+                LOGGER.log(
+                        DEBUG,
+                        "Number of block items sent: "
+                                + metricsService.get(LiveBlockItemsSent).get());
+            } else {
+                LOGGER.log(ERROR, "Not allowed to send next batch of block items");
+                break;
+            }
         }
+        publishedBlocks++;
+        return streamEnabled.get();
+    }
 
-        /**
-         * The PublishStreamObserver class implements the StreamObserver interface to
-         * observe the
-         * stream.
-         */
-        @Override
-        public boolean streamBlockItem(List<BlockItem> blockItems) {
+    /**
+     * Sends a onCompleted message to the server and waits for a short period of
+     * time to ensure the message is sent.
+     *
+     * @throws InterruptedException if the thread is interrupted
+     */
+    @Override
+    public void completeStreaming() throws InterruptedException {
+        requestStreamObserver.onCompleted();
+        Thread.sleep(100);
+    }
 
-                if (streamEnabled.get()) {
-                        requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
-                                        .setBlockItems(BlockItemSet.newBuilder()
-                                                        .addAllBlockItems(blockItems)
-                                                        .build())
-                                        .build());
+    /**
+     * Gets the number of published blocks.
+     *
+     * @return the number of published blocks
+     */
+    @Override
+    public int getPublishedBlocks() {
+        return publishedBlocks;
+    }
 
-                        metricsService.get(LiveBlockItemsSent).add(blockItems.size());
-                        LOGGER.log(
-                                        INFO,
-                                        "Number of block items sent: "
-                                                        + metricsService.get(LiveBlockItemsSent).get());
-                } else {
-                        LOGGER.log(ERROR, "Not allowed to send next batch of block items");
-                }
+    /**
+     * Gets the last known statuses.
+     *
+     * @return the last known statuses
+     */
+    @Override
+    public List<String> getLastKnownStatuses() {
+        return lastKnownStatuses;
+    }
 
-                return streamEnabled.get();
-        }
-
-        /**
-         * The PublishStreamObserver class implements the StreamObserver interface to
-         * observe the
-         * stream.
-         */
-        @Override
-        public boolean streamBlock(Block block) {
-
-                List<List<BlockItem>> streamingBatches = ChunkUtils.chunkify(block.getItemsList(),
-                                blockStreamConfig.blockItemsBatchSize());
-                for (List<BlockItem> streamingBatch : streamingBatches) {
-                        if (streamEnabled.get()) {
-                                requestStreamObserver.onNext(PublishStreamRequest.newBuilder()
-                                                .setBlockItems(BlockItemSet.newBuilder()
-                                                                .addAllBlockItems(streamingBatch)
-                                                                .build())
-                                                .build());
-                                metricsService.get(LiveBlockItemsSent).add(streamingBatch.size());
-                                LOGGER.log(
-                                                DEBUG,
-                                                "Number of block items sent: "
-                                                                + metricsService.get(LiveBlockItemsSent).get());
-                        } else {
-                                LOGGER.log(ERROR, "Not allowed to send next batch of block items");
-                                break;
-                        }
-                }
-                publishedBlocks++;
-                return streamEnabled.get();
-        }
-
-        /**
-         * Sends a onCompleted message to the server and waits for a short period of
-         * time to ensure the message is sent.
-         *
-         * @throws InterruptedException if the thread is interrupted
-         */
-        @Override
-        public void completeStreaming() throws InterruptedException {
-                requestStreamObserver.onCompleted();
-                Thread.sleep(100);
-        }
-
-        /**
-         * Gets the number of published blocks.
-         *
-         * @return the number of published blocks
-         */
-        @Override
-        public int getPublishedBlocks() {
-                return publishedBlocks;
-        }
-
-        /**
-         * Gets the last known statuses.
-         *
-         * @return the last known statuses
-         */
-        @Override
-        public List<String> getLastKnownStatuses() {
-                return lastKnownStatuses;
-        }
-
-        /**
-         * Shutdowns the channel.
-         */
-        @Override
-        public void shutdown() {
-                channel.shutdown();
-        }
+    /**
+     * Shutdowns the channel.
+     */
+    @Override
+    public void shutdown() {
+        channel.shutdown();
+    }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImpl.java
@@ -181,7 +181,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      */
     @Override
     public List<String> getLastKnownStatuses() {
-        return lastKnownStatuses;
+        return List.copyOf(lastKnownStatuses);
     }
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
@@ -36,7 +36,9 @@ public final class SimulatorMetricTypes {
     public enum Counter implements SimulatorMetricMetadata {
         // Standard counters
         /** The number of live block items sent by the simulator . */
-        LiveBlockItemsSent("live_block_items_sent", "Live Block Items Sent");
+        LiveBlockItemsSent("live_block_items_sent", "Live Block Items Sent"),
+        /** The number of live blocks sent by the simulator */
+        LiveBlocksSent("live_blocks_sent", "Live Blocks Sent");
 
         private final String grafanaLabel;
         private final String description;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -56,4 +56,12 @@ public class CombinedModeHandler implements SimulatorModeHandler {
     public void start() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Stops the handler and manager from streaming.
+     */
+    @Override
+    public void stop() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -53,4 +53,12 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
     public void start() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Stops the handler and manager from streaming.
+     */
+    @Override
+    public void stop() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -140,10 +140,9 @@ public class PublisherModeHandler implements SimulatorModeHandler {
     private void constantRateStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
         int delayMSBetweenBlockItems = delayBetweenBlockItems / NANOS_PER_MILLI;
         int delayNSBetweenBlockItems = delayBetweenBlockItems % NANOS_PER_MILLI;
-        boolean streamBlockItem = true;
         int blockItemsStreamed = 0;
 
-        while (streamBlockItem && shouldPublish.get()) {
+        while (shouldPublish.get()) {
             // get block
             Block block = blockStreamManager.getNextBlock();
 
@@ -162,7 +161,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
 
             if (blockItemsStreamed >= blockStreamConfig.maxBlockItemsToStream()) {
                 LOGGER.log(INFO, "Block Stream Simulator has reached the maximum number of block items to" + " stream");
-                streamBlockItem = false;
+                shouldPublish.set(false);
             }
         }
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -48,4 +48,9 @@ public interface SimulatorModeHandler {
      * @throws InterruptedException if the thread running the simulator is interrupted
      */
     void start() throws BlockSimulatorParsingException, IOException, InterruptedException;
+
+    /**
+     * Stops the handler and manager from streaming.
+     */
+    void stop();
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -84,7 +84,7 @@ class BlockStreamSimulatorTest {
         try {
             blockStreamSimulator.stop();
         } catch (UnsupportedOperationException e) {
-            // ignore for now, temporary until consumer mode in simulator is added
+            // @todo (121) Implement consumer logic in the Simulator, which will fix this
         }
     }
 

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -18,14 +18,19 @@ package com.hedera.block.simulator;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.config.data.StreamStatus;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.hedera.block.simulator.generator.BlockStreamManager;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
@@ -130,9 +135,10 @@ class BlockStreamSimulatorTest {
     }
 
     @Test
-    void stop_doesNotThrowException() {
+    void stop_doesNotThrowException() throws InterruptedException {
         assertDoesNotThrow(() -> blockStreamSimulator.stop());
         assertFalse(blockStreamSimulator.isRunning());
+        verify(publishStreamGrpcClient, atLeast(1)).completeStreaming();
     }
 
     @Test
@@ -236,6 +242,29 @@ class BlockStreamSimulatorTest {
         assertThrows(NullPointerException.class, () -> {
             new BlockStreamSimulatorApp(configuration, blockStreamManager, publishStreamGrpcClient, metricsService);
         });
+    }
+
+    @Test
+    void testGetStreamStatus() {
+        int expectedPublishedBlocks = 5;
+        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
+
+        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
+        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
+
+        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
+
+        assertNotNull(streamStatus, "StreamStatus should not be null");
+        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
+        assertEquals(
+                expectedLastKnownStatuses,
+                streamStatus.lastKnownPublisherStatuses(),
+                "Last known statuses should match");
+        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
+        assertEquals(
+                0,
+                streamStatus.lastKnownConsumersStatuses().size(),
+                "Last known consumers statuses should be empty by default");
     }
 
     private List<LogRecord> captureLogs() {

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -75,8 +75,12 @@ class BlockStreamSimulatorTest {
     }
 
     @AfterEach
-    void tearDown() {
-        blockStreamSimulator.stop();
+    void tearDown() throws InterruptedException {
+        try {
+            blockStreamSimulator.stop();
+        } catch (UnsupportedOperationException e) {
+            // ignore for now, temporary until consumer mode in simulator is added
+        }
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -246,7 +246,7 @@ class BlockStreamSimulatorTest {
 
     @Test
     void testGetStreamStatus() {
-        int expectedPublishedBlocks = 5;
+        long expectedPublishedBlocks = 5;
         List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
 
         when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
@@ -19,7 +19,7 @@ package com.hedera.block.simulator.config.data;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -178,11 +178,11 @@ class StreamStatusTest {
         publisherStatuses.add("Publisher2");
         consumerStatuses.add("Consumer2");
 
-        assertEquals(
+        assertNotEquals(
                 List.of("Publisher1", "Publisher2"),
                 streamStatus.lastKnownPublisherStatuses(),
                 "lastKnownPublisherStatuses should be immutable");
-        assertEquals(
+        assertNotEquals(
                 List.of("Consumer1", "Consumer2"),
                 streamStatus.lastKnownConsumersStatuses(),
                 "lastKnownConsumersStatuses should be immutable");
@@ -190,15 +190,12 @@ class StreamStatusTest {
 
     @Test
     void testNullLists() {
-        StreamStatus streamStatus = StreamStatus.builder()
+        assertThrows(NullPointerException.class, () -> StreamStatus.builder()
                 .publishedBlocks(0)
                 .consumedBlocks(0)
                 .lastKnownPublisherStatuses(null)
                 .lastKnownConsumersStatuses(null)
-                .build();
-
-        assertNull(streamStatus.lastKnownPublisherStatuses(), "lastKnownPublisherStatuses should be null");
-        assertNull(streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should be null");
+                .build());
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config.data;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class StreamStatusTest {
+
+    @Test
+    void testBuilderDefaultValues() {
+        StreamStatus streamStatus = StreamStatus.builder().build();
+
+        assertEquals(0, streamStatus.publishedBlocks(), "Default publishedBlocks should be 0");
+        assertEquals(0, streamStatus.consumedBlocks(), "Default consumedBlocks should be 0");
+        assertNotNull(streamStatus.lastKnownPublisherStatuses(), "lastKnownPublisherStatuses should not be null");
+        assertTrue(streamStatus.lastKnownPublisherStatuses().isEmpty(), "lastKnownPublisherStatuses should be empty");
+        assertNotNull(streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should not be null");
+        assertTrue(streamStatus.lastKnownConsumersStatuses().isEmpty(), "lastKnownConsumersStatuses should be empty");
+    }
+
+    @Test
+    void testBuilderWithValues() {
+        List<String> publisherStatuses = List.of("Publisher1", "Publisher2");
+        List<String> consumerStatuses = List.of("Consumer1");
+
+        StreamStatus streamStatus = StreamStatus.builder()
+                .publishedBlocks(10)
+                .consumedBlocks(8)
+                .lastKnownPublisherStatuses(publisherStatuses)
+                .lastKnownConsumersStatuses(consumerStatuses)
+                .build();
+
+        assertEquals(10, streamStatus.publishedBlocks(), "publishedBlocks should be 10");
+        assertEquals(8, streamStatus.consumedBlocks(), "consumedBlocks should be 8");
+        assertEquals(
+                publisherStatuses,
+                streamStatus.lastKnownPublisherStatuses(),
+                "lastKnownPublisherStatuses should match");
+        assertEquals(
+                consumerStatuses, streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should match");
+    }
+
+    @Test
+    void testBuilderSetters() {
+        StreamStatus.Builder builder = StreamStatus.builder();
+
+        builder.publishedBlocks(5);
+        builder.consumedBlocks(3);
+        builder.lastKnownPublisherStatuses(List.of("PubStatus"));
+        builder.lastKnownConsumersStatuses(List.of("ConStatus"));
+
+        StreamStatus streamStatus = builder.build();
+
+        assertEquals(5, streamStatus.publishedBlocks(), "publishedBlocks should be 5");
+        assertEquals(3, streamStatus.consumedBlocks(), "consumedBlocks should be 3");
+        assertEquals(
+                List.of("PubStatus"),
+                streamStatus.lastKnownPublisherStatuses(),
+                "lastKnownPublisherStatuses should match");
+        assertEquals(
+                List.of("ConStatus"),
+                streamStatus.lastKnownConsumersStatuses(),
+                "lastKnownConsumersStatuses should match");
+    }
+
+    @Test
+    void testBuilderDefaultConstructor() {
+        StreamStatus.Builder builder = new StreamStatus.Builder();
+
+        assertNotNull(builder, "Builder should not be null");
+
+        StreamStatus streamStatus = builder.build();
+
+        assertEquals(0, streamStatus.publishedBlocks(), "Default publishedBlocks should be 0");
+        assertEquals(0, streamStatus.consumedBlocks(), "Default consumedBlocks should be 0");
+        assertNotNull(streamStatus.lastKnownPublisherStatuses(), "lastKnownPublisherStatuses should not be null");
+        assertTrue(streamStatus.lastKnownPublisherStatuses().isEmpty(), "lastKnownPublisherStatuses should be empty");
+        assertNotNull(streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should not be null");
+        assertTrue(streamStatus.lastKnownConsumersStatuses().isEmpty(), "lastKnownConsumersStatuses should be empty");
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        List<String> publisherStatuses = List.of("Publisher1");
+        List<String> consumerStatuses = List.of("Consumer1");
+
+        StreamStatus streamStatus1 = StreamStatus.builder()
+                .publishedBlocks(5)
+                .consumedBlocks(3)
+                .lastKnownPublisherStatuses(publisherStatuses)
+                .lastKnownConsumersStatuses(consumerStatuses)
+                .build();
+
+        StreamStatus streamStatus2 = StreamStatus.builder()
+                .publishedBlocks(5)
+                .consumedBlocks(3)
+                .lastKnownPublisherStatuses(publisherStatuses)
+                .lastKnownConsumersStatuses(consumerStatuses)
+                .build();
+
+        assertEquals(streamStatus1, streamStatus2, "StreamStatus instances should be equal");
+        assertEquals(streamStatus1.hashCode(), streamStatus2.hashCode(), "Hash codes should be equal");
+    }
+
+    @Test
+    void testNotEquals() {
+        StreamStatus streamStatus1 =
+                StreamStatus.builder().publishedBlocks(5).consumedBlocks(3).build();
+
+        StreamStatus streamStatus2 =
+                StreamStatus.builder().publishedBlocks(6).consumedBlocks(3).build();
+
+        assertNotEquals(streamStatus1, streamStatus2, "StreamStatus instances should not be equal");
+    }
+
+    @Test
+    void testToString() {
+        List<String> publisherStatuses = List.of("Pub1");
+        List<String> consumerStatuses = List.of("Con1");
+
+        StreamStatus streamStatus = StreamStatus.builder()
+                .publishedBlocks(5)
+                .consumedBlocks(3)
+                .lastKnownPublisherStatuses(publisherStatuses)
+                .lastKnownConsumersStatuses(consumerStatuses)
+                .build();
+
+        String toString = streamStatus.toString();
+
+        assertNotNull(toString, "toString() should not return null");
+        assertTrue(toString.contains("publishedBlocks=5"), "toString() should contain 'publishedBlocks=5'");
+        assertTrue(toString.contains("consumedBlocks=3"), "toString() should contain 'consumedBlocks=3'");
+        assertTrue(
+                toString.contains("lastKnownPublisherStatuses=[Pub1]"),
+                "toString() should contain 'lastKnownPublisherStatuses=[Pub1]'");
+        assertTrue(
+                toString.contains("lastKnownConsumersStatuses=[Con1]"),
+                "toString() should contain 'lastKnownConsumersStatuses=[Con1]'");
+    }
+
+    @Test
+    void testStatusesLists() {
+        List<String> publisherStatuses = new ArrayList<>();
+        List<String> consumerStatuses = new ArrayList<>();
+
+        publisherStatuses.add("Publisher1");
+        consumerStatuses.add("Consumer1");
+
+        StreamStatus streamStatus = StreamStatus.builder()
+                .publishedBlocks(1)
+                .consumedBlocks(1)
+                .lastKnownPublisherStatuses(publisherStatuses)
+                .lastKnownConsumersStatuses(consumerStatuses)
+                .build();
+
+        publisherStatuses.add("Publisher2");
+        consumerStatuses.add("Consumer2");
+
+        assertEquals(
+                List.of("Publisher1", "Publisher2"),
+                streamStatus.lastKnownPublisherStatuses(),
+                "lastKnownPublisherStatuses should be immutable");
+        assertEquals(
+                List.of("Consumer1", "Consumer2"),
+                streamStatus.lastKnownConsumersStatuses(),
+                "lastKnownConsumersStatuses should be immutable");
+    }
+
+    @Test
+    void testNullLists() {
+        StreamStatus streamStatus = StreamStatus.builder()
+                .publishedBlocks(0)
+                .consumedBlocks(0)
+                .lastKnownPublisherStatuses(null)
+                .lastKnownConsumersStatuses(null)
+                .build();
+
+        assertNull(streamStatus.lastKnownPublisherStatuses(), "lastKnownPublisherStatuses should be null");
+        assertNull(streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should be null");
+    }
+
+    @Test
+    void testBuilderChaining() {
+        StreamStatus streamStatus = StreamStatus.builder()
+                .publishedBlocks(2)
+                .consumedBlocks(2)
+                .lastKnownPublisherStatuses(List.of("PubStatus"))
+                .lastKnownConsumersStatuses(List.of("ConStatus"))
+                .build();
+
+        assertEquals(2, streamStatus.publishedBlocks(), "publishedBlocks should be 2");
+        assertEquals(2, streamStatus.consumedBlocks(), "consumedBlocks should be 2");
+        assertEquals(
+                List.of("PubStatus"),
+                streamStatus.lastKnownPublisherStatuses(),
+                "lastKnownPublisherStatuses should match");
+        assertEquals(
+                List.of("ConStatus"),
+                streamStatus.lastKnownConsumersStatuses(),
+                "lastKnownConsumersStatuses should match");
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -17,6 +17,7 @@
 package com.hedera.block.simulator.grpc;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -91,11 +92,15 @@ class PublishStreamGrpcClientImplTest {
                 new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
 
         publishStreamGrpcClient.init();
+        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
+
         boolean result = publishStreamGrpcClient.streamBlock(block);
         assertTrue(result);
 
         boolean result1 = publishStreamGrpcClient.streamBlock(block1);
         assertTrue(result1);
+
+        assertEquals(2, publishStreamGrpcClient.getPublishedBlocks());
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator.grpc;
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -101,6 +102,22 @@ class PublishStreamGrpcClientImplTest {
         assertTrue(result1);
 
         assertEquals(2, publishStreamGrpcClient.getPublishedBlocks());
+    }
+
+    @Test
+    void streamBlockFailsBecauseOfCompletedStreaming() throws InterruptedException {
+        BlockItem blockItem = BlockItem.newBuilder().build();
+        Block block = Block.newBuilder().addItems(blockItem).build();
+
+        PublishStreamGrpcClientImpl publishStreamGrpcClient =
+                new PublishStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService, streamEnabled);
+
+        publishStreamGrpcClient.init();
+        assertTrue(publishStreamGrpcClient.getLastKnownStatuses().isEmpty());
+
+        publishStreamGrpcClient.completeStreaming();
+
+        assertThrows(IllegalStateException.class, () -> publishStreamGrpcClient.streamBlock(block));
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
@@ -28,41 +28,37 @@ import org.junit.jupiter.api.Test;
 
 class PublishStreamObserverTest {
 
-        @Test
-        void onNext() {
-                PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
-                AtomicBoolean streamEnabled = new AtomicBoolean(true);
-                List<String> lastKnownStatuses = new ArrayList<>();
-                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
-                                lastKnownStatuses);
+    @Test
+    void onNext() {
+        PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        List<String> lastKnownStatuses = new ArrayList<>();
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
 
-                publishStreamObserver.onNext(response);
-                assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
-                assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onNext");
-        }
+        publishStreamObserver.onNext(response);
+        assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
+        assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onNext");
+    }
 
-        @Test
-        void onError() {
-                AtomicBoolean streamEnabled = new AtomicBoolean(true);
-                List<String> lastKnownStatuses = new ArrayList<>();
-                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
-                                lastKnownStatuses);
+    @Test
+    void onError() {
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        List<String> lastKnownStatuses = new ArrayList<>();
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
 
-                publishStreamObserver.onError(new Throwable());
-                assertFalse(streamEnabled.get(), "streamEnabled should be set to false after onError");
-                assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onError");
-        }
+        publishStreamObserver.onError(new Throwable());
+        assertFalse(streamEnabled.get(), "streamEnabled should be set to false after onError");
+        assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onError");
+    }
 
-        @Test
-        void onCompleted() {
-                AtomicBoolean streamEnabled = new AtomicBoolean(true);
-                List<String> lastKnownStatuses = new ArrayList<>();
-                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
-                                lastKnownStatuses);
+    @Test
+    void onCompleted() {
+        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        List<String> lastKnownStatuses = new ArrayList<>();
+        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
 
-                publishStreamObserver.onCompleted();
-                assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
-                assertEquals(0, lastKnownStatuses.size(),
-                                "lastKnownStatuses should not have elements after onCompleted");
-        }
+        publishStreamObserver.onCompleted();
+        assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
+        assertEquals(0, lastKnownStatuses.size(), "lastKnownStatuses should not have elements after onCompleted");
+    }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
@@ -16,40 +16,53 @@
 
 package com.hedera.block.simulator.grpc;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 class PublishStreamObserverTest {
 
-    @Test
-    void onNext() {
-        PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
-        AtomicBoolean streamEnabled = new AtomicBoolean(true);
+        @Test
+        void onNext() {
+                PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
+                AtomicBoolean streamEnabled = new AtomicBoolean(true);
+                List<String> lastKnownStatuses = new ArrayList<>();
+                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
+                                lastKnownStatuses);
 
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
-        publishStreamObserver.onNext(response);
-        assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
-    }
+                publishStreamObserver.onNext(response);
+                assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
+                assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onNext");
+        }
 
-    @Test
-    void onError() {
-        AtomicBoolean streamEnabled = new AtomicBoolean(true);
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
+        @Test
+        void onError() {
+                AtomicBoolean streamEnabled = new AtomicBoolean(true);
+                List<String> lastKnownStatuses = new ArrayList<>();
+                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
+                                lastKnownStatuses);
 
-        publishStreamObserver.onError(new Throwable());
-        assertFalse(streamEnabled.get(), "streamEnabled should be set to false after onError");
-    }
+                publishStreamObserver.onError(new Throwable());
+                assertFalse(streamEnabled.get(), "streamEnabled should be set to false after onError");
+                assertEquals(1, lastKnownStatuses.size(), "lastKnownStatuses should have one element after onError");
+        }
 
-    @Test
-    void onCompleted() {
-        AtomicBoolean streamEnabled = new AtomicBoolean(true);
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled);
+        @Test
+        void onCompleted() {
+                AtomicBoolean streamEnabled = new AtomicBoolean(true);
+                List<String> lastKnownStatuses = new ArrayList<>();
+                PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled,
+                                lastKnownStatuses);
 
-        publishStreamObserver.onCompleted();
-        assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
-    }
+                publishStreamObserver.onCompleted();
+                assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
+                assertEquals(0, lastKnownStatuses.size(),
+                                "lastKnownStatuses should not have elements after onCompleted");
+        }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
@@ -18,6 +18,7 @@ package com.hedera.block.simulator.metrics;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlockItemsSent;
+import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksSent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.block.simulator.TestUtils;
@@ -50,5 +51,20 @@ public class MetricsServiceTest {
                 LiveBlockItemsSent.description(),
                 metricsService.get(LiveBlockItemsSent).getDescription());
         assertEquals(10, metricsService.get(LiveBlockItemsSent).get());
+    }
+
+    @Test
+    void MetricsService_verifyLiveBlocksSentCounter() {
+
+        for (int i = 0; i < 10; i++) {
+            metricsService.get(LiveBlocksSent).increment();
+        }
+
+        assertEquals(
+                LiveBlocksSent.grafanaLabel(),
+                metricsService.get(LiveBlocksSent).getName());
+        assertEquals(
+                LiveBlocksSent.description(), metricsService.get(LiveBlocksSent).getDescription());
+        assertEquals(10, metricsService.get(LiveBlocksSent).get());
     }
 }

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -58,7 +58,7 @@ public abstract class BaseSuite {
     protected static int blockNodePort;
 
     /** Executor service for managing threads */
-    protected static CustomThreadPoolExecutor executorService;
+    protected static ErrorLoggingExecutor executorService;
 
     /**
      * Default constructor for the BaseSuite class.
@@ -79,7 +79,7 @@ public abstract class BaseSuite {
     public static void setup() {
         blockNodeContainer = createContainer();
         blockNodeContainer.start();
-        executorService = new CustomThreadPoolExecutor();
+        executorService = new ErrorLoggingExecutor();
     }
 
     /**

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -60,7 +58,7 @@ public abstract class BaseSuite {
     protected static int blockNodePort;
 
     /** Executor service for managing threads */
-    protected static ExecutorService executorService;
+    protected static CustomThreadPoolExecutor executorService;
 
     /**
      * Default constructor for the BaseSuite class.
@@ -81,7 +79,7 @@ public abstract class BaseSuite {
     public static void setup() {
         blockNodeContainer = createContainer();
         blockNodeContainer.start();
-        executorService = Executors.newFixedThreadPool(8);
+        executorService = new CustomThreadPoolExecutor();
     }
 
     /**

--- a/suites/src/main/java/com/hedera/block/suites/CustomThreadPoolExecutor.java
+++ b/suites/src/main/java/com/hedera/block/suites/CustomThreadPoolExecutor.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.suites;
+
+import static java.lang.System.Logger.Level.ERROR;
+
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A custom implementation of {@link ThreadPoolExecutor} that provides specific configurations
+ * and enhanced error logging capabilities for tasks executed within the thread pool.
+ *
+ * <p>This executor is configured with:
+ * <ul>
+ *   <li>Core pool size: 8 threads
+ *   <li>Maximum pool size: 8 threads
+ *   <li>Keep-alive time: 10 seconds
+ *   <li>Work queue: {@link LinkedBlockingQueue} with default capacity
+ * </ul>
+ *
+ * <p>The executor overrides the {@link #afterExecute(Runnable, Throwable)} method to log any
+ * exceptions thrown by tasks after their execution, aiding in debugging and error tracking.
+ */
+public class CustomThreadPoolExecutor extends ThreadPoolExecutor {
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    /**
+     * Constructs a new {@code CustomThreadPoolExecutor} with a fixed thread pool configuration.
+     *
+     * <p>The executor is set up with:
+     * <ul>
+     *   <li>Core pool size of 8 threads: the minimum number of threads to keep in the pool.
+     *   <li>Maximum pool size of 8 threads: the maximum number of threads allowed in the pool.
+     *   <li>Keep-alive time of 10 seconds: the maximum time that excess idle threads will wait for new tasks before terminating.
+     *   <li>Work queue: a {@link LinkedBlockingQueue} to hold tasks before they are executed.
+     * </ul>
+     *
+     * <p>This configuration ensures that the thread pool maintains 8 threads and does not create additional threads beyond that number.
+     */
+    public CustomThreadPoolExecutor() {
+        super(8, 8, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+    }
+
+    /**
+     * Invoked after the execution of the given {@code Runnable} task. This method provides an opportunity to perform
+     * actions after each task execution, such as logging exceptions thrown by the task.
+     *
+     * <p>If the task execution resulted in an exception, this method logs the error message using the {@code System.Logger}.
+     *
+     * @param r the runnable task that has completed execution
+     * @param t the exception that caused termination, or {@code null} if execution completed normally
+     */
+    @Override
+    protected void afterExecute(Runnable r, Throwable t) {
+        super.afterExecute(r, t);
+        if (t != null) {
+            LOGGER.log(ERROR, "Task encountered an error: " + t.getMessage());
+        }
+    }
+}

--- a/suites/src/main/java/com/hedera/block/suites/ErrorLoggingExecutor.java
+++ b/suites/src/main/java/com/hedera/block/suites/ErrorLoggingExecutor.java
@@ -18,13 +18,16 @@ package com.hedera.block.suites;
 
 import static java.lang.System.Logger.Level.ERROR;
 
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A custom implementation of {@link ThreadPoolExecutor} that provides specific configurations
- * and enhanced error logging capabilities for tasks executed within the thread pool.
+ * An executor service that extends {@link ThreadPoolExecutor} to provide custom configurations
+ * and enhanced error logging for tasks executed within the thread pool.
  *
  * <p>This executor is configured with:
  * <ul>
@@ -34,14 +37,16 @@ import java.util.concurrent.TimeUnit;
  *   <li>Work queue: {@link LinkedBlockingQueue} with default capacity
  * </ul>
  *
- * <p>The executor overrides the {@link #afterExecute(Runnable, Throwable)} method to log any
- * exceptions thrown by tasks after their execution, aiding in debugging and error tracking.
+ * <p>The executor overrides the {@link #afterExecute(Runnable, Throwable)} method to capture and log
+ * any exceptions thrown during task execution, including exceptions thrown from {@code Runnable} tasks
+ * and uncaught exceptions from {@code Future} tasks. This aids in debugging and error tracking
+ * by ensuring that all exceptions are properly logged.
  */
-public class CustomThreadPoolExecutor extends ThreadPoolExecutor {
+public class ErrorLoggingExecutor extends ThreadPoolExecutor {
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     /**
-     * Constructs a new {@code CustomThreadPoolExecutor} with a fixed thread pool configuration.
+     * Constructs a new {@code ErrorLoggingExecutor} with a fixed thread pool configuration.
      *
      * <p>The executor is set up with:
      * <ul>
@@ -53,7 +58,7 @@ public class CustomThreadPoolExecutor extends ThreadPoolExecutor {
      *
      * <p>This configuration ensures that the thread pool maintains 8 threads and does not create additional threads beyond that number.
      */
-    public CustomThreadPoolExecutor() {
+    public ErrorLoggingExecutor() {
         super(8, 8, 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
     }
 
@@ -61,16 +66,35 @@ public class CustomThreadPoolExecutor extends ThreadPoolExecutor {
      * Invoked after the execution of the given {@code Runnable} task. This method provides an opportunity to perform
      * actions after each task execution, such as logging exceptions thrown by the task.
      *
-     * <p>If the task execution resulted in an exception, this method logs the error message using the {@code System.Logger}.
+     * <p>This implementation enhances error logging by capturing exceptions that may not have been
+     * detected during the execution of the task. It handles both uncaught exceptions from {@code Runnable} tasks
+     * and exceptions thrown during the computation of {@code Future} tasks.
+     *
+     * <p>Specifically, if the {@code Throwable} parameter {@code t} is {@code null}, indicating that no exception
+     * was thrown during execution, but the task is an instance of {@code Future} and is done, it attempts to retrieve
+     * the result or exception from the {@code Future}. Any exceptions encountered are then logged.
+     *
+     * <p>If the task execution resulted in an exception, this method logs the error message and stack trace using the {@code System.Logger}.
      *
      * @param r the runnable task that has completed execution
      * @param t the exception that caused termination, or {@code null} if execution completed normally
      */
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
-        super.afterExecute(r, t);
-        if (t != null) {
-            LOGGER.log(ERROR, "Task encountered an error: " + t.getMessage());
+        Throwable localThrowable = t;
+        if (localThrowable == null && r instanceof Future<?> && ((Future<?>) r).isDone()) {
+            try {
+                final Object result = ((Future<?>) r).get();
+            } catch (final CancellationException ce) {
+                localThrowable = ce;
+            } catch (final ExecutionException ee) {
+                localThrowable = ee.getCause();
+            } catch (final InterruptedException ie) { // ignore/reset
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (localThrowable != null) {
+            LOGGER.log(ERROR, "Task encountered an error: ", localThrowable);
         }
     }
 }

--- a/suites/src/main/java/com/hedera/block/suites/grpc/GrpcTestSuites.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/GrpcTestSuites.java
@@ -17,6 +17,7 @@
 package com.hedera.block.suites.grpc;
 
 import com.hedera.block.suites.grpc.negative.NegativeServerAvailabilityTests;
+import com.hedera.block.suites.grpc.positive.PositiveEndpointBehaviourTests;
 import com.hedera.block.suites.grpc.positive.PositiveServerAvailabilityTests;
 import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.Suite;
@@ -30,7 +31,11 @@ import org.junit.platform.suite.api.Suite;
  * classes in a single test run.
  */
 @Suite
-@SelectClasses({PositiveServerAvailabilityTests.class, NegativeServerAvailabilityTests.class})
+@SelectClasses({
+    PositiveServerAvailabilityTests.class,
+    PositiveEndpointBehaviourTests.class,
+    NegativeServerAvailabilityTests.class
+})
 public class GrpcTestSuites {
 
     /**

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.suites.grpc.positive;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.block.simulator.BlockStreamSimulatorApp;
+import com.hedera.block.simulator.config.data.StreamStatus;
+import com.hedera.block.suites.BaseSuite;
+import java.io.IOException;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying the positive scenarios for server availability, specifically related to
+ * the gRPC server. This class contains tests to check that the gRPC server and the exposed endpoints are working as expected
+ * and returning correct responses on valid requests.
+ *
+ * <p>Inherits from {@link BaseSuite} to reuse the container setup and teardown logic for the Block
+ * Node.
+ */
+@DisplayName("Positive Endpoint Behaviour Tests")
+public class PositiveEndpointBehaviourTests extends BaseSuite {
+
+    private BlockStreamSimulatorApp blockStreamSimulatorApp;
+
+    private Future<?> simulatorThread;
+
+    @AfterEach
+    void teardownEnvironment() {
+        if (simulatorThread != null && !simulatorThread.isCancelled()) {
+            simulatorThread.cancel(true);
+        }
+    }
+    /** Default constructor for the {@link PositiveEndpointBehaviourTests} class. */
+    public PositiveEndpointBehaviourTests() {}
+
+    @Test
+    void verifyPublishBlockStreamEndpoint() throws IOException, InterruptedException {
+        blockStreamSimulatorApp = createBlockSimulator();
+        simulatorThread = startSimulatorInThread(blockStreamSimulatorApp);
+        Thread.sleep(5000);
+        blockStreamSimulatorApp.stop();
+        StreamStatus streamStatus = blockStreamSimulatorApp.getStreamStatus();
+        assertTrue(streamStatus.publishedBlocks() > 0);
+        assertEquals(
+                streamStatus.publishedBlocks(),
+                streamStatus.lastKnownPublisherStatuses().size());
+
+        // Verify each status contains the word "acknowledgement"
+        streamStatus
+                .lastKnownPublisherStatuses()
+                .forEach(status -> assertTrue(status.toLowerCase().contains("acknowledgement")));
+    }
+}

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -52,6 +52,20 @@ public class PositiveEndpointBehaviourTests extends BaseSuite {
     /** Default constructor for the {@link PositiveEndpointBehaviourTests} class. */
     public PositiveEndpointBehaviourTests() {}
 
+    /**
+     * Tests the {@code PublishBlockStream} gRPC endpoint by starting the Block Stream Simulator,
+     * allowing it to publish blocks, and validating the following:
+     *
+     * <ul>
+     *   <li>The number of published blocks is greater than zero.
+     *   <li>The number of published blocks matches the size of the last known publisher statuses.
+     *   <li>Each publisher status contains the word "acknowledgement" to confirm successful
+     *       responses.
+     * </ul>
+     *
+     * @throws IOException if there is an error starting or stopping the Block Stream Simulator.
+     * @throws InterruptedException if the simulator thread is interrupted during execution.
+     */
     @Test
     void verifyPublishBlockStreamEndpoint() throws IOException, InterruptedException {
         blockStreamSimulatorApp = createBlockSimulator();

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
@@ -40,7 +40,7 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
     /**
      * Test to verify that the gRPC server starts successfully.
      *
-     * <p>The test checks if the Block Node container is running and marked as healthy.
+     * <p>The test checks if the Block Node container is  running and marked as healthy.
      */
     @Test
     public void verifyGrpcServerStartsSuccessfully() {
@@ -57,10 +57,7 @@ public class PositiveServerAvailabilityTests extends BaseSuite {
     @Test
     public void verifyGrpcServerListeningOnCorrectPort() {
         assertTrue(blockNodeContainer.isRunning(), "Block Node container should be running.");
-        assertEquals(
-                1,
-                blockNodeContainer.getExposedPorts().size(),
-                "There should be exactly one exposed port.");
+        assertEquals(1, blockNodeContainer.getExposedPorts().size(), "There should be exactly one exposed port.");
         assertEquals(
                 blockNodePort,
                 blockNodeContainer.getExposedPorts().getFirst(),


### PR DESCRIPTION
**Description**:
This PR adds new functionality aimed at making the simulator a better and more flexible test driver for E2E tests. It achieves this by:

- Adding a new StreamStatus data object, which collects and stores information about the recently published/consumed blocks, as well as the latest statuses.
- Exposing the necessary methods to make this usable in other modules, primarily the E2E Tests module.
- Adding a new E2E test that covers the positive scenario where the simulator sends blocks to the Block Node, which responds with the correct response.
- Adds a new CustomThreadPoolExecutor to handle simulator threads, for now I'm just handling thrown errors, but in the future we might extend, depending on our needs.

**Related issue(s)**:

Fixes #186 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
