### PR TITLE
fix: gradle tasks from different subproject are not isolated

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -61,9 +61,6 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
-      - name: Build application
-        run: ${{ env.GRADLE_EXEC }} build
-
       - name: Run Acceptance Tests
         id: acceptance-tests
         run: ${GRADLE_EXEC} runSuites

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -79,7 +79,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Build And Run Smoke Tests Container
-        run: ${{ env.GRADLE_EXEC }} buildAndRunSmokeTestsContainer -x test
+        run: ${{ env.GRADLE_EXEC }} startDockerContainerSmokeTest
 
       - name: Run Smoke Test
         working-directory: server/src/test/resources/

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -78,16 +78,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Build And Run Smoke Tests Container
+      - name: Start the Smoke Test Container
         run: ${{ env.GRADLE_EXEC }} startDockerContainerSmokeTest
 
-      - name: Run Smoke Test
+      - name: Run Smoke Tests
         working-directory: server/src/test/resources/
         run: ./smoke-test.sh
 
-      - name: Stop Smoke Tests Container
+      - name: Stop Smoke Test Container
         if: always()
-        run: docker compose -p block-node stop
+        run: ${{ env.GRADLE_EXEC }} stopDockerContainer
 
       - name: Print Server Container Logs
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,9 @@ gradle-app.setting
 
 .idea
 .DS_Store
-# .env files
-server/docker/.env
-/server/data/
+
+# .env files (from anywhere)
+.env
 
 # manual test files
 server/src/test/resources/test_output/

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ gradle-app.setting
 # .env files (from anywhere)
 .env
 
+server/data/
+
 # manual test files
 server/src/test/resources/test_output/
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -84,14 +84,16 @@ val updateDockerEnv: TaskProvider<Exec> =
         )
     }
 
