### PR TITLE
feat: Add Grafana dashboards for the Simulator

### DIFF
--- a/server/docker/metrics/dashboards/block-stream-simulator-consumer.json
+++ b/server/docker/metrics/dashboards/block-stream-simulator-consumer.json
@@ -1,0 +1,213 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "liveNow": true,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Blocks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 14
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "hedera_block_node_simulator_live_blocks_consumed_total",
+          "instant": false,
+          "legendFormat": "Blocks Consumed",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Blocks Consumed",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "blocks/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 14
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(hedera_block_node_simulator_live_blocks_consumed_total[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Blocks Consume Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Blocks Consume Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Block Stream Simulator Consumer Dashboard",
+  "uid": "block-stream-simulator-consumer",
+  "version": 1,
+  "weekStart": ""
+}

--- a/server/docker/metrics/dashboards/block-stream-simulator-consumer.json
+++ b/server/docker/metrics/dashboards/block-stream-simulator-consumer.json
@@ -91,7 +91,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "hedera_block_node_simulator_live_blocks_consumed_total",
+          "expr": "hedera_block_node_simulator_live_blocks_consumed_total{instance_type=\"$instance_type\"}",
           "instant": false,
           "legendFormat": "Blocks Consumed",
           "range": true,
@@ -183,7 +183,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(hedera_block_node_simulator_live_blocks_consumed_total[$__rate_interval])",
+          "expr": "rate(hedera_block_node_simulator_live_blocks_consumed_total{instance_type=\"$instance_type\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "Blocks Consume Rate",
           "range": true,
@@ -198,7 +198,35 @@
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "consumer",
+          "value": "consumer"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(instance_type)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance Type",
+        "multi": false,
+        "name": "instance_type",
+        "options": [],
+        "query": {
+          "query": "label_values(instance_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",

--- a/server/docker/metrics/dashboards/block-stream-simulator-publisher.json
+++ b/server/docker/metrics/dashboards/block-stream-simulator-publisher.json
@@ -1,0 +1,384 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "liveNow": true,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Block Items",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "hedera_block_node_simulator_live_block_items_sent_total",
+          "instant": false,
+          "legendFormat": "Block Items Sent",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Block Items Sent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "items/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(hedera_block_node_simulator_live_block_items_sent_total[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Block Items Send Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Block Items Send Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Blocks",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 8
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.4",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "hedera_block_node_simulator_live_blocks_sent_total",
+          "instant": false,
+          "legendFormat": "Blocks Sent",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Blocks Sent",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "blocks/s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 18,
+        "x": 6,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(hedera_block_node_simulator_live_blocks_sent_total[$__rate_interval])",
+          "instant": false,
+          "legendFormat": "Blocks Send Rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live Blocks Send Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Block Stream Simulator Publisher Dashboard",
+  "uid": "block-stream-simulator-publisher",
+  "version": 1,
+  "weekStart": ""
+}

--- a/server/docker/metrics/dashboards/block-stream-simulator-publisher.json
+++ b/server/docker/metrics/dashboards/block-stream-simulator-publisher.json
@@ -91,7 +91,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "hedera_block_node_simulator_live_block_items_sent_total",
+          "expr": "hedera_block_node_simulator_live_block_items_sent_total{instance_type=\"$instance_type\"}",
           "instant": false,
           "legendFormat": "Block Items Sent",
           "range": true,
@@ -183,7 +183,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(hedera_block_node_simulator_live_block_items_sent_total[$__rate_interval])",
+          "expr": "rate(hedera_block_node_simulator_live_block_items_sent_total{instance_type=\"$instance_type\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "Block Items Send Rate",
           "range": true,
@@ -262,7 +262,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "hedera_block_node_simulator_live_blocks_sent_total",
+          "expr": "hedera_block_node_simulator_live_blocks_sent_total{instance_type=\"$instance_type\"}",
           "instant": false,
           "legendFormat": "Blocks Sent",
           "range": true,
@@ -354,7 +354,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(hedera_block_node_simulator_live_blocks_sent_total[$__rate_interval])",
+          "expr": "rate(hedera_block_node_simulator_live_blocks_sent_total{instance_type=\"$instance_type\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "Blocks Send Rate",
           "range": true,
@@ -369,7 +369,35 @@
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "publisher",
+          "value": "publisher"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(instance_type)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Instance Type",
+        "multi": false,
+        "name": "instance_type",
+        "options": [],
+        "query": {
+          "query": "label_values(instance_type)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",

--- a/server/docker/metrics/dashboards/provisioner.yaml
+++ b/server/docker/metrics/dashboards/provisioner.yaml
@@ -4,8 +4,11 @@ providers:
   - name: 'default'
     orgId: 1
     folder: ''
+    folderUid: ''
     type: file
     disableDeletion: false
     updateIntervalSeconds: 10
+    allowUiUpdates: true
     options:
       path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/server/docker/metrics/prometheus.yml
+++ b/server/docker/metrics/prometheus.yml
@@ -5,3 +5,15 @@ scrape_configs:
   - job_name: 'local'
     static_configs:
       - targets: ['block-node-server:9999', 'cadvisor:8080']
+
+  - job_name: 'simulator-publisher'
+    static_configs:
+      - targets: ['host.docker.internal:9998']
+    metrics_path: '/metrics'
+    scheme: 'http'
+
+  - job_name: 'simulator-consumer'
+    static_configs:
+      - targets: ['host.docker.internal:9997']
+    metrics_path: '/metrics'
+    scheme: 'http'

--- a/server/docker/metrics/prometheus.yml
+++ b/server/docker/metrics/prometheus.yml
@@ -11,9 +11,17 @@ scrape_configs:
       - targets: ['host.docker.internal:9998']
     metrics_path: '/metrics'
     scheme: 'http'
+    relabel_configs:
+      - source_labels: [__name__]
+        target_label: instance_type
+        replacement: 'publisher'
 
   - job_name: 'simulator-consumer'
     static_configs:
       - targets: ['host.docker.internal:9997']
     metrics_path: '/metrics'
     scheme: 'http'
+    relabel_configs:
+      - source_labels: [__name__]
+        target_label: instance_type
+        replacement: 'consumer'

--- a/simulator/docs/quickstart.md
+++ b/simulator/docs/quickstart.md
@@ -8,6 +8,7 @@
    1. [Run the Server first](#run-the-server-first)
    1. [Run the Simulator](#run-the-simulator)
    1. [Run the Simulator with Debug](#run-the-simulator-with-debug)
+1. [Viewing Metrics](#viewing-metrics)
 
 ## Configuration
 
@@ -28,6 +29,7 @@ Refer to the [Configuration](configuration.md) for configuration options.
 
 > **NOTE:** if you have not done so already, it is
 > generally recommended to build the entire repo first:
+>
 > ```bash
 > ./gradlew clean build -x test
 > ```
@@ -53,8 +55,52 @@ get started with the application.
 ### Run the Simulator with Debug
 
 1. To start the Simulator with debug enabled, do the following:
+
    ```bash
    ./gradlew :simulator:run --debug-jvm
    ```
 
 1. Attach your remote jvm debugger to port 5005.
+
+## Viewing Metrics
+
+The simulator can run in two modes (Publisher and Consumer) and provides metrics for both configurations. To view the metrics:
+
+1. Start the block node server first:
+
+   ```bash
+   ./gradlew startDockerContainer
+   ```
+
+2. Configure and run the simulator in Publisher mode:
+
+   - In `app.properties`, set:
+     ```properties
+     blockStream.simulatorMode=PUBLISHER
+     prometheus.endpointEnabled=true
+     prometheus.endpointPortNumber=9998
+     ```
+   - Start the simulator:
+     ```bash
+     ./gradlew :simulator:run
+     ```
+
+3. Configure and run the simulator in Consumer mode:
+
+   - In `app.properties`, update:
+     ```properties
+     blockStream.simulatorMode=CONSUMER
+     prometheus.endpointEnabled=true
+     prometheus.endpointPortNumber=9997
+     ```
+   - Start another instance of the simulator:
+     ```bash
+     ./gradlew :simulator:run
+     ```
+
+4. Access the metrics:
+   - Open Grafana at http://localhost:3000
+   - Navigate to Dashboards
+   - You'll find two dashboards:
+     - Block Stream Simulator Publisher: Shows metrics for the publisher instance
+     - Block Stream Simulator Consumer: Shows metrics for the consumer instance

--- a/simulator/src/main/resources/app.properties
+++ b/simulator/src/main/resources/app.properties
@@ -1,3 +1,17 @@
+
+
+# ----------------------------------------------
+# gRPC Config
+# ----------------------------------------------
+grpc.serverAddress=localhost
+grpc.port=8080
+# ----------------------------------------------
+# BlockStreamConfig
+# ----------------------------------------------
+blockStream.simulatorMode=PUBLISHER
+# ----------------------------------------------
+# Prometheus Config
+# ----------------------------------------------
 # The prometheus endpoint is used by the
 # MetricsService to track different metrics.
 # This is disabled by default to avoid port
@@ -6,7 +20,7 @@
 # port to track simulator metrics from a
 # dashboard.
 prometheus.endpointEnabled=false
-
+prometheus.endpointPortNumber=9998
 # ----------------------------------------------
 # BlockAsFileLargeDataSets config
 # ----------------------------------------------

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -80,6 +80,6 @@ class ConfigInjectionModuleTest {
 
         assertNotNull(prometheusConfig);
         assertFalse(prometheusConfig.endpointEnabled());
-        assertEquals(9999, prometheusConfig.endpointPortNumber());
+        assertEquals(9998, prometheusConfig.endpointPortNumber());
     }
 }


### PR DESCRIPTION
**Description**:
This PR adds Grafana dashboards for monitoring the Block Stream Simulator in both Publisher and Consumer modes, along with the necessary Prometheus configuration to support metric collection.

* Add Grafana dashboards for Publisher and Consumer metrics
* Update Prometheus configuration to differentiate metrics by instance type
* Add metrics documentation to simulator quickstart guide

**Related issue(s)**:

Fixes #379 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
