### PR TITLE
build: update helm publish registry to `ghcr.io`

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -118,10 +118,17 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
 
-      - name: Publish helm chart
-        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d # v1.7.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446 # v3.2.0
         with:
-          target_dir: charts
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          app_version: ${{ env.VERSION }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package helm chart
+        run: |
+          helm package charts/hedera-block-node
+
+      - name: Push helm chart
+        run: |
+          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -125,6 +125,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract version
+        id: extract_version
+        run: |
+          VERSION=$(grep 'version=' gradle.properties | cut -d '=' -f2)
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+
       - name: Package helm chart
         run: |
           helm package charts/hedera-block-node

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -138,4 +138,4 @@ jobs:
 
       - name: Push helm chart
         run: |
-          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node
+          helm push block-node-helm-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Package helm chart
         run: |
+          helm dependency update charts/hedera-block-node
           helm package charts/hedera-block-node
 
       - name: Push helm chart

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -103,8 +103,6 @@ jobs:
   helm-chart-release:
     needs: publish
     runs-on: block-node-linux-medium
-    permissions:
-      contents: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -137,4 +137,4 @@ jobs:
 
       - name: Push helm chart
         run: |
-          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node
+          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node/charts

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -137,4 +137,4 @@ jobs:
 
       - name: Push helm chart
         run: |
-          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node/charts
+          helm push hedera-block-node-chart-${{ env.VERSION }}.tgz oci://ghcr.io/hashgraph/hedera-block-node

--- a/charts/hedera-block-node/Chart.yaml
+++ b/charts/hedera-block-node/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
 maintainers:
   - name: Hedera Block Node Team
     email: blocknode@hashgraph.com
-name: hedera-block-node-chart
+name: block-node-helm-chart
 sources:
   - https://github.com/hashgraph/hedera-block-node
 version: 0.3.0-SNAPSHOT

--- a/charts/hedera-block-node/Chart.yaml
+++ b/charts/hedera-block-node/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
 maintainers:
   - name: Hedera Block Node Team
     email: blocknode@hashgraph.com
-name: hedera-block-node
+name: hedera-block-node-chart
 sources:
   - https://github.com/hashgraph/hedera-block-node
 version: 0.3.0-SNAPSHOT

--- a/charts/hedera-block-node/README.md
+++ b/charts/hedera-block-node/README.md
@@ -11,23 +11,35 @@ minikube delete && minikube start --kubernetes-version=v1.23.0 --memory=8g --boo
 ```
 
 Set environment variables that will be used for the remainder of the document:
+Replacing the values with the appropriate values for your environment: bn1 is short for block-node-1, but you can name you release as you wish. And use the version that you want to install.
 ```bash
 export RELEASE="bn1"
+export VERSION="0.3.0-SNAPSHOT"
 ```
 
 ## Template
-To generate the K8 manifest files without installing the chart:
+To generate the K8 manifest files without installing the chart, you need to clone this repo and navigate to `/charts` folder.
 ```bash
 helm template --name-template my-bn hedera-block-node/ --dry-run --output-dir out
 ```
 
-## Install
-To install the chart:
+## Install using released chart
+
+To pull the packaged chart from public repo:
 ```bash
-helm repo add hedera-block-node https://hashgraph.github.io/hedera-block-node/charts
-helm dependency update charts/hedera-block-node
-helm install "${RELEASE}" charts/hedera-block-node -f <path-to-custom-values-file>
+helm pull oci://ghcr.io/hashgraph/hedera-block-node/charts/hedera-block-node-chart --version "${VERSION}"
 ```
+
+To install the chart with default values:
+```bash
+helm install "${RELEASE}" hedera-block-node/charts/hedera-block-node-chart-$VERSION.tgz
+```
+
+To install the chart with custom values:
+```bash
+helm install "${RELEASE}" hedera-block-node/charts/hedera-block-node-chart-$VERSION.tgz -f <path-to-custom-values-file>
+```
+
 *Note:* If using the chart directly after cloning the github repo, there is no need to add the repo. and install can be directly.
 Assuming you are at the root folder of the repo.
 ```bash

--- a/charts/hedera-block-node/README.md
+++ b/charts/hedera-block-node/README.md
@@ -27,17 +27,17 @@ helm template --name-template my-bn hedera-block-node/ --dry-run --output-dir ou
 
 To pull the packaged chart from public repo:
 ```bash
-helm pull oci://ghcr.io/hashgraph/hedera-block-node/charts/hedera-block-node-chart --version "${VERSION}"
+helm pull oci://ghcr.io/hashgraph/hedera-block-node/block-node-helm-chart --version "${VERSION}"
 ```
 
 To install the chart with default values:
 ```bash
-helm install "${RELEASE}" hedera-block-node/charts/hedera-block-node-chart-$VERSION.tgz
+helm install "${RELEASE}" hedera-block-node/charts/block-node-helm-chart-$VERSION.tgz
 ```
 
 To install the chart with custom values:
 ```bash
-helm install "${RELEASE}" hedera-block-node/charts/hedera-block-node-chart-$VERSION.tgz -f <path-to-custom-values-file>
+helm install "${RELEASE}" hedera-block-node/charts/block-node-helm-chart-$VERSION.tgz -f <path-to-custom-values-file>
 ```
 
 *Note:* If using the chart directly after cloning the github repo, there is no need to add the repo. and install can be directly.

--- a/charts/hedera-block-node/README.md
+++ b/charts/hedera-block-node/README.md
@@ -23,9 +23,9 @@ To generate the K8 manifest files without installing the chart, you need to clon
 helm template --name-template my-bn hedera-block-node/ --dry-run --output-dir out
 ```
 
-## Install using released chart
+## Install using a published chart
 
-To pull the packaged chart from public repo:
+To pull the packaged chart from the public repo:
 ```bash
 helm pull oci://ghcr.io/hashgraph/hedera-block-node/block-node-helm-chart --version "${VERSION}"
 ```

--- a/charts/hedera-block-node/README.md
+++ b/charts/hedera-block-node/README.md
@@ -13,7 +13,7 @@ minikube delete && minikube start --kubernetes-version=v1.23.0 --memory=8g --boo
 Set environment variables that will be used for the remainder of the document:
 Replacing the values with the appropriate values for your environment: bn1 is short for block-node-1, but you can name you release as you wish. And use the version that you want to install.
 ```bash
-export RELEASE="bn1"
+export RELEASE="blkNod"
 export VERSION="0.3.0-SNAPSHOT"
 ```
 


### PR DESCRIPTION
**Description**:

- updated chart name to hedera-block-node-chart, in order to differentiate it from the image name hedera-block-node.
- Changed the workflow that publishes the helm chart to use ghcr.io instead of a gh-pages branch.

**Related issue(s)**:

Fixes #256 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