-val createDockerImage: TaskProvider<Exec> = tasks.register<Exec>("createDockerImage") {
-    description = "Creates the docker image of the Block Node Server based on the current version"
-    group = "docker"
+val createDockerImage: TaskProvider<Exec> =
+    tasks.register<Exec>("createDockerImage") {
+        description =
+            "Creates the docker image of the Block Node Server based on the current version"
+        group = "docker"
 
-    dependsOn(updateDockerEnv, tasks.assemble)
-    workingDir(dockerRootDirectory)
-    commandLine("./docker-build.sh", project.version, layout.projectDirectory.dir("..").asFile)
-}
+        dependsOn(updateDockerEnv, tasks.assemble)
+        workingDir(dockerRootDirectory)
+        commandLine("./docker-build.sh", project.version, layout.projectDirectory.dir("..").asFile)
+    }
 
 tasks.register<Exec>("startDockerContainer") {
     description = "Starts the docker container of the Block Node Server of the current version"
@@ -99,7 +101,11 @@ tasks.register<Exec>("startDockerContainer") {
 
     dependsOn(createDockerImage)
     workingDir(dockerRootDirectory)
-    commandLine("sh", "-c", "docker compose --env-file $buildRootEnvFileAbsolutePath -p block-node up -d")
+    commandLine(
+        "sh",
+        "-c",
+        "docker compose --env-file $buildRootEnvFileAbsolutePath -p block-node up -d"
+    )
 }
 
 tasks.register<Exec>("startDockerDebugContainer") {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -77,8 +77,9 @@ val copyDockerFolder: TaskProvider<Copy> =
         into(dockerBuildRootDirectory)
     }
 
-// createProductionDotEnv is temporary and used by the suites, once the suites no longer rely on the
-// .env file from the build root we should remove this task
+// @todo(#343) - createProductionDotEnv is temporary and used by the suites,
+//  once the suites no longer rely on the .env file from the build root we
+//  should remove this task
 val createProductionDotEnv: TaskProvider<Exec> =
     tasks.register<Exec>("createProductionDotEnv") {
         description = "Creates the default dotenv file for the Block Node Server"

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,14 +65,20 @@ tasks.register("bumpVersion") {
 
 // Docker related tasks
 
-var updateDockerEnv =
+val buildRootAbsolutePath: String = layout.buildDirectory.get().asFile.toPath().toAbsolutePath().toString()
+
+val updateDockerEnv: TaskProvider<Exec> =
     tasks.register<Exec>("updateDockerEnv") {
         description =
             "Creates the .env file in the docker folder that contains environment variables for docker"
         group = "docker"
 
         workingDir(layout.projectDirectory.dir("docker"))
-        commandLine("sh", "-c", "./update-env.sh ${project.version} false false")
+        commandLine(
+            "sh",
+            "-c",
+            "./update-env.sh $buildRootAbsolutePath ${project.version} false false"
+        )
     }
 
 tasks.register<Exec>("createDockerImage") {
@@ -102,7 +108,7 @@ tasks.register<Exec>("startDockerDebugContainer") {
     commandLine(
         "sh",
         "-c",
-        "./update-env.sh ${project.version} true false && docker compose -p block-node up -d"
+        "./update-env.sh $buildRootAbsolutePath ${project.version} true false && docker compose -p block-node up -d"
     )
 }
 
@@ -120,7 +126,11 @@ tasks.register("buildAndRunSmokeTestsContainer") {
         // ensure smoke test .env properties before creating the container
         exec {
             workingDir(layout.projectDirectory.dir("docker"))
-            commandLine("sh", "-c", "./update-env.sh ${project.version} false true")
+            commandLine(
+                "sh",
+                "-c",
+                "./update-env.sh $buildRootAbsolutePath ${project.version} false true"
+            )
         }
     }
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -77,12 +77,11 @@ val copyDockerFolder: TaskProvider<Copy> =
         into(dockerBuildRootDirectory)
     }
 
-// createProductionDotEnv is temporary and used by the suites, once the suites no longer rely on the .env file from the build root
-// we should remove this task
+// createProductionDotEnv is temporary and used by the suites, once the suites no longer rely on the
+// .env file from the build root we should remove this task
 val createProductionDotEnv: TaskProvider<Exec> =
     tasks.register<Exec>("createProductionDotEnv") {
-        description =
-            "Creates the default dotenv file for the Block Node Server"
+        description = "Creates the default dotenv file for the Block Node Server"
         group = "docker"
 
         dependsOn(copyDockerFolder)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -123,7 +123,8 @@ val createDockerImageSmokeTest: TaskProvider<Exec> =
     }
 
 tasks.register<Exec>("startDockerContainer") {
-    description = "Starts the docker container of the Block Node Server for the current version"
+    description =
+        "Starts the docker productiongit a container of the Block Node Server for the current version"
     group = "docker"
 
     dependsOn(createDockerImage)
@@ -132,7 +133,8 @@ tasks.register<Exec>("startDockerContainer") {
 }
 
 tasks.register<Exec>("startDockerContainerDebug") {
-    description = "Starts the docker debug container of the Block Node Server for the current version"
+    description =
+        "Starts the docker debug container of the Block Node Server for the current version"
     group = "docker"
 
     dependsOn(createDockerImageDebug)
@@ -141,16 +143,13 @@ tasks.register<Exec>("startDockerContainerDebug") {
 }
 
 tasks.register<Exec>("startDockerContainerSmokeTest") {
-    description = "Starts the docker smoke test container of the Block Node Server for the current version"
+    description =
+        "Starts the docker smoke test container of the Block Node Server for the current version"
     group = "docker"
 
     dependsOn(createDockerImageSmokeTest)
     workingDir(dockerBuildRootDirectory)
-    commandLine(
-        "sh",
-        "-c",
-        "docker compose -p block-node up -d"
-    )
+    commandLine("sh", "-c", "docker compose -p block-node up -d")
 }
 
 tasks.register<Exec>("stopDockerContainer") {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -77,6 +77,19 @@ val copyDockerFolder: TaskProvider<Copy> =
         into(dockerBuildRootDirectory)
     }
 
+// createProductionDotEnv is temporary and used by the suites, once the suites no longer rely on the .env file from the build root
+// we should remove this task
+val createProductionDotEnv: TaskProvider<Exec> =
+    tasks.register<Exec>("createProductionDotEnv") {
+        description =
+            "Creates the default dotenv file for the Block Node Server"
+        group = "docker"
+
+        dependsOn(copyDockerFolder)
+        workingDir(dockerBuildRootDirectory)
+        commandLine("sh", "-c", "./update-env.sh ${project.version} false false")
+    }
+
 val createDockerImage: TaskProvider<Exec> =
     tasks.register<Exec>("createDockerImage") {
         description =

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -85,41 +85,7 @@ val createDockerImage: TaskProvider<Exec> =
 
         dependsOn(copyDockerFolder, tasks.assemble)
         workingDir(dockerBuildRootDirectory)
-        commandLine(
-            "sh",
-            "-c",
-            "./update-env.sh ${project.version} false false && ./docker-build.sh ${project.version}"
-        )
-    }
-
-val createDockerImageDebug: TaskProvider<Exec> =
-    tasks.register<Exec>("createDockerImageDebug") {
-        description =
-            "Creates the debug docker image of the Block Node Server based on the current version"
-        group = "docker"
-
-        dependsOn(copyDockerFolder, tasks.assemble)
-        workingDir(dockerBuildRootDirectory)
-        commandLine(
-            "sh",
-            "-c",
-            "./update-env.sh ${project.version} true false && ./docker-build.sh ${project.version}"
-        )
-    }
-
-val createDockerImageSmokeTest: TaskProvider<Exec> =
-    tasks.register<Exec>("createDockerImageSmokeTest") {
-        description =
-            "Creates the smoke tests docker image of the Block Node Server based on the current version"
-        group = "docker"
-
-        dependsOn(copyDockerFolder, tasks.assemble)
-        workingDir(dockerBuildRootDirectory)
-        commandLine(
-            "sh",
-            "-c",
-            "./update-env.sh ${project.version} false true && ./docker-build.sh ${project.version}"
-        )
+        commandLine("sh", "-c", "./docker-build.sh ${project.version}")
     }
 
 tasks.register<Exec>("startDockerContainer") {
@@ -129,7 +95,11 @@ tasks.register<Exec>("startDockerContainer") {
 
     dependsOn(createDockerImage)
     workingDir(dockerBuildRootDirectory)
-    commandLine("sh", "-c", "docker compose -p block-node up -d")
+    commandLine(
+        "sh",
+        "-c",
+        "./update-env.sh ${project.version} false false && docker compose -p block-node up -d"
+    )
 }
 
 tasks.register<Exec>("startDockerContainerDebug") {
@@ -137,9 +107,13 @@ tasks.register<Exec>("startDockerContainerDebug") {
         "Starts the docker debug container of the Block Node Server for the current version"
     group = "docker"
 
-    dependsOn(createDockerImageDebug)
+    dependsOn(createDockerImage)
     workingDir(dockerBuildRootDirectory)
-    commandLine("sh", "-c", "docker compose -p block-node up -d")
+    commandLine(
+        "sh",
+        "-c",
+        "./update-env.sh ${project.version} true false && docker compose -p block-node up -d"
+    )
 }
 
 tasks.register<Exec>("startDockerContainerSmokeTest") {
@@ -147,9 +121,13 @@ tasks.register<Exec>("startDockerContainerSmokeTest") {
         "Starts the docker smoke test container of the Block Node Server for the current version"
     group = "docker"
 
-    dependsOn(createDockerImageSmokeTest)
+    dependsOn(createDockerImage)
     workingDir(dockerBuildRootDirectory)
-    commandLine("sh", "-c", "docker compose -p block-node up -d")
+    commandLine(
+        "sh",
+        "-c",
+        "./update-env.sh ${project.version} false true && docker compose -p block-node up -d"
+    )
 }
 
 tasks.register<Exec>("stopDockerContainer") {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -103,7 +103,7 @@ val createDockerImage: TaskProvider<Exec> =
 
 tasks.register<Exec>("startDockerContainer") {
     description =
-        "Starts the docker productiongit a container of the Block Node Server for the current version"
+        "Starts the docker production container of the Block Node Server for the current version"
     group = "docker"
 
     dependsOn(createDockerImage)

--- a/server/docker/docker-build.sh
+++ b/server/docker/docker-build.sh
@@ -12,5 +12,6 @@ echo "Using project directory: ${2}"
 echo
 
 # run docker build
-echo "Building container:"
+echo "Building image [block-node-server:${VERSION}]"
 docker buildx build --load -t "block-node-server:${VERSION}" --build-context distributions=../build/distributions --build-arg VERSION="${VERSION}" . || exit "${?}"
+echo "Image [block-node-server:${VERSION}] built successfully!"

--- a/server/docker/docker-build.sh
+++ b/server/docker/docker-build.sh
@@ -7,11 +7,11 @@ fi
 
 VERSION=$1
 
-echo "CREATING CONTAINER FOR VERSION ${VERSION}"
-echo "Using project directory: ${2}"
+echo "Building image [block-node-server:${VERSION}]"
 echo
 
 # run docker build
-echo "Building image [block-node-server:${VERSION}]"
-docker buildx build --load -t "block-node-server:${VERSION}" --build-context distributions=../build/distributions --build-arg VERSION="${VERSION}" . || exit "${?}"
+docker buildx build --load -t "block-node-server:${VERSION}" --build-context distributions=../distributions --build-arg VERSION="${VERSION}" . || exit "${?}"
+
+echo
 echo "Image [block-node-server:${VERSION}] built successfully!"

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: block-node-server
     image: block-node-server:${VERSION}
     env_file:
-      - .env
+      - ../build/.env
     ports:
       - "8080:8080"
       - "5005:5005"

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: block-node-server
     image: block-node-server:${VERSION}
     env_file:
-      - ../build/.env
+      - .env
     ports:
       - "8080:8080"
       - "5005:5005"

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   block-node-server:
     container_name: block-node-server

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -3,21 +3,17 @@
 # This scripts create a '.env' file that is used for docker & docker-compose as an input of environment variables.
 # This script is called by gradle and get the current project version as an input param
 
-if [ $# -lt 2 ]; then
-  # <PROJECT_BUILD_ROOT> and <VERSION> are required!
-  echo "USAGE: $0 <PROJECT_BUILD_ROOT> <VERSION> [DEBUG] [SMOKE_TEST]"
+if [ $# -lt 1 ]; then
+  # <VERSION> is required!
+  echo "USAGE: $0 <VERSION> [DEBUG] [SMOKE_TEST]"
   exit 1
 fi
 
-project_build_root=$1
-project_version=$2
+project_version=$1
 # determine if we should include debug opts
-[ "$3" = true ] && is_debug=true || is_debug=false
+[ "$2" = true ] && is_debug=true || is_debug=false
 # determine if we should include smoke test env variables
-[ "$4" = true ] && is_smoke_test=true || is_smoke_test=false
-
-# work only inside the scope of the project build root
-cd "$project_build_root" || exit 1
+[ "$3" = true ] && is_smoke_test=true || is_smoke_test=false
 
 echo "VERSION=$project_version" > .env
 echo "REGISTRY_PREFIX=" >> .env
@@ -42,3 +38,4 @@ fi
 # Output the values
 echo ".env properties:"
 cat .env
+echo

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -3,16 +3,21 @@
 # This scripts create a '.env' file that is used for docker & docker-compose as an input of environment variables.
 # This script is called by gradle and get the current project version as an input param
 
-if [ $# -lt 1 ]; then
-  echo "USAGE: $0 <VERSION> <DEBUG> <SMOKE_TEST>"
+if [ $# -lt 2 ]; then
+  # <PROJECT_BUILD_ROOT> and <VERSION> are required!
+  echo "USAGE: $0 <PROJECT_BUILD_ROOT> <VERSION> [DEBUG] [SMOKE_TEST]"
   exit 1
 fi
 
-project_version=$1
+project_build_root=$1
+project_version=$2
 # determine if we should include debug opts
-[ "$2" = true ] && is_debug=true || is_debug=false
+[ "$3" = true ] && is_debug=true || is_debug=false
 # determine if we should include smoke test env variables
-[ "$3" = true ] && is_smoke_test=true || is_smoke_test=false
+[ "$4" = true ] && is_smoke_test=true || is_smoke_test=false
+
+# work only inside the scope of the project build root
+cd "$project_build_root" || exit 1
 
 echo "VERSION=$project_version" > .env
 echo "REGISTRY_PREFIX=" >> .env

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -38,31 +38,11 @@ mainModuleInfo {
 // workaround until https://github.com/hashgraph/hedera-block-node/pull/216 is integrated
 dependencies.constraints { implementation("org.slf4j:slf4j-api:2.0.6") }
 
-val updateDockerEnv =
-    tasks.register<Exec>("updateDockerEnv") {
-        description =
-            "Creates the .env file in the docker folder that contains environment variables for Docker"
-        group = "docker"
-
-        workingDir(layout.projectDirectory.dir("../server/docker"))
-        commandLine("sh", "-c", "./update-env.sh ${project.version} false false")
-    }
-
-// Task to build the Docker image
-tasks.register<Exec>("createDockerImage") {
-    description = "Creates the Docker image of the Block Node Server based on the current version"
-    group = "docker"
-
-    dependsOn(updateDockerEnv, tasks.assemble)
-    workingDir(layout.projectDirectory.dir("../server/docker"))
-    commandLine("./docker-build.sh", project.version, layout.projectDirectory.dir("..").asFile)
-}
-
 tasks.register<Test>("runSuites") {
     description = "Runs E2E Test Suites"
     group = "suites"
     modularity.inferModulePath = false
-    dependsOn("createDockerImage")
+    dependsOn(":server:createDockerImage")
 
     useJUnitPlatform()
     testLogging { events("passed", "skipped", "failed") }

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -42,7 +42,7 @@ tasks.register<Test>("runSuites") {
     description = "Runs E2E Test Suites"
     group = "suites"
     modularity.inferModulePath = false
-    dependsOn(":server:createDockerImage")
+    dependsOn(":server:createDockerImage", ":server:createProductionDotEnv")
 
     useJUnitPlatform()
     testLogging { events("passed", "skipped", "failed") }

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -42,6 +42,8 @@ tasks.register<Test>("runSuites") {
     description = "Runs E2E Test Suites"
     group = "suites"
     modularity.inferModulePath = false
+
+    // @todo(#343) - :server:createProductionDotEnv should disappear
     dependsOn(":server:createDockerImage", ":server:createProductionDotEnv")
 
     useJUnitPlatform()

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -50,6 +50,10 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The Block Node Application version is retrieved dynamically from an environment file (.env).
  */
 public abstract class BaseSuite {
+    /**
+     * Dotenv instance to load the environment variables from the .env file that
+     * is inside the build root of the :server.
+     */
     protected static final Dotenv DOTENV =
             Dotenv.configure().directory("../server/build").filename(".env").load();
 
@@ -177,10 +181,6 @@ public abstract class BaseSuite {
 
     /**
      * Retrieves the Block Node server version from the .env file.
-     *
-     * <p>This method loads the .env file from the "../server/docker" directory and extracts the
-     * value of the "VERSION" environment variable, which represents the version of the Block Node
-     * server to be used in the container.
      *
      * @return the version of the Block Node server as a string
      */

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -54,6 +54,9 @@ public abstract class BaseSuite {
      * Dotenv instance to load the environment variables from the .env file that
      * is inside the build root of the :server.
      */
+    // @todo(#343) - do not use build/environment related files from other
+    // projects directly like that, the SERVER_DOTENV should be constructed
+    // in another way
     protected static final Dotenv SERVER_DOTENV = Dotenv.configure()
             .directory("../server/build/docker")
             .filename(".env")

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -54,8 +54,10 @@ public abstract class BaseSuite {
      * Dotenv instance to load the environment variables from the .env file that
      * is inside the build root of the :server.
      */
-    protected static final Dotenv DOTENV =
-            Dotenv.configure().directory("../server/build").filename(".env").load();
+    protected static final Dotenv DOTENV = Dotenv.configure()
+            .directory("../server/build/docker")
+            .filename(".env")
+            .load();
 
     /** Container running the Block Node Application */
     protected static GenericContainer<?> blockNodeContainer;

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -50,6 +50,8 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The Block Node Application version is retrieved dynamically from an environment file (.env).
  */
 public abstract class BaseSuite {
+    protected static final Dotenv DOTENV =
+            Dotenv.configure().directory("../server/build").filename(".env").load();
 
     /** Container running the Block Node Application */
     protected static GenericContainer<?> blockNodeContainer;
@@ -92,6 +94,7 @@ public abstract class BaseSuite {
     public static void teardown() {
         if (blockNodeContainer != null) {
             blockNodeContainer.stop();
+            blockNodeContainer.close();
         }
         if (executorService != null) {
             executorService.shutdownNow();
@@ -182,11 +185,6 @@ public abstract class BaseSuite {
      * @return the version of the Block Node server as a string
      */
     private static String getBlockNodeVersion() {
-        Dotenv dotenv = Dotenv.configure()
-                .directory("../server/docker")
-                .filename(".env")
-                .load();
-
-        return dotenv.get("VERSION");
+        return DOTENV.get("VERSION");
     }
 }

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -54,7 +54,7 @@ public abstract class BaseSuite {
      * Dotenv instance to load the environment variables from the .env file that
      * is inside the build root of the :server.
      */
-    protected static final Dotenv DOTENV = Dotenv.configure()
+    protected static final Dotenv SERVER_DOTENV = Dotenv.configure()
             .directory("../server/build/docker")
             .filename(".env")
             .load();
@@ -187,6 +187,6 @@ public abstract class BaseSuite {
      * @return the version of the Block Node server as a string
      */
     private static String getBlockNodeVersion() {
-        return DOTENV.get("VERSION");
+        return SERVER_DOTENV.get("VERSION");
     }
 }


### PR DESCRIPTION
**Description**:

Isolate `gradle` tasks to not go outside of the respective project's build root.

**Related issue(s)**:

Fixes #299

**Notes for reviewer**:

- am I missing something?

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
