### PR TITLE
feat: new BlockReader implementation for block-as-file

### DIFF
--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -92,14 +92,17 @@ public interface PersistenceInjectionModule {
      *
      * @param config the persistence storage configuration needed to build the
      * block reader
+     * @param blockPathResolver the block path resolver needed to build
+     * the block reader
      * @return a block reader singleton
      */
     @Provides
     @Singleton
-    static BlockReader<BlockUnparsed> providesBlockReader(@NonNull final PersistenceStorageConfig config) {
+    static BlockReader<BlockUnparsed> providesBlockReader(
+            @NonNull final PersistenceStorageConfig config, @NonNull final BlockPathResolver blockPathResolver) {
         final StorageType persistenceType = config.type();
         return switch (persistenceType) {
-            case BLOCK_AS_LOCAL_FILE -> BlockAsLocalFileReader.newInstance();
+            case BLOCK_AS_LOCAL_FILE -> BlockAsLocalFileReader.of(blockPathResolver);
             case BLOCK_AS_LOCAL_DIRECTORY -> BlockAsLocalDirReader.of(config);
             case NO_OP -> NoOpBlockReader.newInstance();
         };

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -66,12 +66,15 @@ public final class BlockAsLocalFileReader implements LocalBlockReader<BlockUnpar
         if (Files.exists(resolvedBlockPath)) {
             return Optional.of(doRead(resolvedBlockPath));
         } else {
+            // todo we generally expect the block to be there, so we
+            // return an empty optional here, or do something else?
+            // of course sometimes the block may not even exist yet.
             return Optional.empty();
         }
     }
 
     private BlockUnparsed doRead(final Path resolvedBlockPath) throws IOException, ParseException {
-        // todo there are other ways of parsing, for example we can pass ReadableSequentialData instead of the fos
+        // todo there are other ways of parsing, for example we can pass ReadableSequentialData instead of the fis
         // because the readAllBytes does not seem like the best idea, what is the correct (or better) way to parse
         // the block file?
         try (final FileInputStream fis = new FileInputStream(resolvedBlockPath.toFile())) {

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -17,34 +17,65 @@
 package com.hedera.block.server.persistence.storage.read;
 
 import com.hedera.block.common.utils.Preconditions;
+import com.hedera.block.server.persistence.storage.path.BlockPathResolver;
 import com.hedera.hapi.block.BlockUnparsed;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
  * A Block reader that reads block-as-file.
  */
 public final class BlockAsLocalFileReader implements LocalBlockReader<BlockUnparsed> {
+    private final BlockPathResolver pathResolver;
+
     /**
      * Constructor.
+     *
+     * @param pathResolver valid, {@code non-null} instance of
+     * {@link BlockPathResolver} used to resolve paths to block files
      */
-    private BlockAsLocalFileReader() {}
+    private BlockAsLocalFileReader(@NonNull final BlockPathResolver pathResolver) {
+        this.pathResolver = Objects.requireNonNull(pathResolver);
+    }
 
     /**
      * This method creates and returns a new instance of
      * {@link BlockAsLocalFileReader}.
      *
+     * @param pathResolver valid, {@code non-null} instance of
+     * {@link BlockPathResolver} used to resolve paths to block files
      * @return a new, fully initialized instance of
      * {@link BlockAsLocalFileReader}
      */
-    public static BlockAsLocalFileReader newInstance() {
-        return new BlockAsLocalFileReader();
+    public static BlockAsLocalFileReader of(@NonNull final BlockPathResolver pathResolver) {
+        return new BlockAsLocalFileReader(pathResolver);
     }
 
     @NonNull
     @Override
-    public Optional<BlockUnparsed> read(final long blockNumber) {
+    public Optional<BlockUnparsed> read(final long blockNumber) throws IOException, ParseException {
         Preconditions.requireWhole(blockNumber);
-        throw new UnsupportedOperationException("Not implemented yet");
+        final Path resolvedBlockPath = pathResolver.resolvePathToBlock(blockNumber);
+        if (Files.exists(resolvedBlockPath)) {
+            return Optional.of(doRead(resolvedBlockPath));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private BlockUnparsed doRead(final Path resolvedBlockPath) throws IOException, ParseException {
+        // todo there are other ways of parsing, for example we can pass ReadableSequentialData instead of the fos
+        // because the readAllBytes does not seem like the best idea, what is the correct (or better) way to parse
+        // the block file?
+        try (final FileInputStream fis = new FileInputStream(resolvedBlockPath.toFile())) {
+            return BlockUnparsed.PROTOBUF.parse(Bytes.wrap(fis.readAllBytes()));
+        }
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -20,9 +20,8 @@ import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.server.persistence.storage.path.BlockPathResolver;
 import com.hedera.hapi.block.BlockUnparsed;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -66,19 +65,13 @@ public final class BlockAsLocalFileReader implements LocalBlockReader<BlockUnpar
         if (Files.exists(resolvedBlockPath)) {
             return Optional.of(doRead(resolvedBlockPath));
         } else {
-            // todo we generally expect the block to be there, so we
-            // return an empty optional here, or do something else?
-            // of course sometimes the block may not even exist yet.
             return Optional.empty();
         }
     }
 
     private BlockUnparsed doRead(final Path resolvedBlockPath) throws IOException, ParseException {
-        // todo there are other ways of parsing, for example we can pass ReadableSequentialData instead of the fis
-        // because the readAllBytes does not seem like the best idea, what is the correct (or better) way to parse
-        // the block file?
-        try (final FileInputStream fis = new FileInputStream(resolvedBlockPath.toFile())) {
-            return BlockUnparsed.PROTOBUF.parse(Bytes.wrap(fis.readAllBytes()));
+        try (final ReadableStreamingData data = new ReadableStreamingData(resolvedBlockPath)) {
+            return BlockUnparsed.PROTOBUF.parse(data);
         }
     }
 }

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -179,7 +179,7 @@ class PersistenceInjectionModuleTest {
         when(persistenceStorageConfigMock.type()).thenReturn(storageType);
 
         final BlockReader<BlockUnparsed> actual =
-                PersistenceInjectionModule.providesBlockReader(persistenceStorageConfigMock);
+                PersistenceInjectionModule.providesBlockReader(persistenceStorageConfigMock, blockPathResolverMock);
 
         final Class<?> targetInstanceType =
                 switch (storageType) {

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -150,9 +150,7 @@ class BlockAsLocalFileReaderTest {
     @MethodSource("validBlockNumbers")
     void testEmptyOptWhenNoBLockFileFound(final long blockNumber) throws IOException, ParseException {
         final Optional<BlockUnparsed> actual = toTest.read(blockNumber);
-        assertThat(actual)
-            .isNotNull()
-            .isEmpty();
+        assertThat(actual).isNotNull().isEmpty();
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -62,15 +62,14 @@ class BlockAsLocalFileReaderTest {
     @BeforeEach
     void setUp() throws IOException {
         blockNodeContext = TestConfigUtil.getTestBlockNodeContext(
-            Map.of(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString()));
+                Map.of(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString()));
         testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
 
         final String testConfigLiveRootPath = testConfig.liveRootPath();
         assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
 
         blockAsLocalFileResolverMock = spy(BlockAsLocalFilePathResolver.of(testLiveRootPath));
-        blockAsLocalFileWriterMock = spy(
-            BlockAsLocalFileWriter.of(blockNodeContext, blockAsLocalFileResolverMock));
+        blockAsLocalFileWriterMock = spy(BlockAsLocalFileWriter.of(blockNodeContext, blockAsLocalFileResolverMock));
         toTest = BlockAsLocalFileReader.of(blockAsLocalFileResolverMock);
     }
 
@@ -82,34 +81,34 @@ class BlockAsLocalFileReaderTest {
     @MethodSource("validBlockNumbers")
     void testSuccessfulBlockRead(final long blockNumber) throws IOException, ParseException {
         final List<BlockItemUnparsed> blockItemUnparsed =
-            PersistTestUtils.generateBlockItemsUnparsedForWithBlockNumber(blockNumber);
+                PersistTestUtils.generateBlockItemsUnparsedForWithBlockNumber(blockNumber);
         final Optional<List<BlockItemUnparsed>> written = blockAsLocalFileWriterMock.write(blockItemUnparsed);
 
         assertThat(written).isNotNull().isPresent();
 
         final Optional<BlockUnparsed> actual = toTest.read(blockNumber);
         assertThat(actual)
-            .isNotNull()
-            .isPresent()
-            .get(InstanceOfAssertFactories.type(BlockUnparsed.class))
-            .isNotNull()
-            .isExactlyInstanceOf(BlockUnparsed.class)
-            .returns(blockNumber, from(blockUnparsed -> {
-                try {
-                    return BlockHeader.PROTOBUF
-                        .parse(Objects.requireNonNull(
-                            blockUnparsed.blockItems().getFirst().blockHeader()))
-                        .number();
-                } catch (final ParseException e) {
-                    throw new RuntimeException(e);
-                }
-            }))
-            .extracting(BlockUnparsed::blockItems)
-            .asList()
-            .isNotNull()
-            .isNotEmpty()
-            .hasSize(blockItemUnparsed.size())
-            .containsExactlyElementsOf(blockItemUnparsed);
+                .isNotNull()
+                .isPresent()
+                .get(InstanceOfAssertFactories.type(BlockUnparsed.class))
+                .isNotNull()
+                .isExactlyInstanceOf(BlockUnparsed.class)
+                .returns(blockNumber, from(blockUnparsed -> {
+                    try {
+                        return BlockHeader.PROTOBUF
+                                .parse(Objects.requireNonNull(
+                                        blockUnparsed.blockItems().getFirst().blockHeader()))
+                                .number();
+                    } catch (final ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                }))
+                .extracting(BlockUnparsed::blockItems)
+                .asList()
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(blockItemUnparsed.size())
+                .containsExactlyElementsOf(blockItemUnparsed);
     }
 
     /**
@@ -132,28 +131,28 @@ class BlockAsLocalFileReaderTest {
      */
     public static Stream<Arguments> validBlockNumbers() {
         return Stream.of(
-            Arguments.of(0L),
-            Arguments.of(1L),
-            Arguments.of(2L),
-            Arguments.of(10L),
-            Arguments.of(100L),
-            Arguments.of(1_000L),
-            Arguments.of(10_000L),
-            Arguments.of(100_000L),
-            Arguments.of(1_000_000L),
-            Arguments.of(10_000_000L),
-            Arguments.of(100_000_000L),
-            Arguments.of(1_000_000_000L),
-            Arguments.of(10_000_000_000L),
-            Arguments.of(100_000_000_000L),
-            Arguments.of(1_000_000_000_000L),
-            Arguments.of(10_000_000_000_000L),
-            Arguments.of(100_000_000_000_000L),
-            Arguments.of(1_000_000_000_000_000L),
-            Arguments.of(10_000_000_000_000_000L),
-            Arguments.of(100_000_000_000_000_000L),
-            Arguments.of(1_000_000_000_000_000_000L),
-            Arguments.of(Long.MAX_VALUE));
+                Arguments.of(0L),
+                Arguments.of(1L),
+                Arguments.of(2L),
+                Arguments.of(10L),
+                Arguments.of(100L),
+                Arguments.of(1_000L),
+                Arguments.of(10_000L),
+                Arguments.of(100_000L),
+                Arguments.of(1_000_000L),
+                Arguments.of(10_000_000L),
+                Arguments.of(100_000_000L),
+                Arguments.of(1_000_000_000L),
+                Arguments.of(10_000_000_000L),
+                Arguments.of(100_000_000_000L),
+                Arguments.of(1_000_000_000_000L),
+                Arguments.of(10_000_000_000_000L),
+                Arguments.of(100_000_000_000_000L),
+                Arguments.of(1_000_000_000_000_000L),
+                Arguments.of(10_000_000_000_000_000L),
+                Arguments.of(100_000_000_000_000_000L),
+                Arguments.of(1_000_000_000_000_000_000L),
+                Arguments.of(Long.MAX_VALUE));
     }
 
     /**
@@ -163,26 +162,26 @@ class BlockAsLocalFileReaderTest {
      */
     public static Stream<Arguments> invalidBlockNumbers() {
         return Stream.of(
-            Arguments.of(-1L),
-            Arguments.of(-2L),
-            Arguments.of(-10L),
-            Arguments.of(-100L),
-            Arguments.of(-1_000L),
-            Arguments.of(-10_000L),
-            Arguments.of(-100_000L),
-            Arguments.of(-1_000_000L),
-            Arguments.of(-10_000_000L),
-            Arguments.of(-100_000_000L),
-            Arguments.of(-1_000_000_000L),
-            Arguments.of(-10_000_000_000L),
-            Arguments.of(-100_000_000_000L),
-            Arguments.of(-1_000_000_000_000L),
-            Arguments.of(-10_000_000_000_000L),
-            Arguments.of(-100_000_000_000_000L),
-            Arguments.of(-1_000_000_000_000_000L),
-            Arguments.of(-10_000_000_000_000_000L),
-            Arguments.of(-100_000_000_000_000_000L),
-            Arguments.of(-1_000_000_000_000_000_000L),
-            Arguments.of(Long.MIN_VALUE));
+                Arguments.of(-1L),
+                Arguments.of(-2L),
+                Arguments.of(-10L),
+                Arguments.of(-100L),
+                Arguments.of(-1_000L),
+                Arguments.of(-10_000L),
+                Arguments.of(-100_000L),
+                Arguments.of(-1_000_000L),
+                Arguments.of(-10_000_000L),
+                Arguments.of(-100_000_000L),
+                Arguments.of(-1_000_000_000L),
+                Arguments.of(-10_000_000_000L),
+                Arguments.of(-100_000_000_000L),
+                Arguments.of(-1_000_000_000_000L),
+                Arguments.of(-10_000_000_000_000L),
+                Arguments.of(-100_000_000_000_000L),
+                Arguments.of(-1_000_000_000_000_000L),
+                Arguments.of(-10_000_000_000_000_000L),
+                Arguments.of(-100_000_000_000_000_000L),
+                Arguments.of(-1_000_000_000_000_000_000L),
+                Arguments.of(Long.MIN_VALUE));
     }
 }

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -16,11 +16,33 @@
 
 package com.hedera.block.server.persistence.storage.read;
 
+import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.from;
+import static org.mockito.Mockito.spy;
 
+import com.hedera.block.server.config.BlockNodeContext;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.path.BlockAsLocalFilePathResolver;
+import com.hedera.block.server.persistence.storage.write.BlockAsLocalFileWriter;
+import com.hedera.block.server.util.PersistTestUtils;
+import com.hedera.block.server.util.TestConfigUtil;
+import com.hedera.hapi.block.BlockItemUnparsed;
+import com.hedera.hapi.block.BlockUnparsed;
+import com.hedera.hapi.block.stream.output.BlockHeader;
+import com.hedera.pbj.runtime.ParseException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,25 +51,64 @@ import org.junit.jupiter.params.provider.MethodSource;
  * Tests for the {@link BlockAsLocalFileReader} class.
  */
 class BlockAsLocalFileReaderTest {
+    private BlockAsLocalFileWriter blockAsLocalFileWriterMock;
+    private BlockAsLocalFilePathResolver blockAsLocalFileResolverMock;
+    private BlockNodeContext blockNodeContext;
+    private PersistenceStorageConfig testConfig;
     private BlockAsLocalFileReader toTest;
 
+    @TempDir
+    private Path testLiveRootPath;
+
     @BeforeEach
-    void setUp() {
-        toTest = BlockAsLocalFileReader.newInstance();
+    void setUp() throws IOException {
+        blockNodeContext = TestConfigUtil.getTestBlockNodeContext(
+                Map.of(PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY, testLiveRootPath.toString()));
+        testConfig = blockNodeContext.configuration().getConfigData(PersistenceStorageConfig.class);
+
+        final String testConfigLiveRootPath = testConfig.liveRootPath();
+        assertThat(testConfigLiveRootPath).isEqualTo(testLiveRootPath.toString());
+
+        blockAsLocalFileResolverMock = spy(BlockAsLocalFilePathResolver.of(testLiveRootPath));
+        blockAsLocalFileWriterMock = spy(BlockAsLocalFileWriter.of(blockNodeContext, blockAsLocalFileResolverMock));
+        toTest = BlockAsLocalFileReader.of(blockAsLocalFileResolverMock);
     }
 
     /**
      * This test aims to verify that the
      * {@link BlockAsLocalFileReader#read(long)} correctly reads a block with
      * a given block number.
-     *
-     * @param toRead parameterized, block number
      */
-    @ParameterizedTest
-    @MethodSource("validBlockNumbers")
-    void testSuccessfulBlockRead(final long toRead) {
-        // todo currently throws UnsupportedOperationException
-        assertThatExceptionOfType(UnsupportedOperationException.class).isThrownBy(() -> toTest.read(toRead));
+    @Test
+    void testSuccessfulBlockRead() throws IOException, ParseException {
+        final List<BlockItemUnparsed> blockItemUnparsed = PersistTestUtils.generateBlockItemsUnparsed(1);
+        final Optional<List<BlockItemUnparsed>> written = blockAsLocalFileWriterMock.write(blockItemUnparsed);
+
+        assertThat(written).isNotNull().isPresent();
+
+        final Optional<BlockUnparsed> actual = toTest.read(1);
+        assertThat(actual)
+                .isNotNull()
+                .isPresent()
+                .get(InstanceOfAssertFactories.type(BlockUnparsed.class))
+                .isNotNull()
+                .isExactlyInstanceOf(BlockUnparsed.class)
+                .returns(1L, from(blockUnparsed -> {
+                    try {
+                        return BlockHeader.PROTOBUF
+                                .parse(Objects.requireNonNull(
+                                        blockUnparsed.blockItems().getFirst().blockHeader()))
+                                .number();
+                    } catch (final ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                }))
+                .extracting(BlockUnparsed::blockItems)
+                .asList()
+                .isNotNull()
+                .isNotEmpty()
+                .hasSize(blockItemUnparsed.size())
+                .containsExactlyElementsOf(blockItemUnparsed);
     }
 
     /**
@@ -62,37 +123,6 @@ class BlockAsLocalFileReaderTest {
     @MethodSource("invalidBlockNumbers")
     void testInvalidBlockNumber(final long toRead) {
         assertThatIllegalArgumentException().isThrownBy(() -> toTest.read(toRead));
-    }
-
-    /**
-     * Some valid block numbers.
-     *
-     * @return a stream of valid block numbers
-     */
-    public static Stream<Arguments> validBlockNumbers() {
-        return Stream.of(
-                Arguments.of(0L),
-                Arguments.of(1L),
-                Arguments.of(2L),
-                Arguments.of(10L),
-                Arguments.of(100L),
-                Arguments.of(1_000L),
-                Arguments.of(10_000L),
-                Arguments.of(100_000L),
-                Arguments.of(1_000_000L),
-                Arguments.of(10_000_000L),
-                Arguments.of(100_000_000L),
-                Arguments.of(1_000_000_000L),
-                Arguments.of(10_000_000_000L),
-                Arguments.of(100_000_000_000L),
-                Arguments.of(1_000_000_000_000L),
-                Arguments.of(10_000_000_000_000L),
-                Arguments.of(100_000_000_000_000L),
-                Arguments.of(1_000_000_000_000_000L),
-                Arguments.of(10_000_000_000_000_000L),
-                Arguments.of(100_000_000_000_000_000L),
-                Arguments.of(1_000_000_000_000_000_000L),
-                Arguments.of(Long.MAX_VALUE));
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -142,6 +142,21 @@ class BlockAsLocalFileReaderTest {
 
     /**
      * This test aims to verify that the
+     * {@link BlockAsLocalFileReader#read(long) correctly returns an empty
+     * {@link Optional} when no block file is found for the given valid block
+     * number.
+     */
+    @ParameterizedTest
+    @MethodSource("validBlockNumbers")
+    void testEmptyOptWhenNoBLockFileFound(final long blockNumber) throws IOException, ParseException {
+        final Optional<BlockUnparsed> actual = toTest.read(blockNumber);
+        assertThat(actual)
+            .isNotNull()
+            .isEmpty();
+    }
+
+    /**
+     * This test aims to verify that the
      * {@link BlockAsLocalFileReader#read(long)} correctly throws an
      * {@link IllegalArgumentException} when an invalid block number is
      * provided. A block number is invalid if it is a strictly negative number.

--- a/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
@@ -51,45 +51,73 @@ public final class PersistTestUtils {
         }
     }
 
-    public static List<BlockItemUnparsed> generateBlockItemsUnparsed(int numOfBlocks) {
-
-        List<BlockItemUnparsed> blockItems = new ArrayList<>();
-        for (int i = 1; i <= numOfBlocks; i++) {
-            for (int j = 1; j <= 10; j++) {
-                switch (j) {
-                    case 1:
-                        // First block is always the header
-                        blockItems.add(BlockItemUnparsed.newBuilder()
-                                .blockHeader(BlockHeader.PROTOBUF.toBytes(BlockHeader.newBuilder()
-                                        .number(i)
-                                        .softwareVersion(SemanticVersion.newBuilder()
-                                                .major(1)
-                                                .minor(0)
-                                                .build())
-                                        .build()))
-                                .build());
-                        break;
-                    case 10:
-                        // Last block is always the state proof
-                        blockItems.add(BlockItemUnparsed.newBuilder()
-                                .blockProof(BlockProof.PROTOBUF.toBytes(
-                                        BlockProof.newBuilder().block(i).build()))
-                                .build());
-                        break;
-                    default:
-                        // Middle blocks are events
-                        blockItems.add(BlockItemUnparsed.newBuilder()
-                                .eventHeader(EventHeader.PROTOBUF.toBytes(EventHeader.newBuilder()
-                                        .eventCore(EventCore.newBuilder()
-                                                .creatorNodeId(i)
-                                                .build())
-                                        .build()))
-                                .build());
-                        break;
-                }
+    /**
+     * This method generates a list of {@link BlockItemUnparsed} with the input
+     * blockNumber used to generate the block items for. It generates 10 block
+     * items starting with the block header, followed by 8 events and ending
+     * with the block proof.
+     *
+     * @param blockNumber the block number to generate the block items for
+     *
+     * @return a list of {@link BlockItemUnparsed} with the input blockNumber
+     * used to generate the block items for
+     */
+    public static List<BlockItemUnparsed> generateBlockItemsUnparsedForWithBlockNumber(final long blockNumber) {
+        final List<BlockItemUnparsed> result = new ArrayList<>();
+        for (int j = 1; j <= 10; j++) {
+            switch (j) {
+                case 1:
+                    // First block is always the header
+                    result.add(BlockItemUnparsed.newBuilder()
+                            .blockHeader(BlockHeader.PROTOBUF.toBytes(BlockHeader.newBuilder()
+                                    .number(blockNumber)
+                                    .softwareVersion(SemanticVersion.newBuilder()
+                                            .major(1)
+                                            .minor(0)
+                                            .build())
+                                    .build()))
+                            .build());
+                    break;
+                case 10:
+                    // Last block is always the state proof
+                    result.add(BlockItemUnparsed.newBuilder()
+                            .blockProof(BlockProof.PROTOBUF.toBytes(
+                                    BlockProof.newBuilder().block(blockNumber).build()))
+                            .build());
+                    break;
+                default:
+                    // Middle blocks are events
+                    result.add(BlockItemUnparsed.newBuilder()
+                            .eventHeader(EventHeader.PROTOBUF.toBytes(EventHeader.newBuilder()
+                                    .eventCore(EventCore.newBuilder()
+                                            .creatorNodeId(blockNumber)
+                                            .build())
+                                    .build()))
+                            .build());
+                    break;
             }
         }
+        return result;
+    }
 
+    /**
+     * This method generates a list of {@link BlockItemUnparsed} for as many
+     * blocks as specified by the input parameter numOfBlocks. For each block
+     * number from 1 to numOfBlocks, it generates 10 block items starting with
+     * the block header, followed by 8 events and ending with the block proof.
+     * In a way, this simulates a stream of block items. Each 10 items in the
+     * list represent a block.
+     *
+     * @param numOfBlocks the number of blocks to generate block items for
+     *
+     * @return a list of {@link BlockItemUnparsed} for as many blocks as
+     * specified by the input parameter numOfBlocks
+     */
+    public static List<BlockItemUnparsed> generateBlockItemsUnparsed(int numOfBlocks) {
+        final List<BlockItemUnparsed> blockItems = new ArrayList<>();
+        for (int i = 1; i <= numOfBlocks; i++) {
+            blockItems.addAll(generateBlockItemsUnparsedForWithBlockNumber(i));
+        }
         return blockItems;
     }
 


### PR DESCRIPTION
**Description**:

- adding reading logic to complement #281 

**Related issue(s)**:

Fixes #349 

**Notes for reviewer**:

- what would be the best way to parse the block file, having a file input stream and calling readAllBytes does not seem like the best option, there are other (based on the api), but which one would be preferable?

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
