### PR TITLE
feat: allow block-node operators to easily set resource allocations to block-node deployment on k8 using helm chart

### DIFF
--- a/charts/hedera-block-node/templates/deployment.yaml
+++ b/charts/hedera-block-node/templates/deployment.yaml
@@ -43,6 +43,13 @@ spec:
               name: {{ include "hedera-block-node.fullname" . }}-config
           - secretRef:
               name: {{ include "hedera-block-node.fullname" . }}-secret
+        resources:
+          requests:
+            memory: {{ .Values.blockNode.resources.requests.memory }}
+            cpu: {{ .Values.blockNode.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.blockNode.resources.limits.memory }}
+            cpu: {{ .Values.blockNode.resources.limits.cpu }}
         livenessProbe:
           httpGet:
             path: {{ .Values.blockNode.health.liveness.endpoint }}

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -121,4 +121,3 @@ kubepromstack:
 
   nodeExporter:
     enabled: true
-

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -89,6 +89,13 @@ blockNode:
       endpoint: "/healthz/livez"
     metrics:
       port: 9999
+  resources:
+    limits:
+      cpu: "8"
+      memory: "16Gi"
+    requests:
+      cpu: "2"
+      memory: "8Gi"
 
 kubepromstack:
   enabled: true
@@ -114,3 +121,4 @@ kubepromstack:
 
   nodeExporter:
     enabled: true
+


### PR DESCRIPTION
**Description**:
it became obvious that we needed to increase the resource requirements and to allow easy parametrization using the values.yaml files.

**Related issue(s)**:

Fixes #115

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
