### PR TITLE
chore: Add missing config values to mapper

### DIFF
--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -33,9 +33,13 @@ public final class ServerMappedConfigSourceInitializer {
             new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
             new ConfigMapping("service.delayMillis", "SERVICE_DELAY_MILLIS"),
             new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
+            new ConfigMapping("mediator.type", "MEDIATOR_TYPE"),
             new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE"),
+            new ConfigMapping("producer.type", "PRODUCER_TYPE"),
             new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
-            new ConfigMapping("server.port", "SERVER_PORT"));
+            new ConfigMapping("server.port", "SERVER_PORT"),
+            new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
+            new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER"));
 
     private ServerMappedConfigSourceInitializer() {}
 

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -44,6 +44,34 @@ testModuleInfo {
     requires("com.google.protobuf")
 }
 
+// Task to run simulator in Publisher mode
+tasks.register<JavaExec>("runPublisher") {
+    description = "Run the simulator in Publisher mode"
+    group = "application"
+
+    mainClass = application.mainClass
+    mainModule = application.mainModule
+    classpath = sourceSets["main"].runtimeClasspath
+
+    environment("BLOCK_STREAM_SIMULATOR_MODE", "PUBLISHER")
+    environment("PROMETHEUS_ENDPOINT_ENABLED", "true")
+    environment("PROMETHEUS_ENDPOINT_PORT_NUMBER", "9998")
+}
+
+// Task to run simulator in Consumer mode
+tasks.register<JavaExec>("runConsumer") {
+    description = "Run the simulator in Consumer mode"
+    group = "application"
+
+    mainClass = application.mainClass
+    mainModule = application.mainModule
+    classpath = sourceSets["main"].runtimeClasspath
+
+    environment("BLOCK_STREAM_SIMULATOR_MODE", "CONSUMER")
+    environment("PROMETHEUS_ENDPOINT_ENABLED", "true")
+    environment("PROMETHEUS_ENDPOINT_PORT_NUMBER", "9997")
+}
+
 tasks.register<Copy>("untarTestBlockStream") {
     description = "Untar the test block stream data"
     group = "build"

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -19,6 +19,7 @@ package com.hedera.block.simulator;
 import static com.hedera.block.common.constants.StringsConstants.APPLICATION_PROPERTIES;
 import static java.lang.System.Logger.Level.INFO;
 
+import com.hedera.block.simulator.config.SimulatorMappedConfigSourceInitializer;
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -50,6 +51,7 @@ public class BlockStreamSimulator {
         LOGGER.log(INFO, "Starting Block Stream Simulator!");
 
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
+                .withSource(SimulatorMappedConfigSourceInitializer.getMappedConfigSource())
                 .withSource(SystemEnvironmentConfigSource.getInstance())
                 .withSource(SystemPropertiesConfigSource.getInstance())
                 .withSource(new ClasspathFileConfigSource(Path.of(APPLICATION_PROPERTIES)))

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.block.simulator.config;
+
+import com.swirlds.config.extensions.sources.ConfigMapping;
+import com.swirlds.config.extensions.sources.MappedConfigSource;
+import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+
+/**
+ * A class that extends {@link MappedConfigSource} in order to have project-relevant initialization.
+ */
+public final class SimulatorMappedConfigSourceInitializer {
+    private static final List<ConfigMapping> MAPPINGS = List.of(
+            // gRPC configuration
+            new ConfigMapping("grpc.serverAddress", "GRPC_SERVER_ADDRESS"),
+            new ConfigMapping("grpc.port", "GRPC_PORT"),
+
+            // Block stream configuration
+            new ConfigMapping("blockStream.simulatorMode", "BLOCK_STREAM_SIMULATOR_MODE"),
+            new ConfigMapping("blockStream.delayBetweenBlockItems", "BLOCK_STREAM_DELAY_BETWEEN_BLOCK_ITEMS"),
+            new ConfigMapping("blockStream.maxBlockItemsToStream", "BLOCK_STREAM_MAX_BLOCK_ITEMS_TO_STREAM"),
+            new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),
+            new ConfigMapping("blockStream.millisecondsPerBlock", "BLOCK_STREAM_MILLISECONDS_PER_BLOCK"),
+            new ConfigMapping("blockStream.blockItemsBatchSize", "BLOCK_STREAM_BLOCK_ITEMS_BATCH_SIZE"),
+
+            // Block generator configuration
+            new ConfigMapping("generator.generationMode", "GENERATOR_GENERATION_MODE"),
+            new ConfigMapping("generator.folderRootPath", "GENERATOR_FOLDER_ROOT_PATH"),
+            new ConfigMapping("generator.managerImplementation", "GENERATOR_MANAGER_IMPLEMENTATION"),
+            new ConfigMapping("generator.paddedLength", "GENERATOR_PADDED_LENGTH"),
+            new ConfigMapping("generator.fileExtension", "GENERATOR_FILE_EXTENSION"),
+            new ConfigMapping("generator.startBlockNumber", "GENERATOR_START_BLOCK_NUMBER"),
+            new ConfigMapping("generator.endBlockNumber", "GENERATOR_END_BLOCK_NUMBER"),
+
+            // Prometheus configuration
+            new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
+            new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER"));
+
+    private SimulatorMappedConfigSourceInitializer() {}
+
+    /**
+     * This method constructs, initializes and returns a new instance of {@link MappedConfigSource}
+     * which internally uses {@link SystemEnvironmentConfigSource} and maps relevant config keys to
+     * other keys so that they could be used within the application
+     *
+     * @return newly constructed fully initialized {@link MappedConfigSource}
+     */
+    @NonNull
+    public static MappedConfigSource getMappedConfigSource() {
+        final MappedConfigSource config = new MappedConfigSource(SystemEnvironmentConfigSource.getInstance());
+        MAPPINGS.forEach(config::addMapping);
+        return config;
+    }
+}

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hedera.block.server.config;
+package com.hedera.block.simulator.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -27,19 +27,30 @@ import java.util.function.Predicate;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-class ServerMappedConfigSourceInitializerTest {
+class SimulatorMappedConfigSourceInitializerTest {
     private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
-        new ConfigMapping("consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
-        new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
-        new ConfigMapping("persistence.storage.archiveRootPath", "PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH"),
-        new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
-        new ConfigMapping("service.delayMillis", "SERVICE_DELAY_MILLIS"),
-        new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
-        new ConfigMapping("mediator.type", "MEDIATOR_TYPE"),
-        new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE"),
-        new ConfigMapping("producer.type", "PRODUCER_TYPE"),
-        new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
-        new ConfigMapping("server.port", "SERVER_PORT"),
+        // gRPC configuration
+        new ConfigMapping("grpc.serverAddress", "GRPC_SERVER_ADDRESS"),
+        new ConfigMapping("grpc.port", "GRPC_PORT"),
+
+        // Block stream configuration
+        new ConfigMapping("blockStream.simulatorMode", "BLOCK_STREAM_SIMULATOR_MODE"),
+        new ConfigMapping("blockStream.delayBetweenBlockItems", "BLOCK_STREAM_DELAY_BETWEEN_BLOCK_ITEMS"),
+        new ConfigMapping("blockStream.maxBlockItemsToStream", "BLOCK_STREAM_MAX_BLOCK_ITEMS_TO_STREAM"),
+        new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),
+        new ConfigMapping("blockStream.millisecondsPerBlock", "BLOCK_STREAM_MILLISECONDS_PER_BLOCK"),
+        new ConfigMapping("blockStream.blockItemsBatchSize", "BLOCK_STREAM_BLOCK_ITEMS_BATCH_SIZE"),
+
+        // Block generator configuration
+        new ConfigMapping("generator.generationMode", "GENERATOR_GENERATION_MODE"),
+        new ConfigMapping("generator.folderRootPath", "GENERATOR_FOLDER_ROOT_PATH"),
+        new ConfigMapping("generator.managerImplementation", "GENERATOR_MANAGER_IMPLEMENTATION"),
+        new ConfigMapping("generator.paddedLength", "GENERATOR_PADDED_LENGTH"),
+        new ConfigMapping("generator.fileExtension", "GENERATOR_FILE_EXTENSION"),
+        new ConfigMapping("generator.startBlockNumber", "GENERATOR_START_BLOCK_NUMBER"),
+        new ConfigMapping("generator.endBlockNumber", "GENERATOR_END_BLOCK_NUMBER"),
+
+        // Prometheus configuration
         new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
         new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER")
     };
@@ -47,17 +58,17 @@ class ServerMappedConfigSourceInitializerTest {
 
     @BeforeAll
     static void setUp() {
-        toTest = ServerMappedConfigSourceInitializer.getMappedConfigSource();
+        toTest = SimulatorMappedConfigSourceInitializer.getMappedConfigSource();
     }
 
     /**
      * This test aims to fail if we have added or removed any {@link ConfigMapping} that will be
-     * initialized by the {@link ServerMappedConfigSourceInitializer#getMappedConfigSource()}
+     * initialized by the {@link SimulatorMappedConfigSourceInitializer#getMappedConfigSource()}
      * without reflecting it here in the test. The purpose is to bring attention to any changes to
      * the developer so we can make sure we are aware of them in order to be sure we require the
      * change. This test is more to bring attention than to test actual logic. So if this fails, we
      * either change the {@link #SUPPORTED_MAPPINGS} here or the {@link
-     * ServerMappedConfigSourceInitializer#MAPPINGS} to make this pass.
+     * SimulatorMappedConfigSourceInitializer#MAPPINGS} to make this pass.
      */
     @Test
     void test_VerifyAllSupportedMappingsAreAddedToInstance() throws ReflectiveOperationException {


### PR DESCRIPTION
**Description**:
This PR makes the following changes:
- On the `server` side adds the following missing configs to the mapper:
   - producer.type → PRODUCER_TYPE (default: "PRODUCTION")
   - mediator.type → MEDIATOR_TYPE (default: "PRODUCTION")
- On the `simulator` side adds the following missing configs to the mapper:
   - From GrpcConfig.java:
      - grpc.serverAddress (default: "localhost")
      - grpc.port (default: 8080)
   - From BlockStreamConfig.java:
      - blockStream.simulatorMode (default: "PUBLISHER")
      - blockStream.delayBetweenBlockItems (default: 1_500_000)
      - blockStream.maxBlockItemsToStream (default: 100_000)
      - blockStream.streamingMode (default: "MILLIS_PER_BLOCK")
      - blockStream.millisecondsPerBlock (default: 1000)
      - blockStream.blockItemsBatchSize (default: 1000)
   - From BlockGeneratorConfig.java:
      - generator.generationMode (default: "DIR")
      - generator.folderRootPath (default: "")
      - generator.managerImplementation (default: "BlockAsFileBlockStreamManager")
      - generator.paddedLength (default: 36)
      - generator.fileExtension (default: ".blk.gz")
      - generator.startBlockNumber (default: 1)
      - generator.endBlockNumber (default: -1)

Additional external variables added to both are:
- prometheus.endpointEnabled (default: true)
- prometheus.endpointPortNumber (default: 9999)

Adds two new gradle tasks for the simulator: 
- runPublisher (starts simulator in Publisher mode with enabled prometheus on port 9998)
- runConsumer (starts simulator in Consumer mode with enabled prometheus on port 9997)

**Related issue(s)**:

Fixes #285 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
