### PR TITLE
feat: Implement consumer handler in the Simulator

### DIFF
--- a/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
+++ b/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
@@ -55,8 +55,8 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      */
     public static String requireNotBlank(final String toCheck, final String errorMessage) {
         if (StringUtilities.isBlank(toCheck)) {
-            final String message = Objects.isNull(errorMessage) ? "The input String is required to be non-blank."
-                    : errorMessage;
+            final String message =
+                    Objects.isNull(errorMessage) ? "The input String is required to be non-blank." : errorMessage;
             throw new IllegalArgumentException(message);
         } else {
             return toCheck;
@@ -257,6 +257,5 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
         }
     }
 
-    private Preconditions() {
-    }
+    private Preconditions() {}
 }

--- a/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
+++ b/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
@@ -27,11 +27,11 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * we return it, else we throw {@link IllegalArgumentException}.
      *
      * @param toCheck a {@link String} to be checked if is blank as defined
-     * above
+     *                above
      * @return the {@link String} to be checked if it is not blank as defined
-     * above
+     *         above
      * @throws IllegalArgumentException if the input {@link String} to be
-     * checked is blank
+     *                                  checked is blank
      */
     public static String requireNotBlank(final String toCheck) {
         return requireNotBlank(toCheck, null);
@@ -43,19 +43,20 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * {@link String#isBlank()}. If the given {@link String} is not blank, then
      * we return it, else we throw {@link IllegalArgumentException}.
      *
-     * @param toCheck a {@link String} to be checked if is blank as defined
-     * above
+     * @param toCheck      a {@link String} to be checked if is blank as defined
+     *                     above
      * @param errorMessage the error message to be used in the exception if the
-     * input {@link String} to be checked is blank, if null, a default message
+     *                     input {@link String} to be checked is blank, if null, a
+     *                     default message
      * @return the {@link String} to be checked if it is not blank as defined
-     * above
+     *         above
      * @throws IllegalArgumentException if the input {@link String} to be
-     * checked is blank
+     *                                  checked is blank
      */
     public static String requireNotBlank(final String toCheck, final String errorMessage) {
         if (StringUtilities.isBlank(toCheck)) {
-            final String message =
-                    Objects.isNull(errorMessage) ? "The input String is required to be non-blank." : errorMessage;
+            final String message = Objects.isNull(errorMessage) ? "The input String is required to be non-blank."
+                    : errorMessage;
             throw new IllegalArgumentException(message);
         } else {
             return toCheck;
@@ -69,7 +70,7 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * @param toCheck the number to check if it is a positive power of two
      * @return the number to check if it is positive
      * @throws IllegalArgumentException if the input number to check is not
-     * positive
+     *                                  positive
      */
     public static int requirePositive(final int toCheck) {
         return requirePositive(toCheck, null);
@@ -79,13 +80,14 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * This method asserts a given integer is a positive. An integer is positive
      * if it is NOT equal to zero and is greater than zero.
      *
-     * @param toCheck the integer to check if it is a positive power of two
+     * @param toCheck      the integer to check if it is a positive power of two
      * @param errorMessage the error message to be used in the exception if the
-     * input integer to check is not positive, if null, a default message will
-     * be used
+     *                     input integer to check is not positive, if null, a
+     *                     default message will
+     *                     be used
      * @return the number to check if it is positive
      * @throws IllegalArgumentException if the input number to check is not
-     * positive
+     *                                  positive
      */
     public static int requirePositive(final int toCheck, final String errorMessage) {
         if (0 >= toCheck) {
@@ -105,7 +107,7 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * @param toCheck the long to check if it is a positive power of two
      * @return the long to check if it is positive
      * @throws IllegalArgumentException if the input long to check is not
-     * positive
+     *                                  positive
      */
     public static long requirePositive(final long toCheck) {
         return requirePositive(toCheck, null);
@@ -115,13 +117,14 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * This method asserts a given long is a positive. A long is positive
      * if it is NOT equal to zero and is greater than zero.
      *
-     * @param toCheck the long to check if it is a positive power of two
+     * @param toCheck      the long to check if it is a positive power of two
      * @param errorMessage the error message to be used in the exception if the
-     * input long to check is not positive, if null, a default message will
-     * be used
+     *                     input long to check is not positive, if null, a default
+     *                     message will
+     *                     be used
      * @return the long to check if it is positive
      * @throws IllegalArgumentException if the input long to check is not
-     * positive
+     *                                  positive
      */
     public static long requirePositive(final long toCheck, final String errorMessage) {
         if (0L >= toCheck) {
@@ -135,13 +138,61 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
     }
 
     /**
+     * Ensures that a given long value is greater than or equal to a specified base
+     * value.
+     * If the value does not meet the requirement, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * <p>
+     * This method delegates the validation to
+     * {@link #requireGreaterOrEqual(long, long, String)},
+     * using a default error message if the check fails.
+     * </p>
+     *
+     * @param toTest the long value to test
+     * @param base   the base value to compare against
+     * @return the input {@code toTest} if it is greater than or equal to
+     *         {@code base}
+     * @throws IllegalArgumentException if {@code toTest} is less than {@code base}
+     */
+    public static long requireGreaterOrEqual(final long toTest, final long base) {
+        return requireGreaterOrEqual(toTest, base, null);
+    }
+
+    /**
+     * Ensures that a given long value is greater than or equal to a specified base
+     * value.
+     * If the value does not meet the requirement, an
+     * {@link IllegalArgumentException} is thrown.
+     *
+     * @param toTest       the long value to test
+     * @param base         the base value to compare against
+     * @param errorMessage the error message to include in the exception if the
+     *                     check fails;
+     *                     if {@code null}, a default message is used
+     * @return the input {@code toTest} if it is greater than or equal to
+     *         {@code base}
+     * @throws IllegalArgumentException if {@code toTest} is less than {@code base}
+     */
+    public static long requireGreaterOrEqual(final long toTest, final long base, final String errorMessage) {
+        if (toTest >= base) {
+            return toTest;
+        }
+
+        final String message = Objects.isNull(errorMessage)
+                ? "The input integer [%d] is required be greater or equal than [%d].".formatted(toTest, base)
+                : errorMessage;
+        throw new IllegalArgumentException(message);
+    }
+
+    /**
      * This method asserts a given long is a whole number. A long is whole
      * if it is greater or equal to zero.
      *
      * @param toCheck the long to check if it is a whole number
      * @return the number to check if it is whole number
      * @throws IllegalArgumentException if the input number to check is not
-     * positive
+     *                                  positive
      */
     public static long requireWhole(final long toCheck) {
         return requireWhole(toCheck, null);
@@ -151,13 +202,14 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * This method asserts a given long is a whole number. A long is whole
      * if it is greater or equal to zero.
      *
-     * @param toCheck the long to check if it is a whole number
+     * @param toCheck      the long to check if it is a whole number
      * @param errorMessage the error message to be used in the exception if the
-     * input long to check is not a whole number, if null, a default message will
-     * be used
+     *                     input long to check is not a whole number, if null, a
+     *                     default message will
+     *                     be used
      * @return the number to check if it is whole number
      * @throws IllegalArgumentException if the input number to check is not
-     * positive
+     *                                  positive
      */
     public static long requireWhole(final long toCheck, final String errorMessage) {
         if (toCheck >= 0) {
@@ -176,7 +228,7 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
      * @param toCheck the number to check if it is a power of two
      * @return the number to check if it is a power of two
      * @throws IllegalArgumentException if the input number to check is not a
-     * power of two
+     *                                  power of two
      */
     public static int requirePowerOfTwo(final int toCheck) {
         return requirePowerOfTwo(toCheck, null);
@@ -185,13 +237,14 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
     /**
      * This method asserts a given integer is a power of two.
      *
-     * @param toCheck the number to check if it is a power of two
+     * @param toCheck      the number to check if it is a power of two
      * @param errorMessage the error message to be used in the exception if the
-     * input integer to check is not a power of two, if null, a default message
-     * will be used
+     *                     input integer to check is not a power of two, if null, a
+     *                     default message
+     *                     will be used
      * @return the number to check if it is a power of two
      * @throws IllegalArgumentException if the input number to check is not a
-     * power of two
+     *                                  power of two
      */
     public static int requirePowerOfTwo(final int toCheck, final String errorMessage) {
         if (!MathUtilities.isPowerOfTwo(toCheck)) {
@@ -204,5 +257,6 @@ public final class Preconditions { // @todo(381) change the APIs to accept non-n
         }
     }
 
-    private Preconditions() {}
+    private Preconditions() {
+    }
 }

--- a/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
+++ b/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
@@ -208,6 +208,26 @@ public final class CommonsTestUtility {
     }
 
     /**
+     * Provides valid test data for cases where the value to test is greater than or equal to the base value.
+     *
+     * @return a stream of arguments where each argument is a pair of {@code (toTest, base)} values,
+     *         such that {@code toTest >= base}.
+     */
+    public static Stream<Arguments> validGreaterOrEqualValues() {
+        return Stream.of(Arguments.of(10L, 5L), Arguments.of(5L, 5L), Arguments.of(0L, -5L), Arguments.of(100L, 50L));
+    }
+
+    /**
+     * Provides invalid test data for cases where the value to test is less than the base value.
+     *
+     * @return a stream of arguments where each argument is a pair of {@code (toTest, base)} values,
+     *         such that {@code toTest < base}.
+     */
+    public static Stream<Arguments> invalidGreaterOrEqualValues() {
+        return Stream.of(Arguments.of(3L, 5L), Arguments.of(-10L, -5L), Arguments.of(0L, 1L), Arguments.of(-1L, 0L));
+    }
+
+    /**
      * Zero and some negative integers.
      */
     public static Stream<Arguments> zeroAndNegativeIntegers() {

--- a/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
@@ -108,6 +108,44 @@ class PreconditionsTest {
 
     /**
      * This test aims to verify that the
+     * {@link Preconditions#requireGreaterOrEqual(long, long)} will return the input
+     * 'toTest' parameter if the check passes.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#validGreaterOrEqualValues")
+    void testRequireGreaterOrEqualPass(final long toTest, final long base) {
+        final Consumer<Long> asserts =
+                actual -> assertThat(actual).isGreaterThanOrEqualTo(base).isEqualTo(toTest);
+
+        final long actual = Preconditions.requireGreaterOrEqual(toTest, base);
+        assertThat(actual).satisfies(asserts);
+
+        final long actualOverload = Preconditions.requireGreaterOrEqual(toTest, base, "test error message");
+        assertThat(actualOverload).satisfies(asserts);
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link Preconditions#requireGreaterOrEqual(long, long)} will throw an
+     * {@link IllegalArgumentException} if the check fails.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#invalidGreaterOrEqualValues")
+    void testRequireGreaterOrEqualFail(final long toTest, final long base) {
+        assertThatIllegalArgumentException().isThrownBy(() -> Preconditions.requireGreaterOrEqual(toTest, base));
+
+        final String testErrorMessage = "test error message";
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> Preconditions.requireGreaterOrEqual(toTest, base, testErrorMessage))
+                .withMessage(testErrorMessage);
+    }
+
+    /**
+     * This test aims to verify that the
      * {@link Preconditions#requirePositive(int)} will return the input 'toTest'
      * parameter if the positive check passes. Test includes overloads.
      *

--- a/simulator/docs/configuration.md
+++ b/simulator/docs/configuration.md
@@ -11,6 +11,7 @@ Uses the prefix `blockStream` so all properties should start with `blockStream.`
 
 | Key | Description | Default Value |
 |:---|:---|---:|
+| `simulatorMode` | The desired simulator mode to use, it can be either `PUBLISHER` or `CONSUMER`. | `PUBLISHER` |
 | `delayBetweenBlockItems` | The delay between each block item in nanoseconds, only applicable when streamingMode=CONSTANT_RATE | `1_500_000` |
 | `maxBlockItemsToStream` | exit condition for the simulator and the circular implementations such as `BlockAsDir` or `BlockAsFile` implementations | `10_000` |
 | `streamingMode` | can either be `CONSTANT_RATE` or `MILLIS_PER_BLOCK` | `CONSTANT_RATE` |

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -44,31 +44,44 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import javax.inject.Inject;
 
-/** BlockStream Simulator App */
+/**
+ * The BlockStream Simulator Application manages the lifecycle and coordination
+ * of block streaming
+ * operations. It supports different modes of operation including publishing,
+ * consuming, or both
+ * simultaneously.
+ *
+ * <p>
+ * This class serves as the main entry point for the simulator, handling
+ * initialization,
+ * execution, and shutdown of streaming operations based on the configured mode.
+ */
 public class BlockStreamSimulatorApp {
-
+    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
+    // Service dependencies
     private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final ConsumerStreamGrpcClient consumerStreamGrpcClient;
-    private final BlockStreamConfig blockStreamConfig;
     private final SimulatorModeHandler simulatorModeHandler;
-    private final AtomicBoolean isRunning = new AtomicBoolean(false);
     private final MetricsService metricsService;
 
+    // State
+    private final AtomicBoolean isRunning;
+
     /**
-     * Creates a new BlockStreamSimulatorApp instance.
+     * Creates a new BlockStreamSimulatorApp instance with the specified
+     * dependencies.
      *
-     * @param configuration            the configuration to be used by the block
+     * @param configuration            The configuration to be used by the block
      *                                 stream simulator
-     * @param blockStreamManager       the block stream manager to be used by the
-     *                                 block stream simulator
-     * @param publishStreamGrpcClient  the gRPC client to be used by the block
-     *                                 stream simulator to publish blocks
-     * @param consumerStreamGrpcClient the gRPC client to be used by the block
-     *                                 stream simulator to consume blocks
-     * @param metricsService           the metrics service to be used by the block
-     *                                 stream simulator
+     * @param blockStreamManager       The manager responsible for block stream
+     *                                 generation
+     * @param publishStreamGrpcClient  The gRPC client for publishing blocks
+     * @param consumerStreamGrpcClient The gRPC client for consuming blocks
+     * @param metricsService           The service for recording metrics
+     * @throws NullPointerException     if any parameter is null
+     * @throws IllegalArgumentException if an unknown simulator mode is configured
      */
     @Inject
     public BlockStreamSimulatorApp(
@@ -80,6 +93,7 @@ public class BlockStreamSimulatorApp {
 
         requireNonNull(configuration);
         requireNonNull(blockStreamManager);
+
         this.metricsService = requireNonNull(metricsService);
         this.publishStreamGrpcClient = requireNonNull(publishStreamGrpcClient);
         loadLoggingProperties();
@@ -87,38 +101,34 @@ public class BlockStreamSimulatorApp {
         final BlockStreamConfig blockStreamConfig = requireNonNull(
                 configuration.getConfigData(BlockStreamConfig.class));
         this.consumerStreamGrpcClient = requireNonNull(consumerStreamGrpcClient);
+        this.isRunning = new AtomicBoolean(false);
 
+        // Initialize the appropriate mode handler based on configuration
+        final BlockStreamConfig blockStreamConfig = requireNonNull(
+                configuration.getConfigData(BlockStreamConfig.class));
         final SimulatorMode simulatorMode = blockStreamConfig.simulatorMode();
-        switch (simulatorMode) {
-            case PUBLISHER -> simulatorModeHandler = new PublisherModeHandler(
+        this.simulatorModeHandler = switch (simulatorMode) {
+            case PUBLISHER -> new PublisherModeHandler(
                     blockStreamConfig, publishStreamGrpcClient, blockStreamManager, metricsService);
-            case CONSUMER ->
-                simulatorModeHandler = new ConsumerModeHandler(blockStreamConfig, consumerStreamGrpcClient);
-            case BOTH -> simulatorModeHandler = new CombinedModeHandler(blockStreamConfig);
+            case CONSUMER -> new ConsumerModeHandler(blockStreamConfig, consumerStreamGrpcClient);
+            case BOTH -> new CombinedModeHandler(blockStreamConfig);
             default -> throw new IllegalArgumentException("Unknown SimulatorMode: " + simulatorMode);
-        }
+        };
     }
 
     /**
-     * Starts the block stream simulator.
+     * Initializes and starts the block stream simulator in the configured mode.
+     * This method initializes all components and begins the streaming process.
      *
-     * @throws InterruptedException           if the thread is interrupted
-     * @throws BlockSimulatorParsingException if a parse error occurs
-     * @throws IOException                    if an I/O error occurs
+     * @throws InterruptedException           if the streaming process is
+     *                                        interrupted
+     * @throws BlockSimulatorParsingException if a block parsing error occurs
+     * @throws IOException                    if an I/O error occurs during
+     *                                        streaming
      */
     public void start() throws InterruptedException, BlockSimulatorParsingException, IOException {
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator started initializing components...");
-
-        // WIP
-        switch (blockStreamConfig.simulatorMode()) {
-            case PUBLISHER -> publishStreamGrpcClient.init();
-            case CONSUMER -> consumerStreamGrpcClient.init();
-            case BOTH -> throw new UnsupportedOperationException(
-                    "Unknown SimulatorMode: " + blockStreamConfig.simulatorMode());
-            default -> throw new IllegalArgumentException(
-                    "Unknown SimulatorMode: " + blockStreamConfig.simulatorMode());
-        }
-        // WIP
+        LOGGER.log(INFO, "Block Stream Simulator started initializing components...");
+        simulatorModeHandler.init();
 
         isRunning.set(true);
 
@@ -126,33 +136,35 @@ public class BlockStreamSimulatorApp {
     }
 
     /**
-     * Returns whether the block stream simulator is running.
+     * Checks if the simulator is currently running.
      *
-     * @return true if the block stream simulator is running, false otherwise
+     * @return true if the simulator is running, false otherwise
      */
     public boolean isRunning() {
         return isRunning.get();
     }
 
     /**
-     * Stops the Block Stream Simulator and closes off all grpc channels.
+     * Gracefully stops the simulator and closes all gRPC channels.
+     * This method ensures proper cleanup of resources and termination of streaming
+     * operations.
      *
-     * @throws InterruptedException if the thread is interrupted
+     * @throws InterruptedException if the shutdown process is interrupted
      */
     public void stop() throws InterruptedException {
         simulatorModeHandler.stop();
-        publishStreamGrpcClient.completeStreaming();
-
-        publishStreamGrpcClient.shutdown();
         isRunning.set(false);
 
         LOGGER.log(INFO, "Block Stream Simulator has stopped");
     }
 
     /**
-     * Gets the stream status from both the publisher and the consumer.
+     * Retrieves the current status of both publishing and consuming streams.
+     * This method provides information about the number of blocks processed and the
+     * last known status of both publisher and consumer operations.
      *
-     * @return the stream status
+     * @return A StreamStatus object containing current metrics and status
+     *         information
      */
     public StreamStatus getStreamStatus() {
         return StreamStatus.builder()

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -33,7 +33,7 @@ import com.swirlds.config.api.ConfigProperty;
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
-        @ConfigProperty(defaultValue = "CONSUMER") SimulatorMode simulatorMode,
+        @ConfigProperty(defaultValue = "PUBLISHER") SimulatorMode simulatorMode,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -33,7 +33,7 @@ import com.swirlds.config.api.ConfigProperty;
  */
 @ConfigData("blockStream")
 public record BlockStreamConfig(
-        @ConfigProperty(defaultValue = "PUBLISHER") SimulatorMode simulatorMode,
+        @ConfigProperty(defaultValue = "CONSUMER") SimulatorMode simulatorMode,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
@@ -63,6 +63,13 @@ public class BlockAsDirBlockStreamManager implements BlockStreamManager {
     @Inject
     public BlockAsDirBlockStreamManager(@NonNull BlockGeneratorConfig blockGeneratorConfig) {
         this.rootFolder = blockGeneratorConfig.folderRootPath();
+    }
+
+    /**
+     * Initialize the block stream manager and load blocks into memory.
+     */
+    @Override
+    public void init() {
         try {
             this.loadBlocks();
         } catch (IOException | ParseException | IllegalArgumentException e) {

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -59,6 +59,13 @@ public class BlockAsFileBlockStreamManager implements BlockStreamManager {
     @Inject
     public BlockAsFileBlockStreamManager(@NonNull BlockGeneratorConfig blockStreamConfig) {
         this.rootFolder = blockStreamConfig.folderRootPath();
+    }
+
+    /**
+     * Initialize the block stream manager and load blocks into memory.
+     */
+    @Override
+    public void init() {
         try {
             this.loadBlocks();
         } catch (IOException | ParseException | IllegalArgumentException e) {

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -65,14 +65,6 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
         this.formatString = "%0" + config.paddedLength() + "d" + config.fileExtension();
     }
 
-    /**
-     * Initialize the block stream manager and load blocks into memory.
-     */
-    @Override
-    public void init() {
-        // Do nothing, because we don't have real initializing and loading blocks into memory for this implementation.
-    }
-
     @Override
     public GenerationMode getGenerationMode() {
         return GenerationMode.DIR;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -65,6 +65,14 @@ public class BlockAsFileLargeDataSets implements BlockStreamManager {
         this.formatString = "%0" + config.paddedLength() + "d" + config.fileExtension();
     }
 
+    /**
+     * Initialize the block stream manager and load blocks into memory.
+     */
+    @Override
+    public void init() {
+        // Do nothing, because we don't have real initializing and loading blocks into memory for this implementation.
+    }
+
     @Override
     public GenerationMode getGenerationMode() {
         return GenerationMode.DIR;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
@@ -28,7 +28,7 @@ public interface BlockStreamManager {
     /**
      * Initialize the block stream manager and load blocks into memory.
      */
-    void init();
+    default void init() {}
 
     /**
      * Get the generation mode.

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
@@ -26,6 +26,11 @@ import java.io.IOException;
 public interface BlockStreamManager {
 
     /**
+     * Initialize the block stream manager and load blocks into memory.
+     */
+    void init();
+
+    /**
      * Get the generation mode.
      *
      * @return the generation mode

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.grpc;
+
+import java.util.List;
+
+public interface ConsumerStreamGrpcClient {
+
+    /**
+     * Initialize, opens a gRPC channel and creates the needed stubs with the passed configuration.
+     */
+    void init();
+
+    void requestBlocks(long startBlock, long endBlock) throws InterruptedException;
+
+    long getConsumedBlocks();
+
+    List<String> getLastKnownStatuses();
+
+    void shutdown();
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
@@ -40,7 +40,7 @@ public interface ConsumerStreamGrpcClient {
     void requestBlocks(long startBlock, long endBlock) throws InterruptedException;
 
     /**
-     * Signals completion of the streaming process to the server.
+     * Shutdown the channel and signals completion of the streaming process to the server.
      * This method should be called to gracefully terminate the stream.
      *
      * @throws InterruptedException if the completion process is interrupted
@@ -60,10 +60,4 @@ public interface ConsumerStreamGrpcClient {
      * @return a list of status messages in chronological order
      */
     List<String> getLastKnownStatuses();
-
-    /**
-     * Shuts down the gRPC channel and releases associated resources.
-     * This method should be called when the client is no longer needed.
-     */
-    void shutdown();
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
@@ -18,18 +18,52 @@ package com.hedera.block.simulator.grpc;
 
 import java.util.List;
 
+/**
+ * Interface defining the contract for a gRPC client that consumes blocks from a stream.
+ * This interface provides methods for initializing, managing, and monitoring block consumption.
+ */
 public interface ConsumerStreamGrpcClient {
 
     /**
-     * Initialize, opens a gRPC channel and creates the needed stubs with the passed configuration.
+     * Initializes the gRPC channel and creates the necessary stubs based on configuration.
+     * This method must be called before any streaming operations can begin.
      */
     void init();
 
+    /**
+     * Requests a stream of blocks from the server within the specified range.
+     *
+     * @param startBlock The block number to start streaming from (inclusive)
+     * @param endBlock The block number to end streaming at (inclusive). Use 0 for infinite streaming
+     * @throws InterruptedException if the streaming process is interrupted
+     */
     void requestBlocks(long startBlock, long endBlock) throws InterruptedException;
 
+    /**
+     * Signals completion of the streaming process to the server.
+     * This method should be called to gracefully terminate the stream.
+     *
+     * @throws InterruptedException if the completion process is interrupted
+     */
+    void completeStreaming() throws InterruptedException;
+
+    /**
+     * Retrieves the total number of blocks that have been consumed from the stream.
+     *
+     * @return the count of consumed blocks
+     */
     long getConsumedBlocks();
 
+    /**
+     * Retrieves the most recent status messages received from the server.
+     *
+     * @return a list of status messages in chronological order
+     */
     List<String> getLastKnownStatuses();
 
+    /**
+     * Shuts down the gRPC channel and releases associated resources.
+     * This method should be called when the client is no longer needed.
+     */
     void shutdown();
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
@@ -16,6 +16,8 @@
 
 package com.hedera.block.simulator.grpc;
 
+import com.hedera.block.simulator.grpc.impl.ConsumerStreamGrpcClientImpl;
+import com.hedera.block.simulator.grpc.impl.PublishStreamGrpcClientImpl;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
@@ -35,6 +37,16 @@ public interface GrpcInjectionModule {
     @Singleton
     @Binds
     PublishStreamGrpcClient bindPublishStreamGrpcClient(PublishStreamGrpcClientImpl publishStreamGrpcClient);
+
+    /**
+     * Binds the ConsumerStreamGrpcClient to the ConsumerStreamGrpcClientImpl.
+     *
+     * @param consumerStreamGrpcClient the ConsumerStreamGrpcClientImpl
+     * @return the ConsumerStreamGrpcClient
+     */
+    @Singleton
+    @Binds
+    ConsumerStreamGrpcClient bindConsumerStreamGrpcClient(ConsumerStreamGrpcClientImpl consumerStreamGrpcClient);
 
     /**
      * Provides the stream enabled flag

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -69,5 +69,5 @@ public interface PublishStreamGrpcClient {
     /**
      * Shutdowns the channel.
      */
-    void shutdown();
+    void shutdown() throws InterruptedException;
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -68,6 +68,8 @@ public interface PublishStreamGrpcClient {
 
     /**
      * Shutdowns the channel.
+     *
+     * @throws InterruptedException if the thread is interrupted
      */
     void shutdown() throws InterruptedException;
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -85,6 +85,7 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
     public void requestBlocks(long startBlock, long endBlock) throws InterruptedException {
         Preconditions.requireWhole(startBlock);
         Preconditions.requireWhole(endBlock);
+        Preconditions.requireGreaterOrEqual(endBlock, startBlock);
 
         consumerStreamObserver = new ConsumerStreamObserver(metricsService, streamLatch, lastKnownStatuses);
 
@@ -99,7 +100,7 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
     }
 
     @Override
-    public void completeStreaming() throws InterruptedException {
+    public void completeStreaming() {
         streamLatch.countDown();
         channel.shutdown();
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.grpc.impl;
+
+import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksConsumed;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
+import com.hedera.block.simulator.metrics.MetricsService;
+import com.hedera.hapi.block.protoc.BlockStreamServiceGrpc;
+import com.hedera.hapi.block.protoc.SubscribeStreamRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import javax.inject.Inject;
+
+public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
+    private final GrpcConfig grpcConfig;
+    private ManagedChannel channel;
+    private BlockStreamServiceGrpc.BlockStreamServiceStub stub;
+    private final MetricsService metricsService;
+    private final List<String> lastKnownStatuses = new ArrayList<>();
+
+    @Inject
+    public ConsumerStreamGrpcClientImpl(
+            @NonNull final GrpcConfig grpcConfig, @NonNull final MetricsService metricsService) {
+        this.grpcConfig = requireNonNull(grpcConfig);
+        this.metricsService = requireNonNull(metricsService);
+    }
+
+    public void init() {
+        channel = ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
+                .usePlaintext()
+                .build();
+        stub = BlockStreamServiceGrpc.newStub(channel);
+        lastKnownStatuses.clear();
+    }
+
+    public void requestBlocks(long startBlock, long endBlock) throws InterruptedException {
+        CountDownLatch streamLatch = new CountDownLatch(1);
+        SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
+                .setStartBlockNumber(startBlock)
+                .setEndBlockNumber(endBlock)
+                .setAllowUnverified(true)
+                .build();
+        stub.subscribeBlockStream(request, new ConsumerStreamObserver(streamLatch));
+
+        streamLatch.await();
+    }
+
+    @Override
+    public long getConsumedBlocks() {
+        return metricsService.get(LiveBlocksConsumed).get();
+    }
+
+    @Override
+    public List<String> getLastKnownStatuses() {
+        return List.copyOf(lastKnownStatuses);
+    }
+
+    public void shutdown() {
+        channel.shutdown();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -19,33 +19,58 @@ package com.hedera.block.simulator.grpc.impl;
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksConsumed;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
 import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.hapi.block.protoc.BlockStreamServiceGrpc;
 import com.hedera.hapi.block.protoc.SubscribeStreamRequest;
+import com.hedera.hapi.block.protoc.SubscribeStreamResponse;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import javax.inject.Inject;
 
+/**
+ * Implementation of {@link ConsumerStreamGrpcClient} that handles the consumption of blocks
+ * via gRPC streaming. This implementation manages the connection to the server and tracks
+ * metrics related to block consumption.
+ */
 public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
+    // Configuration
     private final GrpcConfig grpcConfig;
+
+    // Service dependencies
+    private final MetricsService metricsService;
+
+    // gRPC components
     private ManagedChannel channel;
     private BlockStreamServiceGrpc.BlockStreamServiceStub stub;
-    private final MetricsService metricsService;
-    private final List<String> lastKnownStatuses = new ArrayList<>();
+    private StreamObserver<SubscribeStreamResponse> consumerStreamObserver;
 
+    // State
+    private final List<String> lastKnownStatuses;
+
+    /**
+     * Constructs a new ConsumerStreamGrpcClientImpl with the specified configuration and metrics service.
+     *
+     * @param grpcConfig The configuration for gRPC connection settings
+     * @param metricsService The service for recording consumption metrics
+     * @throws NullPointerException if any parameter is null
+     */
     @Inject
     public ConsumerStreamGrpcClientImpl(
             @NonNull final GrpcConfig grpcConfig, @NonNull final MetricsService metricsService) {
         this.grpcConfig = requireNonNull(grpcConfig);
         this.metricsService = requireNonNull(metricsService);
+        this.lastKnownStatuses = new ArrayList<>();
     }
 
+    @Override
     public void init() {
         channel = ManagedChannelBuilder.forAddress(grpcConfig.serverAddress(), grpcConfig.port())
                 .usePlaintext()
@@ -55,15 +80,26 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
     }
 
     public void requestBlocks(long startBlock, long endBlock) throws InterruptedException {
+        Preconditions.requireWhole(startBlock);
+        Preconditions.requireWhole(endBlock);
+
         CountDownLatch streamLatch = new CountDownLatch(1);
+        consumerStreamObserver = new ConsumerStreamObserver(metricsService, streamLatch);
+
         SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
                 .setStartBlockNumber(startBlock)
                 .setEndBlockNumber(endBlock)
                 .setAllowUnverified(true)
                 .build();
-        stub.subscribeBlockStream(request, new ConsumerStreamObserver(streamLatch));
+        stub.subscribeBlockStream(request, consumerStreamObserver);
 
         streamLatch.await();
+    }
+
+    public void completeStreaming() throws InterruptedException {
+        consumerStreamObserver.onCompleted();
+        // todo(352) Find a suitable solution for removing the sleep
+        Thread.sleep(100);
     }
 
     @Override

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -79,12 +79,13 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
         lastKnownStatuses.clear();
     }
 
+    @Override
     public void requestBlocks(long startBlock, long endBlock) throws InterruptedException {
         Preconditions.requireWhole(startBlock);
         Preconditions.requireWhole(endBlock);
 
         CountDownLatch streamLatch = new CountDownLatch(1);
-        consumerStreamObserver = new ConsumerStreamObserver(metricsService, streamLatch);
+        consumerStreamObserver = new ConsumerStreamObserver(metricsService, streamLatch, lastKnownStatuses);
 
         SubscribeStreamRequest request = SubscribeStreamRequest.newBuilder()
                 .setStartBlockNumber(startBlock)
@@ -96,6 +97,7 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
         streamLatch.await();
     }
 
+    @Override
     public void completeStreaming() throws InterruptedException {
         consumerStreamObserver.onCompleted();
         // todo(352) Find a suitable solution for removing the sleep
@@ -112,6 +114,7 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
         return List.copyOf(lastKnownStatuses);
     }
 
+    @Override
     public void shutdown() {
         channel.shutdown();
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -16,41 +16,90 @@
 
 package com.hedera.block.simulator.grpc.impl;
 
+import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksConsumed;
 import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.INFO;
+import static java.util.Objects.requireNonNull;
 
+import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.hapi.block.protoc.SubscribeStreamResponse;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
+/**
+ * Implementation of StreamObserver that handles responses from the block stream subscription.
+ * This class processes incoming blocks and status messages, updating metrics accordingly.
+ */
 public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamResponse> {
 
+    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
+
+    // Service dependencies
+    private final MetricsService metricsService;
+
+    // State
     private final CountDownLatch streamLatch;
 
-    public ConsumerStreamObserver(CountDownLatch streamLatch) {
-        this.streamLatch = streamLatch;
+    /**
+     * Constructs a new ConsumerStreamObserver.
+     *
+     * @param metricsService The service for recording consumption metrics
+     * @param streamLatch A latch used to coordinate stream completion
+     * @throws NullPointerException if any parameter is null
+     */
+    public ConsumerStreamObserver(
+            @NonNull final MetricsService metricsService, @NonNull final CountDownLatch streamLatch) {
+        this.metricsService = requireNonNull(metricsService);
+        this.streamLatch = requireNonNull(streamLatch);
     }
 
+    /**
+     * Processes incoming stream responses, handling both status messages and block items.
+     *
+     * @param subscribeStreamResponse The response received from the server
+     * @throws IllegalArgumentException if an unknown response type is received
+     */
     @Override
     public void onNext(SubscribeStreamResponse subscribeStreamResponse) {
-        LOGGER.log(INFO, "Received Response: " + subscribeStreamResponse.toString());
-        // WIP,
-        // metricService.get(LiveBlocksConsumed).increment() when a whole block is received.
-        // we still need to do something with those blocks
+        final SubscribeStreamResponse.ResponseCase responseType = subscribeStreamResponse.getResponseCase();
+
+        switch (responseType) {
+            case STATUS -> LOGGER.log(INFO, "Received Response: " + subscribeStreamResponse);
+            case BLOCK_ITEMS -> processBlockItems(
+                    subscribeStreamResponse.getBlockItems().getBlockItemsList());
+            default -> throw new IllegalArgumentException("Unknown response type: " + responseType);
+        }
     }
 
+    /**
+     * Handles stream errors by logging the error and releasing the stream latch.
+     *
+     * @param streamError The error that occurred during streaming
+     */
     @Override
     public void onError(Throwable streamError) {
         Status status = Status.fromThrowable(streamError);
-        LOGGER.log(ERROR, "Stream error: {0}, status: {1}.", streamError, status);
+        LOGGER.log(ERROR, "Error %s with status %s.".formatted(streamError, status), streamError);
         streamLatch.countDown();
     }
 
+    /**
+     * Handles stream completion by logging the event and releasing the stream latch.
+     */
     @Override
     public void onCompleted() {
         LOGGER.log(INFO, "Subscribe request completed.");
         streamLatch.countDown();
+    }
+
+    private void processBlockItems(List<BlockItem> blockItems) {
+        blockItems.stream()
+                .filter(BlockItem::hasBlockProof)
+                .forEach(__ -> metricsService.get(LiveBlocksConsumed).increment());
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.grpc.impl;
+
+import static java.lang.System.Logger.Level.ERROR;
+import static java.lang.System.Logger.Level.INFO;
+
+import com.hedera.hapi.block.protoc.SubscribeStreamResponse;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.CountDownLatch;
+
+public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamResponse> {
+
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+    private final CountDownLatch streamLatch;
+
+    public ConsumerStreamObserver(CountDownLatch streamLatch) {
+        this.streamLatch = streamLatch;
+    }
+
+    @Override
+    public void onNext(SubscribeStreamResponse subscribeStreamResponse) {
+        LOGGER.log(INFO, "Received Response: " + subscribeStreamResponse.toString());
+        // WIP,
+        // metricService.get(LiveBlocksConsumed).increment() when a whole block is received.
+        // we still need to do something with those blocks
+    }
+
+    @Override
+    public void onError(Throwable streamError) {
+        Status status = Status.fromThrowable(streamError);
+        LOGGER.log(ERROR, "Stream error: {0}, status: {1}.", streamError, status);
+        streamLatch.countDown();
+    }
+
+    @Override
+    public void onCompleted() {
+        LOGGER.log(INFO, "Subscribe request completed.");
+        streamLatch.countDown();
+    }
+}

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -44,6 +44,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
 
     // State
     private final CountDownLatch streamLatch;
+    private final List<String> lastKnownStatuses;
 
     /**
      * Constructs a new ConsumerStreamObserver.
@@ -53,9 +54,12 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
      * @throws NullPointerException if any parameter is null
      */
     public ConsumerStreamObserver(
-            @NonNull final MetricsService metricsService, @NonNull final CountDownLatch streamLatch) {
+            @NonNull final MetricsService metricsService,
+            @NonNull final CountDownLatch streamLatch,
+            @NonNull final List<String> lastKnownStatuses) {
         this.metricsService = requireNonNull(metricsService);
         this.streamLatch = requireNonNull(streamLatch);
+        this.lastKnownStatuses = requireNonNull(lastKnownStatuses);
     }
 
     /**
@@ -67,6 +71,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     @Override
     public void onNext(SubscribeStreamResponse subscribeStreamResponse) {
         final SubscribeStreamResponse.ResponseCase responseType = subscribeStreamResponse.getResponseCase();
+        lastKnownStatuses.add(subscribeStreamResponse.toString());
 
         switch (responseType) {
             case STATUS -> LOGGER.log(INFO, "Received Response: " + subscribeStreamResponse);
@@ -84,6 +89,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     @Override
     public void onError(Throwable streamError) {
         Status status = Status.fromThrowable(streamError);
+        lastKnownStatuses.add(status.toString());
         LOGGER.log(ERROR, "Error %s with status %s.".formatted(streamError, status), streamError);
         streamLatch.countDown();
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -51,6 +51,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
      *
      * @param metricsService The service for recording consumption metrics
      * @param streamLatch A latch used to coordinate stream completion
+     * @param lastKnownStatuses List to store the most recent status messages
      * @throws NullPointerException if any parameter is null
      */
     public ConsumerStreamObserver(

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -35,8 +35,6 @@ import java.util.concurrent.CountDownLatch;
  * This class processes incoming blocks and status messages, updating metrics accordingly.
  */
 public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamResponse> {
-
-    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     // Service dependencies
@@ -105,8 +103,10 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     }
 
     private void processBlockItems(List<BlockItem> blockItems) {
-        blockItems.stream()
-                .filter(BlockItem::hasBlockProof)
-                .forEach(__ -> metricsService.get(LiveBlocksConsumed).increment());
+        blockItems.stream().filter(BlockItem::hasBlockProof).forEach(blockItem -> {
+            metricsService.get(LiveBlocksConsumed).increment();
+            LOGGER.log(
+                    INFO, "Received block number: " + blockItem.getBlockProof().getBlock());
+        });
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -48,7 +48,6 @@ import javax.inject.Inject;
  * block chunking, and tracks metrics related to block publication.
  */
 public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
-    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     // Configuration
@@ -196,7 +195,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
      * Shutdowns the channel.
      */
     @Override
-    public void shutdown() {
+    public void shutdown() throws InterruptedException {
+        completeStreaming();
         channel.shutdown();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -193,6 +193,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
     /**
      * Shutdowns the channel.
+     *
+     * @throws InterruptedException if the thread is interrupted
      */
     @Override
     public void shutdown() throws InterruptedException {

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.block.simulator.grpc;
+package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlockItemsSent;
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksSent;
@@ -26,6 +26,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.block.common.utils.ChunkUtils;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
 import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.hapi.block.protoc.BlockItemSet;
 import com.hedera.hapi.block.protoc.BlockStreamServiceGrpc;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -64,7 +64,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
     // State
     private final AtomicBoolean streamEnabled;
-    private final List<String> lastKnownStatuses;
+    private final List<String> lastKnownStatuses = new ArrayList<>();
 
     /**
      * Creates a new PublishStreamGrpcClientImpl with the specified dependencies.
@@ -85,7 +85,6 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
         this.metricsService = requireNonNull(metricsService);
         this.streamEnabled = requireNonNull(streamEnabled);
-        this.lastKnownStatuses = new ArrayList<>();
     }
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -32,8 +32,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * This class processes server responses and manages the stream state based on server feedback.
  */
 public class PublishStreamObserver implements StreamObserver<PublishStreamResponse> {
-
-    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     // State

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.block.simulator.grpc;
+package com.hedera.block.simulator.grpc.impl;
 
 import static java.lang.System.Logger.Level.INFO;
 import static java.util.Objects.requireNonNull;

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
@@ -38,7 +38,9 @@ public final class SimulatorMetricTypes {
         /** The number of live block items sent by the simulator . */
         LiveBlockItemsSent("live_block_items_sent", "Live Block Items Sent"),
         /** The number of live blocks sent by the simulator */
-        LiveBlocksSent("live_blocks_sent", "Live Blocks Sent");
+        LiveBlocksSent("live_blocks_sent", "Live Blocks Sent"),
+        /** The number of live blocks consumed by the simulator */
+        LiveBlocksConsumed("live_blocks_consumed", "Live Blocks Consumed");
 
         private final String grafanaLabel;
         private final String description;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -16,10 +16,7 @@
 
 package com.hedera.block.simulator.mode;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * The {@code CombinedModeHandler} class implements the {@link SimulatorModeHandler} interface
@@ -34,17 +31,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * {@link UnsupportedOperationException}.
  */
 public class CombinedModeHandler implements SimulatorModeHandler {
-    private final BlockStreamConfig blockStreamConfig;
 
     /**
      * Constructs a new {@code CombinedModeHandler} with the specified configuration.
-     *
-     * @param blockStreamConfig The configuration for block streaming parameters
-     * @throws NullPointerException if blockStreamConfig is null
      */
-    public CombinedModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
-        this.blockStreamConfig = requireNonNull(blockStreamConfig);
-    }
+    public CombinedModeHandler() {}
 
     /**
      * Initializes resources for both consuming and publishing blocks.

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -37,20 +37,29 @@ public class CombinedModeHandler implements SimulatorModeHandler {
     private final BlockStreamConfig blockStreamConfig;
 
     /**
-     * Constructs a new {@code CombinedModeHandler} with the specified block stream configuration.
+     * Constructs a new {@code CombinedModeHandler} with the specified configuration.
      *
-     * @param blockStreamConfig the configuration data for managing block streams
+     * @param blockStreamConfig The configuration for block streaming parameters
+     * @throws NullPointerException if blockStreamConfig is null
      */
     public CombinedModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
     }
 
     /**
-     * Starts the simulator in combined mode, handling both consumption and publication
-     * of block stream. However, this method is currently not implemented, and will throw
-     * an {@link UnsupportedOperationException}.
+     * Initializes resources for both consuming and publishing blocks.
      *
-     * @throws UnsupportedOperationException as the method is not yet implemented
+     * @throws UnsupportedOperationException as this functionality is not yet implemented
+     */
+    @Override
+    public void init() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Starts both consuming and publishing blocks simultaneously.
+     *
+     * @throws UnsupportedOperationException as this functionality is not yet implemented
      */
     @Override
     public void start() {
@@ -58,7 +67,9 @@ public class CombinedModeHandler implements SimulatorModeHandler {
     }
 
     /**
-     * Stops the handler and manager from streaming.
+     * Gracefully stops both consumption and publishing of blocks.
+     *
+     * @throws UnsupportedOperationException as this functionality is not yet implemented
      */
     @Override
     public void stop() {

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator.mode;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
+import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -34,24 +35,25 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * {@link UnsupportedOperationException}.
  */
 public class ConsumerModeHandler implements SimulatorModeHandler {
-
+    private final System.Logger LOGGER = System.getLogger(getClass().getName());
+    private final ConsumerStreamGrpcClient consumerStreamGrpcClient;
     private final BlockStreamConfig blockStreamConfig;
 
-    /**
-     * Constructs a new {@code ConsumerModeHandler} with the specified block stream configuration.
-     *
-     * @param blockStreamConfig the configuration data for managing block streams
-     */
-    public ConsumerModeHandler(@NonNull final BlockStreamConfig blockStreamConfig) {
+    public ConsumerModeHandler(
+            @NonNull final BlockStreamConfig blockStreamConfig,
+            @NonNull final ConsumerStreamGrpcClient consumerStreamGrpcClient) {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
+        this.consumerStreamGrpcClient = requireNonNull(consumerStreamGrpcClient);
     }
 
     /**
      * Starts the simulator and initiate streaming, depending on the working mode.
      */
     @Override
-    public void start() {
-        throw new UnsupportedOperationException();
+    public void start() throws InterruptedException {
+        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator is starting in consumer mode.");
+        // WIP
+        consumerStreamGrpcClient.requestBlocks(0, 0);
     }
 
     /**
@@ -59,6 +61,7 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
      */
     @Override
     public void stop() {
+        // WIP
         throw new UnsupportedOperationException();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -36,11 +36,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * {@link UnsupportedOperationException}.
  */
 public class ConsumerModeHandler implements SimulatorModeHandler {
-    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
-
-    // Configuration
-    private final BlockStreamConfig blockStreamConfig;
 
     // Service dependencies
     private final ConsumerStreamGrpcClient consumerStreamGrpcClient;
@@ -48,14 +44,10 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
     /**
      * Constructs a new {@code ConsumerModeHandler} with the specified dependencies.
      *
-     * @param blockStreamConfig The configuration for block streaming parameters
      * @param consumerStreamGrpcClient The client for consuming blocks via gRPC
      * @throws NullPointerException if any parameter is null
      */
-    public ConsumerModeHandler(
-            @NonNull final BlockStreamConfig blockStreamConfig,
-            @NonNull final ConsumerStreamGrpcClient consumerStreamGrpcClient) {
-        this.blockStreamConfig = requireNonNull(blockStreamConfig);
+    public ConsumerModeHandler(@NonNull final ConsumerStreamGrpcClient consumerStreamGrpcClient) {
         this.consumerStreamGrpcClient = requireNonNull(consumerStreamGrpcClient);
     }
 
@@ -88,6 +80,5 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
     @Override
     public void stop() throws InterruptedException {
         consumerStreamGrpcClient.completeStreaming();
-        consumerStreamGrpcClient.shutdown();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -70,7 +70,7 @@ public class ConsumerModeHandler implements SimulatorModeHandler {
 
     /**
      * Starts consuming blocks from the stream beginning at genesis (block 0).
-     * Currently requests an infinite stream of blocks starting from genesis.
+     * Currently, requests an infinite stream of blocks starting from genesis.
      *
      * @throws InterruptedException if the consumption process is interrupted
      */

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -46,27 +46,31 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * the simulator needs to handle publication of blocks.
  */
 public class PublisherModeHandler implements SimulatorModeHandler {
+    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
-    private final BlockStreamManager blockStreamManager;
+
+    // Configuration fields
     private final BlockStreamConfig blockStreamConfig;
-    private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final StreamingMode streamingMode;
     private final int delayBetweenBlockItems;
     private final int millisecondsPerBlock;
+
+    // Service dependencies
+    private final BlockStreamManager blockStreamManager;
+    private final PublishStreamGrpcClient publishStreamGrpcClient;
     private final MetricsService metricsService;
-    private final AtomicBoolean shouldPublish = new AtomicBoolean(true);
+
+    // State fields
+    private final AtomicBoolean shouldPublish;
 
     /**
-     * Constructs a new {@code PublisherModeHandler} with the specified block stream
-     * configuration and publisher client.
+     * Constructs a new {@code PublisherModeHandler} with the specified dependencies.
      *
-     * @param blockStreamConfig       the configuration data for managing block
-     *                                streams
-     * @param publishStreamGrpcClient the grpc client used for streaming blocks
-     * @param blockStreamManager      the block stream manager, responsible for
-     *                                generating blocks
-     * @param metricsService          the metrics service to record and report usage
-     *                                statistics
+     * @param blockStreamConfig The configuration for block streaming parameters
+     * @param publishStreamGrpcClient The client for publishing blocks via gRPC
+     * @param blockStreamManager The manager responsible for block generation
+     * @param metricsService The service for recording metrics
+     * @throws NullPointerException if any parameter is null
      */
     public PublisherModeHandler(
             @NonNull final BlockStreamConfig blockStreamConfig,
@@ -81,6 +85,12 @@ public class PublisherModeHandler implements SimulatorModeHandler {
         streamingMode = blockStreamConfig.streamingMode();
         delayBetweenBlockItems = blockStreamConfig.delayBetweenBlockItems();
         millisecondsPerBlock = blockStreamConfig.millisecondsPerBlock();
+        shouldPublish = new AtomicBoolean(true);
+    }
+
+    public void init() {
+        publishStreamGrpcClient.init();
+        LOGGER.log(INFO, "gRPC Channel initialized for publishing blocks.");
     }
 
     /**
@@ -95,7 +105,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
      */
     @Override
     public void start() throws BlockSimulatorParsingException, IOException, InterruptedException {
-        LOGGER.log(System.Logger.Level.INFO, "Block Stream Simulator has started streaming.");
+        LOGGER.log(INFO, "Block Stream Simulator is starting in publisher mode.");
         if (streamingMode == StreamingMode.MILLIS_PER_BLOCK) {
             millisPerBlockStreaming();
         } else {
@@ -170,7 +180,9 @@ public class PublisherModeHandler implements SimulatorModeHandler {
      * Stops the handler and manager from streaming.
      */
     @Override
-    public void stop() {
+    public void stop() throws InterruptedException {
         shouldPublish.set(false);
+        publishStreamGrpcClient.completeStreaming();
+        publishStreamGrpcClient.shutdown();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -89,6 +89,7 @@ public class PublisherModeHandler implements SimulatorModeHandler {
     }
 
     public void init() {
+        blockStreamManager.init();
         publishStreamGrpcClient.init();
         LOGGER.log(INFO, "gRPC Channel initialized for publishing blocks.");
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * the simulator needs to handle publication of blocks.
  */
 public class PublisherModeHandler implements SimulatorModeHandler {
-    /** Logger for this class */
     private final System.Logger LOGGER = System.getLogger(getClass().getName());
 
     // Configuration fields
@@ -183,7 +182,6 @@ public class PublisherModeHandler implements SimulatorModeHandler {
     @Override
     public void stop() throws InterruptedException {
         shouldPublish.set(false);
-        publishStreamGrpcClient.completeStreaming();
         publishStreamGrpcClient.shutdown();
     }
 }

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -31,17 +31,18 @@ import java.io.IOException;
  *   <li>Publisher mode: The simulator publishes data to the block stream.</li>
  *   <li>Combined mode: The simulator handles both consuming and publishing.</li>
  * </ul>
- *
- * <p>The {@code SimulatorModeHandler} is responsible for managing the simulator lifecycle,
- * starting and stopping the streaming of blocks and handling any exceptions that may arise
- * during the process.
  */
 public interface SimulatorModeHandler {
 
     /**
-     * Starts the simulator and initiates the streaming process, based on the
-     * configuration. The behavior
-     * of this method depends on the specific working mode (e.g., consumer, publisher, both).
+     * Initializes the handler by setting up required resources and connections.
+     * This method should be called before {@link #start()}.
+     */
+    void init();
+
+    /**
+     * Starts the simulator and initiates the streaming process according to the configured mode.
+     * The behavior of this method depends on the specific working mode (consumer, publisher, or combined).
      *
      * @throws BlockSimulatorParsingException if an error occurs while parsing blocks
      * @throws IOException if an I/O error occurs during block streaming
@@ -50,7 +51,9 @@ public interface SimulatorModeHandler {
     void start() throws BlockSimulatorParsingException, IOException, InterruptedException;
 
     /**
-     * Stops the handler and manager from streaming.
+     * Gracefully stops the handler, cleaning up resources and terminating any active streams.
+     *
+     * @throws InterruptedException if the shutdown process is interrupted
      */
-    void stop();
+    void stop() throws InterruptedException;
 }

--- a/simulator/src/main/java/module-info.java
+++ b/simulator/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.hedera.block.simulator {
     exports com.hedera.block.simulator.grpc;
     exports com.hedera.block.simulator.generator;
     exports com.hedera.block.simulator.metrics;
+    exports com.hedera.block.simulator.grpc.impl;
 
     requires static com.github.spotbugs.annotations;
     requires static com.google.auto.service;

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -60,302 +60,279 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BlockStreamSimulatorTest {
 
-        @Mock
-        private BlockStreamManager blockStreamManager;
+    @Mock
+    private BlockStreamManager blockStreamManager;
 
-        @Mock
-        private PublishStreamGrpcClient publishStreamGrpcClient;
+    @Mock
+    private PublishStreamGrpcClient publishStreamGrpcClient;
 
-        @Mock
-        private ConsumerStreamGrpcClient consumerStreamGrpcClient;
+    @Mock
+    private ConsumerStreamGrpcClient consumerStreamGrpcClient;
 
-        private BlockStreamSimulatorApp blockStreamSimulator;
-        private MetricsService metricsService;
+    private BlockStreamSimulatorApp blockStreamSimulator;
+    private MetricsService metricsService;
 
-        @BeforeEach
-        void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
 
-                Configuration configuration = TestUtils.getTestConfiguration(
-                                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode",
-                                                "CONSTANT_RATE"));
+        Configuration configuration = TestUtils.getTestConfiguration(
+                Map.of("blockStream.maxBlockItemsToStream", "100", "blockStream.streamingMode", "CONSTANT_RATE"));
 
-                metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-                blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        try {
+            blockStreamSimulator.stop();
+        } catch (UnsupportedOperationException e) {
+            // @todo (121) Implement consumer logic in the Simulator, which will fix this
         }
+    }
 
-        @AfterEach
-        void tearDown() throws InterruptedException {
-                try {
-                        blockStreamSimulator.stop();
-                } catch (UnsupportedOperationException e) {
-                        // @todo (121) Implement consumer logic in the Simulator, which will fix this
-                }
-        }
+    @Test
+    void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
 
-        @Test
-        void start_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
-                blockStreamSimulator.start();
-                assertTrue(blockStreamSimulator.isRunning());
-        }
+    @Test
+    void startPublishing_logsStartedMessage() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
 
-        @Test
-        void startPublishing_logsStartedMessage()
-                        throws InterruptedException, BlockSimulatorParsingException, IOException {
-                blockStreamSimulator.start();
-                assertTrue(blockStreamSimulator.isRunning());
-        }
+    @Test
+    void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
 
-        @Test
-        void startConsuming() throws IOException, BlockSimulatorParsingException, InterruptedException {
-                Configuration configuration = TestUtils
-                                .getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
+        blockStreamSimulator.start();
 
-                metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-                blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
-                blockStreamSimulator.start();
+        verify(consumerStreamGrpcClient).init();
+        verify(consumerStreamGrpcClient).requestBlocks(0, 0);
+        assertTrue(blockStreamSimulator.isRunning());
+    }
 
-                verify(consumerStreamGrpcClient).init();
-                verify(consumerStreamGrpcClient).requestBlocks(0, 0);
-                assertTrue(blockStreamSimulator.isRunning());
-        }
+    @Test
+    void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
 
-        @Test
-        void start_constantRateStreaming() throws InterruptedException, BlockSimulatorParsingException, IOException {
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
 
-                BlockItem blockItem = BlockItem.newBuilder()
-                                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                                .build();
+        Block block1 = Block.newBuilder().addItems(blockItem).build();
+        Block block2 = Block.newBuilder()
+                .addItems(blockItem)
+                .addItems(blockItem)
+                .addItems(blockItem)
+                .build();
 
-                Block block1 = Block.newBuilder().addItems(blockItem).build();
-                Block block2 = Block.newBuilder()
-                                .addItems(blockItem)
-                                .addItems(blockItem)
-                                .addItems(blockItem)
-                                .build();
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER",
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "CONSTANT_RATE",
+                "blockStream.blockItemsBatchSize",
+                "2"));
 
-                BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-                when(blockStreamManager.getNextBlock()).thenReturn(block1, block2, null);
-                Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                                "blockStream.simulatorMode",
-                                "PUBLISHER",
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.streamingMode",
-                                "CONSTANT_RATE",
-                                "blockStream.blockItemsBatchSize",
-                                "2"));
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
 
-                BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
 
-                blockStreamSimulator.start();
-                assertTrue(blockStreamSimulator.isRunning());
-        }
+    private String getAbsoluteFolder(String relativePath) {
+        return Paths.get(relativePath).toAbsolutePath().toString();
+    }
 
-        @Test
-        void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
-                Configuration configuration = TestUtils
-                                .getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER"));
+    @Test
+    void stopPublishing_doesNotThrowException() throws InterruptedException, IOException {
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "PUBLISHER"));
 
-                metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-                blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
 
-                assertDoesNotThrow(() -> blockStreamSimulator.stop());
-                assertFalse(blockStreamSimulator.isRunning());
-                verify(publishStreamGrpcClient, atLeast(1)).completeStreaming();
-        }
+        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+        assertFalse(blockStreamSimulator.isRunning());
+        verify(publishStreamGrpcClient, atLeast(1)).shutdown();
+    }
 
-        @Test
-        void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
-                Configuration configuration = TestUtils
-                                .getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
+    @Test
+    void stopConsuming_doesNotThrowException() throws InterruptedException, IOException {
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "CONSUMER"));
 
-                metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
-                blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
-                assertDoesNotThrow(() -> blockStreamSimulator.stop());
-                assertFalse(blockStreamSimulator.isRunning());
-                verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
-        }
+        metricsService = new MetricsServiceImpl(getTestMetrics(configuration));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
+        assertDoesNotThrow(() -> blockStreamSimulator.stop());
+        assertFalse(blockStreamSimulator.isRunning());
+        verify(consumerStreamGrpcClient, atLeast(1)).completeStreaming();
+    }
 
-        @Test
-        void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
-                BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-                BlockItem blockItem = BlockItem.newBuilder()
-                                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                                .build();
-                Block block = Block.newBuilder().addItems(blockItem).build();
-                when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+    @Test
+    void start_millisPerBlockStreaming() throws InterruptedException, IOException, BlockSimulatorParsingException {
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
+        Block block = Block.newBuilder().addItems(blockItem).build();
+        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
 
-                Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                                "blockStream.simulatorMode",
-                                "PUBLISHER",
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.streamingMode",
-                                "MILLIS_PER_BLOCK"));
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER",
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "generator.managerImplementation",
+                "BlockAsFileLargeDataSets",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK"));
 
-                Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "generator.managerImplementation",
-                                "BlockAsFileLargeDataSets",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.streamingMode",
-                                "MILLIS_PER_BLOCK"));
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
 
-                BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
+    }
 
-                blockStreamSimulator.start();
-                assertTrue(blockStreamSimulator.isRunning());
-        }
+    @Test
+    void start_millisPerSecond_streamingLagVerifyWarnLog()
+            throws InterruptedException, IOException, BlockSimulatorParsingException {
+        BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
+        BlockItem blockItem = BlockItem.newBuilder()
+                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
+                .build();
+        Block block = Block.newBuilder().addItems(blockItem).build();
+        when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
+        PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
 
-        @Test
-        void start_millisPerSecond_streamingLagVerifyWarnLog()
-                        throws InterruptedException, IOException, BlockSimulatorParsingException {
-                BlockStreamManager blockStreamManager = mock(BlockStreamManager.class);
-                BlockItem blockItem = BlockItem.newBuilder()
-                                .setBlockHeader(BlockHeader.newBuilder().setNumber(1L).build())
-                                .build();
-                Block block = Block.newBuilder().addItems(blockItem).build();
-                when(blockStreamManager.getNextBlock()).thenReturn(block, block, null);
-                PublishStreamGrpcClient publishStreamGrpcClient = mock(PublishStreamGrpcClient.class);
+        // simulate that the first block takes 15ms to stream, when the limit is 10, to
+        // force to go
+        // over WARN Path.
+        when(publishStreamGrpcClient.streamBlock(any()))
+                .thenAnswer(invocation -> {
+                    Thread.sleep(15);
+                    return true;
+                })
+                .thenReturn(true);
 
-                // simulate that the first block takes 15ms to stream, when the limit is 10, to
-                // force to go
-                // over WARN Path.
-                when(publishStreamGrpcClient.streamBlock(any()))
-                                .thenAnswer(invocation -> {
-                                        Thread.sleep(15);
-                                        return true;
-                                })
-                                .thenReturn(true);
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of(
+                "blockStream.simulatorMode",
+                "PUBLISHER",
+                "generator.managerImplementation",
+                "BlockAsFileBlockStreamManager",
+                "generator.rootPath",
+                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
+                "blockStream.maxBlockItemsToStream",
+                "2",
+                "blockStream.streamingMode",
+                "MILLIS_PER_BLOCK",
+                "blockStream.millisecondsPerBlock",
+                "10",
+                "blockStream.blockItemsBatchSize",
+                "1"));
 
-                Configuration configuration = TestUtils.getTestConfiguration(Map.of(
-                                "blockStream.simulatorMode",
-                                "PUBLISHER",
-                                "generator.managerImplementation",
-                                "BlockAsFileBlockStreamManager",
-                                "generator.rootPath",
-                                getAbsoluteFolder("src/test/resources/block-0.0.3-blk/"),
-                                "blockStream.maxBlockItemsToStream",
-                                "2",
-                                "blockStream.streamingMode",
-                                "MILLIS_PER_BLOCK",
-                                "blockStream.millisecondsPerBlock",
-                                "10",
-                                "blockStream.blockItemsBatchSize",
-                                "1"));
+        BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
+        List<LogRecord> logRecords = captureLogs();
 
-                BlockStreamSimulatorApp blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
-                List<LogRecord> logRecords = captureLogs();
+        blockStreamSimulator.start();
+        assertTrue(blockStreamSimulator.isRunning());
 
-                blockStreamSimulator.start();
-                assertTrue(blockStreamSimulator.isRunning());
+        // Assert log exists
+        boolean found_log = logRecords.stream()
+                .anyMatch(logRecord -> logRecord.getMessage().contains("Block Server is running behind"));
+        assertTrue(found_log);
+    }
 
-                // Assert log exists
-                boolean found_log = logRecords.stream()
-                                .anyMatch(logRecord -> logRecord.getMessage()
-                                                .contains("Block Server is running behind"));
-                assertTrue(found_log);
-        }
+    @Test
+    void start_withBothMode_throwsUnsupportedOperationException() throws Exception {
+        Configuration configuration = TestUtils.getTestConfiguration(Map.of("blockStream.simulatorMode", "BOTH"));
+        blockStreamSimulator = new BlockStreamSimulatorApp(
+                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient, metricsService);
+        assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
+    }
 
-        @Test
-        void start_withBothMode_throwsUnsupportedOperationException() throws Exception {
-                Configuration configuration = TestUtils
-                                .getTestConfiguration(Map.of("blockStream.simulatorMode", "BOTH"));
-                blockStreamSimulator = new BlockStreamSimulatorApp(
-                                configuration, blockStreamManager, publishStreamGrpcClient, consumerStreamGrpcClient,
-                                metricsService);
-                assertThrows(UnsupportedOperationException.class, () -> blockStreamSimulator.start());
-        }
+    @Test
+    void constructor_throwsExceptionForNullSimulatorMode() {
+        Configuration configuration = mock(Configuration.class);
+        BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
 
-        @Test
-        void constructor_throwsExceptionForNullSimulatorMode() {
-                Configuration configuration = mock(Configuration.class);
-                BlockStreamConfig blockStreamConfig = mock(BlockStreamConfig.class);
+        when(configuration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.simulatorMode()).thenReturn(null);
 
-                when(configuration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
-                when(blockStreamConfig.simulatorMode()).thenReturn(null);
+        assertThrows(NullPointerException.class, () -> {
+            new BlockStreamSimulatorApp(
+                    configuration,
+                    blockStreamManager,
+                    publishStreamGrpcClient,
+                    consumerStreamGrpcClient,
+                    metricsService);
+        });
+    }
 
-                assertThrows(NullPointerException.class, () -> {
-                        new BlockStreamSimulatorApp(
-                                        configuration,
-                                        blockStreamManager,
-                                        publishStreamGrpcClient,
-                                        consumerStreamGrpcClient,
-                                        metricsService);
-                });
-        }
+    @Test
+    void testGetStreamStatus() {
+        long expectedPublishedBlocks = 5;
+        List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
 
-        @Test
-        void testGetStreamStatus() {
-                long expectedPublishedBlocks = 5;
-                List<String> expectedLastKnownStatuses = List.of("Status1", "Status2");
+        when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
+        when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
 
-                when(publishStreamGrpcClient.getPublishedBlocks()).thenReturn(expectedPublishedBlocks);
-                when(publishStreamGrpcClient.getLastKnownStatuses()).thenReturn(expectedLastKnownStatuses);
+        StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
 
-                StreamStatus streamStatus = blockStreamSimulator.getStreamStatus();
+        assertNotNull(streamStatus, "StreamStatus should not be null");
+        assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
+        assertEquals(
+                expectedLastKnownStatuses,
+                streamStatus.lastKnownPublisherStatuses(),
+                "Last known statuses should match");
+        assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
+        assertEquals(
+                0,
+                streamStatus.lastKnownConsumersStatuses().size(),
+                "Last known consumers statuses should be empty by default");
+    }
 
-                assertNotNull(streamStatus, "StreamStatus should not be null");
-                assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
-                assertEquals(
-                                expectedLastKnownStatuses,
-                                streamStatus.lastKnownPublisherStatuses(),
-                                "Last known statuses should match");
-                assertEquals(0, streamStatus.consumedBlocks(), "Consumed blocks should be 0 by default");
-                assertEquals(
-                                0,
-                                streamStatus.lastKnownConsumersStatuses().size(),
-                                "Last known consumers statuses should be empty by default");
-        }
+    private List<LogRecord> captureLogs() {
+        // Capture logs
+        Logger logger = Logger.getLogger(PublisherModeHandler.class.getName());
+        final List<LogRecord> logRecords = new ArrayList<>();
 
-        private List<LogRecord> captureLogs() {
-                // Capture logs
-                Logger logger = Logger.getLogger(PublisherModeHandler.class.getName());
-                final List<LogRecord> logRecords = new ArrayList<>();
+        // Custom handler to capture logs
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                logRecords.add(record);
+            }
 
-                // Custom handler to capture logs
-                Handler handler = new Handler() {
-                        @Override
-                        public void publish(LogRecord record) {
-                                logRecords.add(record);
-                        }
+            @Override
+            public void flush() {}
 
-                        @Override
-                        public void flush() {
-                        }
+            @Override
+            public void close() throws SecurityException {}
+        };
 
-                        @Override
-                        public void close() throws SecurityException {
-                        }
-                };
+        // Add handler to logger
+        logger.addHandler(handler);
 
-                // Add handler to logger
-                logger.addHandler(handler);
-
-                return logRecords;
-        }
+        return logRecords;
+    }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
@@ -24,6 +24,7 @@ import com.swirlds.config.extensions.sources.SimpleConfigSource;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -54,5 +55,11 @@ public class TestUtils {
         final Metrics metrics = metricsProvider.createGlobalMetrics();
         metricsProvider.start();
         return metrics;
+    }
+
+    public static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
@@ -46,6 +46,7 @@ class BlockAsDirBlockStreamManagerTest {
     @Test
     void getNextBlockItem() throws IOException, BlockSimulatorParsingException {
         BlockStreamManager blockStreamManager = getBlockAsDirBlockStreamManager(getAbsoluteFolder(rootFolder));
+        blockStreamManager.init();
 
         for (int i = 0; i < 1000; i++) {
             assertNotNull(blockStreamManager.getNextBlockItem());
@@ -55,6 +56,7 @@ class BlockAsDirBlockStreamManagerTest {
     @Test
     void getNextBlock() throws IOException, BlockSimulatorParsingException {
         BlockStreamManager blockStreamManager = getBlockAsDirBlockStreamManager(getAbsoluteFolder(rootFolder));
+        blockStreamManager.init();
 
         for (int i = 0; i < 3000; i++) {
             assertNotNull(blockStreamManager.getNextBlock());
@@ -71,7 +73,8 @@ class BlockAsDirBlockStreamManagerTest {
     private BlockStreamManager getBlockAsDirBlockStreamManager(String rootFolder) {
         final BlockGeneratorConfig blockGeneratorConfig = new BlockGeneratorConfig(
                 GenerationMode.DIR, rootFolder, "BlockAsDirBlockStreamManager", 36, ".blk", 0, 0);
-
-        return new BlockAsDirBlockStreamManager(blockGeneratorConfig);
+        final BlockStreamManager blockStreamManager = new BlockAsDirBlockStreamManager(blockGeneratorConfig);
+        blockStreamManager.init();
+        return blockStreamManager;
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClientImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.hedera.block.simulator.grpc.impl.PublishStreamGrpcClientImpl;
 import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.block.simulator.metrics.MetricsServiceImpl;
 import com.hedera.hapi.block.stream.protoc.Block;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/PublishStreamObserverTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.block.simulator.grpc.impl.PublishStreamObserver;
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
 import java.util.ArrayList;
 import java.util.List;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -16,6 +16,7 @@
 
 package com.hedera.block.simulator.grpc.impl;
 
+import static com.hedera.block.simulator.TestUtils.findFreePort;
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -35,7 +36,6 @@ import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.net.ServerSocket;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,15 +46,13 @@ public class ConsumerStreamGrpcClientImplTest {
     @Mock
     private GrpcConfig grpcConfig;
 
-    private MetricsService metricsService;
     private ConsumerStreamGrpcClient consumerStreamGrpcClientImpl;
     private Server server;
-    private int serverPort;
 
     @BeforeEach
     void setUp() throws IOException {
         MockitoAnnotations.openMocks(this);
-        serverPort = findFreePort();
+        final int serverPort = findFreePort();
         server = ServerBuilder.forPort(serverPort)
                 .addService(new BlockStreamServiceGrpc.BlockStreamServiceImplBase() {
                     @Override
@@ -100,8 +98,8 @@ public class ConsumerStreamGrpcClientImplTest {
         when(grpcConfig.serverAddress()).thenReturn("localhost");
         when(grpcConfig.port()).thenReturn(serverPort);
 
-        Configuration config = TestUtils.getTestConfiguration();
-        metricsService = new MetricsServiceImpl(getTestMetrics(config));
+        final Configuration config = TestUtils.getTestConfiguration();
+        final MetricsService metricsService = new MetricsServiceImpl(getTestMetrics(config));
         consumerStreamGrpcClientImpl = new ConsumerStreamGrpcClientImpl(grpcConfig, metricsService);
         consumerStreamGrpcClientImpl.init();
     }
@@ -178,12 +176,5 @@ public class ConsumerStreamGrpcClientImplTest {
                         .augmentDescription("Channel shutdown invoked")
                         .toString(),
                 firstStatus);
-    }
-
-    private int findFreePort() throws IOException {
-        // Find a free port
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.grpc.impl;
+
+import static com.hedera.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.hedera.block.simulator.TestUtils;
+import com.hedera.block.simulator.config.data.GrpcConfig;
+import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
+import com.hedera.block.simulator.metrics.MetricsService;
+import com.hedera.block.simulator.metrics.MetricsServiceImpl;
+import com.hedera.hapi.block.protoc.*;
+import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.hedera.hapi.block.stream.protoc.BlockProof;
+import com.swirlds.config.api.Configuration;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class ConsumerStreamGrpcClientImplTest {
+    @Mock
+    private GrpcConfig grpcConfig;
+
+    private MetricsService metricsService;
+    private ConsumerStreamGrpcClient consumerStreamGrpcClientImpl;
+    private Server server;
+    private int serverPort;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MockitoAnnotations.openMocks(this);
+        serverPort = findFreePort();
+        server = ServerBuilder.forPort(serverPort)
+                .addService(new BlockStreamServiceGrpc.BlockStreamServiceImplBase() {
+                    @Override
+                    public void subscribeBlockStream(
+                            SubscribeStreamRequest request, StreamObserver<SubscribeStreamResponse> responseObserver) {
+
+                        // Simulate streaming blocks
+                        long startBlock = request.getStartBlockNumber();
+                        long endBlock = request.getEndBlockNumber();
+
+                        for (long i = startBlock; i < endBlock; i++) {
+                            // Simulate block items
+                            BlockItem blockItemHeader = BlockItem.newBuilder()
+                                    .setBlockHeader(BlockHeader.newBuilder()
+                                            .setNumber(i)
+                                            .build())
+                                    .build();
+                            BlockItem blockItemProof = BlockItem.newBuilder()
+                                    .setBlockProof(
+                                            BlockProof.newBuilder().setBlock(i).build())
+                                    .build();
+
+                            BlockItemSet blockItems = BlockItemSet.newBuilder()
+                                    .addBlockItems(blockItemHeader)
+                                    .addBlockItems(blockItemProof)
+                                    .build();
+
+                            responseObserver.onNext(SubscribeStreamResponse.newBuilder()
+                                    .setBlockItems(blockItems)
+                                    .build());
+                        }
+
+                        // Send success status code at the end
+                        responseObserver.onNext(SubscribeStreamResponse.newBuilder()
+                                .setStatus(SubscribeStreamResponseCode.READ_STREAM_SUCCESS)
+                                .build());
+                        responseObserver.onCompleted();
+                    }
+                })
+                .build()
+                .start();
+
+        when(grpcConfig.serverAddress()).thenReturn("localhost");
+        when(grpcConfig.port()).thenReturn(serverPort);
+
+        Configuration config = TestUtils.getTestConfiguration();
+        metricsService = new MetricsServiceImpl(getTestMetrics(config));
+        consumerStreamGrpcClientImpl = new ConsumerStreamGrpcClientImpl(grpcConfig, metricsService);
+        consumerStreamGrpcClientImpl.init();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        consumerStreamGrpcClientImpl.shutdown();
+        server.shutdownNow();
+    }
+
+    @Test
+    public void testInit() {
+        assertTrue(consumerStreamGrpcClientImpl.getLastKnownStatuses().isEmpty());
+    }
+
+    @Test
+    void requestBlocks_Success() throws InterruptedException {
+        final long startBlock = 0;
+        final long endBlock = 5;
+
+        assertEquals(startBlock, consumerStreamGrpcClientImpl.getConsumedBlocks());
+        assertTrue(consumerStreamGrpcClientImpl.getLastKnownStatuses().isEmpty());
+
+        consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock);
+
+        // We check if the final status matches what we have send from the server.
+        final String lastStatus =
+                consumerStreamGrpcClientImpl.getLastKnownStatuses().getLast();
+        assertTrue(lastStatus.contains("status: %s".formatted(SubscribeStreamResponseCode.READ_STREAM_SUCCESS.name())));
+
+        assertEquals(endBlock, consumerStreamGrpcClientImpl.getConsumedBlocks());
+    }
+
+    @Test
+    void requestBlocks_InvalidStartBlock() {
+        final long startBlock = -1;
+        final long endBlock = 5;
+
+        assertThrows(
+                IllegalArgumentException.class, () -> consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock));
+    }
+
+    @Test
+    void requestBlocks_InvalidEndBlock() {
+        final long startBlock = 0;
+        final long endBlock = -1;
+
+        assertThrows(
+                IllegalArgumentException.class, () -> consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock));
+    }
+
+    @Test
+    void completeStreaming_Success() throws InterruptedException {
+        final long startBlock = 0;
+        final long endBlock = 5;
+
+        consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock);
+        consumerStreamGrpcClientImpl.completeStreaming();
+    }
+
+    @Test
+    void shutdown() throws InterruptedException {
+        final long startBlock = 0;
+        final long endBlock = 5;
+
+        consumerStreamGrpcClientImpl.shutdown();
+        consumerStreamGrpcClientImpl.requestBlocks(startBlock, endBlock);
+
+        // We check if the first status is UNAVAILABLE, because should fail immediately
+        final String firstStatus =
+                consumerStreamGrpcClientImpl.getLastKnownStatuses().getFirst();
+        assertEquals(
+                Status.UNAVAILABLE
+                        .augmentDescription("Channel shutdown invoked")
+                        .toString(),
+                firstStatus);
+    }
+
+    private int findFreePort() throws IOException {
+        // Find a free port
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.grpc.impl;
+
+import static com.hedera.block.simulator.TestUtils.getTestMetrics;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.hedera.block.simulator.TestUtils;
+import com.hedera.block.simulator.metrics.MetricsService;
+import com.hedera.block.simulator.metrics.MetricsServiceImpl;
+import com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter;
+import com.hedera.hapi.block.protoc.BlockItemSet;
+import com.hedera.hapi.block.protoc.SubscribeStreamResponse;
+import com.hedera.hapi.block.protoc.SubscribeStreamResponseCode;
+import com.hedera.hapi.block.stream.protoc.BlockItem;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConsumerStreamObserverTest {
+
+    private MetricsService metricsService;
+    private CountDownLatch streamLatch;
+    private List<String> lastKnownStatuses;
+    private ConsumerStreamObserver observer;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Configuration config = TestUtils.getTestConfiguration();
+
+        metricsService = spy(new MetricsServiceImpl(getTestMetrics(config)));
+        streamLatch = mock(CountDownLatch.class);
+        List<String> lastKnownStatuses = new ArrayList<>();
+
+        observer = new ConsumerStreamObserver(metricsService, streamLatch, lastKnownStatuses);
+    }
+
+    @Test
+    void testConstructorWithNullArguments() {
+        assertThrows(
+                NullPointerException.class, () -> new ConsumerStreamObserver(null, streamLatch, lastKnownStatuses));
+        assertThrows(
+                NullPointerException.class, () -> new ConsumerStreamObserver(metricsService, null, lastKnownStatuses));
+        assertThrows(NullPointerException.class, () -> new ConsumerStreamObserver(metricsService, streamLatch, null));
+    }
+
+    @Test
+    void testOnNextWithStatusResponse() {
+        SubscribeStreamResponse response = SubscribeStreamResponse.newBuilder()
+                .setStatus(SubscribeStreamResponseCode.READ_STREAM_SUCCESS)
+                .build();
+
+        observer.onNext(response);
+
+        verifyNoInteractions(metricsService);
+        verifyNoInteractions(streamLatch);
+    }
+
+    @Test
+    void testOnNextWithBlockItemsResponse() {
+        BlockItem blockItemWithProof = mock(BlockItem.class);
+        when(blockItemWithProof.hasBlockProof()).thenReturn(true);
+
+        BlockItem blockItemWithoutProof = mock(BlockItem.class);
+        when(blockItemWithoutProof.hasBlockProof()).thenReturn(false);
+
+        List<BlockItem> blockItems = Arrays.asList(blockItemWithProof, blockItemWithoutProof, blockItemWithProof);
+        BlockItemSet blockItemSet =
+                BlockItemSet.newBuilder().addAllBlockItems(blockItems).build();
+
+        SubscribeStreamResponse response =
+                SubscribeStreamResponse.newBuilder().setBlockItems(blockItemSet).build();
+        assertEquals(metricsService.get(Counter.LiveBlocksConsumed).get(), 0);
+
+        observer.onNext(response);
+
+        assertEquals(metricsService.get(Counter.LiveBlocksConsumed).get(), 2);
+        verifyNoInteractions(streamLatch);
+    }
+
+    @Test
+    void testOnNextWithUnknownResponseType() {
+        SubscribeStreamResponse response = SubscribeStreamResponse.newBuilder().build();
+
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> observer.onNext(response));
+
+        assertEquals("Unknown response type: RESPONSE_NOT_SET", exception.getMessage());
+        verifyNoInteractions(metricsService);
+        verifyNoInteractions(streamLatch);
+    }
+
+    @Test
+    void testOnError() {
+        Throwable testException = new RuntimeException("Test exception");
+
+        observer.onError(testException);
+
+        verify(streamLatch).countDown();
+        verifyNoInteractions(metricsService);
+    }
+
+    @Test
+    void testOnCompleted() {
+        observer.onCompleted();
+
+        verify(streamLatch).countDown();
+        verifyNoInteractions(metricsService);
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
@@ -17,8 +17,12 @@
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.metrics.MetricsService;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -20,7 +20,7 @@ import static com.hedera.block.simulator.TestUtils.findFreePort;
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
@@ -28,7 +28,11 @@ import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.block.simulator.grpc.PublishStreamGrpcClient;
 import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.block.simulator.metrics.MetricsServiceImpl;
-import com.hedera.hapi.block.protoc.*;
+import com.hedera.hapi.block.protoc.BlockItemSet;
+import com.hedera.hapi.block.protoc.BlockStreamServiceGrpc;
+import com.hedera.hapi.block.protoc.PublishStreamRequest;
+import com.hedera.hapi.block.protoc.PublishStreamResponse;
+import com.hedera.hapi.block.protoc.PublishStreamResponseCode;
 import com.hedera.hapi.block.stream.output.protoc.BlockHeader;
 import com.hedera.hapi.block.stream.protoc.Block;
 import com.hedera.hapi.block.stream.protoc.BlockItem;
@@ -139,7 +143,6 @@ class PublishStreamGrpcClientImplTest {
 
     @AfterEach
     void teardown() throws InterruptedException {
-        publishStreamGrpcClient.completeStreaming();
         publishStreamGrpcClient.shutdown();
 
         if (server != null) {

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.block.simulator.grpc;
+package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import com.hedera.block.simulator.TestUtils;
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
-import com.hedera.block.simulator.grpc.impl.PublishStreamGrpcClientImpl;
 import com.hedera.block.simulator.metrics.MetricsService;
 import com.hedera.block.simulator.metrics.MetricsServiceImpl;
 import com.hedera.hapi.block.stream.protoc.Block;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package com.hedera.block.simulator.grpc;
+package com.hedera.block.simulator.grpc.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.hedera.block.simulator.grpc.impl.PublishStreamObserver;
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
 import java.util.ArrayList;
 import java.util.List;

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -18,22 +18,15 @@ package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class CombinedModeHandlerTest {
-
-    @Mock
-    private BlockStreamConfig blockStreamConfig;
 
     private CombinedModeHandler combinedModeHandler;
 
     @Test
     void testStartThrowsUnsupportedOperationException() {
-        MockitoAnnotations.openMocks(this);
-        combinedModeHandler = new CombinedModeHandler(blockStreamConfig);
+        combinedModeHandler = new CombinedModeHandler();
 
         assertThrows(UnsupportedOperationException.class, () -> combinedModeHandler.start());
     }

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -17,31 +17,29 @@
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConsumerModeHandlerTest {
 
-    private BlockStreamConfig blockStreamConfig;
     private ConsumerStreamGrpcClient consumerStreamGrpcClient;
     private ConsumerModeHandler consumerModeHandler;
 
     @BeforeEach
     void setUp() {
-        blockStreamConfig = mock(BlockStreamConfig.class);
         consumerStreamGrpcClient = mock(ConsumerStreamGrpcClient.class);
 
-        consumerModeHandler = new ConsumerModeHandler(blockStreamConfig, consumerStreamGrpcClient);
+        consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient);
     }
 
     @Test
     void testConstructorWithNullArguments() {
-        assertThrows(NullPointerException.class, () -> new ConsumerModeHandler(null, consumerStreamGrpcClient));
-        assertThrows(NullPointerException.class, () -> new ConsumerModeHandler(blockStreamConfig, null));
+        assertThrows(NullPointerException.class, () -> new ConsumerModeHandler(null));
     }
 
     @Test
@@ -72,7 +70,6 @@ class ConsumerModeHandlerTest {
         consumerModeHandler.stop();
 
         verify(consumerStreamGrpcClient).completeStreaming();
-        verify(consumerStreamGrpcClient).shutdown();
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -16,25 +16,25 @@
 
 package com.hedera.block.simulator.mode;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import com.hedera.block.simulator.config.data.BlockStreamConfig;
-import org.junit.jupiter.api.Test;
+import com.hedera.block.simulator.grpc.impl.ConsumerStreamGrpcClientImpl;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 public class ConsumerModeHandlerTest {
 
     @Mock
     private BlockStreamConfig blockStreamConfig;
 
+    @Mock
+    private ConsumerStreamGrpcClientImpl consumerStreamGrpcClient;
+
     private ConsumerModeHandler consumerModeHandler;
 
-    @Test
-    void testStartThrowsUnsupportedOperationException() {
-        MockitoAnnotations.openMocks(this);
-        consumerModeHandler = new ConsumerModeHandler(blockStreamConfig);
-
-        assertThrows(UnsupportedOperationException.class, () -> consumerModeHandler.start());
-    }
+    //    @Test
+    //    void testStartThrowsUnsupportedOperationException() {
+    //        MockitoAnnotations.openMocks(this);
+    //        consumerModeHandler = new ConsumerModeHandler(consumerStreamGrpcClient, blockStreamConfig);
+    //
+    //        assertThrows(UnsupportedOperationException.class, () -> consumerModeHandler.start());
+    //    }
 }

--- a/stream/src/main/java/module-info.java
+++ b/stream/src/main/java/module-info.java
@@ -67,6 +67,8 @@ module com.hedera.block.stream {
     exports com.hedera.hapi.platform.state;
     exports com.hedera.hapi.node.state.roster;
     exports com.hedera.hapi.block.stream.schema;
+    exports com.hedera.hapi.platform.state.legacy to
+            com.google.protobuf;
 
     requires transitive com.google.common;
     requires transitive com.google.protobuf;


### PR DESCRIPTION
**Description**:
This pull request aims to make use of the consumer mode in the simulator, by adding needed implementations.
We add:
- gRPC client and observer for consuming blocks, which utilizes `SubscribeStreamRequest` and `SubscribeStreamResponse`, which are part of the `subscribeBlockStream` rpc.
- Makes the neccessery changes to initilize managers and clients, depending on mode.
- Adds neccessery unit and integration tests for sufficient code coverage, by making use of as less mocks as possible.

**Related issue(s)**:

Fixes #121 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
