### PR TITLE
chore: Fix Simulator unbounded memory growth

### DIFF
--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -33,6 +33,7 @@ public final class SimulatorMappedConfigSourceInitializer {
 
             // Block stream configuration
             new ConfigMapping("blockStream.simulatorMode", "BLOCK_STREAM_SIMULATOR_MODE"),
+            new ConfigMapping("blockStream.lastKnownStatusesCapacity", "BLOCK_STREAM_LAST_KNOWN_STATUSES_CAPACITY"),
             new ConfigMapping("blockStream.delayBetweenBlockItems", "BLOCK_STREAM_DELAY_BETWEEN_BLOCK_ITEMS"),
             new ConfigMapping("blockStream.maxBlockItemsToStream", "BLOCK_STREAM_MAX_BLOCK_ITEMS_TO_STREAM"),
             new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -34,6 +34,7 @@ import com.swirlds.config.api.ConfigProperty;
 @ConfigData("blockStream")
 public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "PUBLISHER") SimulatorMode simulatorMode,
+        @ConfigProperty(defaultValue = "10") int lastKnownStatusesCapacity,
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
@@ -54,6 +55,7 @@ public record BlockStreamConfig(
      */
     public static class Builder {
         private SimulatorMode simulatorMode = SimulatorMode.PUBLISHER;
+        private int lastKnownStatusesCapacity = 10;
         private int delayBetweenBlockItems = 1_500_000;
         private int maxBlockItemsToStream = 10_000;
         private StreamingMode streamingMode = StreamingMode.MILLIS_PER_BLOCK;
@@ -75,6 +77,17 @@ public record BlockStreamConfig(
          */
         public Builder simulatorMode(SimulatorMode simulatorMode) {
             this.simulatorMode = simulatorMode;
+            return this;
+        }
+
+        /**
+         * Sets the capacity of the last known statuses.
+         *
+         * @param lastKnownStatusesCapacity the capacity
+         * @return this {@code Builder} instance
+         */
+        public Builder lastKnownStatusesCapacity(int lastKnownStatusesCapacity) {
+            this.lastKnownStatusesCapacity = lastKnownStatusesCapacity;
             return this;
         }
 
@@ -141,6 +154,7 @@ public record BlockStreamConfig(
         public BlockStreamConfig build() {
             return new BlockStreamConfig(
                     simulatorMode,
+                    lastKnownStatusesCapacity,
                     delayBetweenBlockItems,
                     maxBlockItemsToStream,
                     streamingMode,

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -25,6 +25,7 @@ import com.swirlds.config.api.ConfigProperty;
  * Defines the configuration data for the block stream in the Hedera Block Simulator.
  *
  * @param simulatorMode the mode of the simulator, in terms of publishing, consuming or both
+ * @param lastKnownStatusesCapacity the capacity of the last known statuses
  * @param delayBetweenBlockItems the delay in microseconds between streaming each block item
  * @param maxBlockItemsToStream the maximum number of block items to stream before stopping
  * @param streamingMode the mode of streaming for the block stream (e.g., time-based, count-based)
@@ -38,7 +39,7 @@ public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
-        @ConfigProperty(defaultValue = "10") int millisecondsPerBlock,
+        @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock,
         @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize) {
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -38,7 +38,7 @@ public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "1_500_000") int delayBetweenBlockItems,
         @ConfigProperty(defaultValue = "100_000") int maxBlockItemsToStream,
         @ConfigProperty(defaultValue = "MILLIS_PER_BLOCK") StreamingMode streamingMode,
-        @ConfigProperty(defaultValue = "1000") int millisecondsPerBlock,
+        @ConfigProperty(defaultValue = "10") int millisecondsPerBlock,
         @ConfigProperty(defaultValue = "1000") int blockItemsBatchSize) {
 
     /**

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -19,7 +19,8 @@ package com.hedera.block.simulator.config.data;
 import static com.hedera.block.common.utils.Preconditions.requireWhole;
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -33,8 +34,8 @@ import java.util.List;
 public record StreamStatus(
         long publishedBlocks,
         long consumedBlocks,
-        List<String> lastKnownPublisherStatuses,
-        List<String> lastKnownConsumersStatuses) {
+        Deque<String> lastKnownPublisherStatuses,
+        Deque<String> lastKnownConsumersStatuses) {
 
     /**
      * Creates a new {@link Builder} instance for constructing a {@code StreamStatus}.
@@ -51,8 +52,8 @@ public record StreamStatus(
     public static class Builder {
         private long publishedBlocks = 0;
         private long consumedBlocks = 0;
-        private List<String> lastKnownPublisherStatuses = new ArrayList<>();
-        private List<String> lastKnownConsumersStatuses = new ArrayList<>();
+        private Deque<String> lastKnownPublisherStatuses = new ArrayDeque<>();
+        private Deque<String> lastKnownConsumersStatuses = new ArrayDeque<>();
 
         /**
          * Creates a new instance of the {@code Builder} class with default configuration values.
@@ -93,7 +94,7 @@ public record StreamStatus(
          */
         public Builder lastKnownPublisherStatuses(List<String> lastKnownPublisherStatuses) {
             requireNonNull(lastKnownPublisherStatuses);
-            this.lastKnownPublisherStatuses = new ArrayList<>(lastKnownPublisherStatuses);
+            this.lastKnownPublisherStatuses = new ArrayDeque<>(lastKnownPublisherStatuses);
             return this;
         }
 
@@ -105,7 +106,7 @@ public record StreamStatus(
          */
         public Builder lastKnownConsumersStatuses(List<String> lastKnownConsumersStatuses) {
             requireNonNull(lastKnownConsumersStatuses);
-            this.lastKnownConsumersStatuses = new ArrayList<>(lastKnownConsumersStatuses);
+            this.lastKnownConsumersStatuses = new ArrayDeque<>(lastKnownConsumersStatuses);
             return this;
         }
 

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -32,6 +32,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import javax.inject.Inject;
@@ -56,13 +57,14 @@ public class ConsumerStreamGrpcClientImpl implements ConsumerStreamGrpcClient {
 
     // State
     private final int lastKnownStatusesCapacity;
-    private final ArrayDeque<String> lastKnownStatuses;
+    private final Deque<String> lastKnownStatuses;
     private CountDownLatch streamLatch;
 
     /**
      * Constructs a new ConsumerStreamGrpcClientImpl with the specified configuration and metrics service.
      *
      * @param grpcConfig The configuration for gRPC connection settings
+     * @param blockStreamConfig The configuration for the block stream
      * @param metricsService The service for recording consumption metrics
      * @throws NullPointerException if any parameter is null
      */

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -75,7 +75,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     @Override
     public void onNext(SubscribeStreamResponse subscribeStreamResponse) {
         final SubscribeStreamResponse.ResponseCase responseType = subscribeStreamResponse.getResponseCase();
-        if (lastKnownStatuses.size() == lastKnownStatusesCapacity) {
+        if (lastKnownStatuses.size() >= lastKnownStatusesCapacity) {
             lastKnownStatuses.pollFirst();
         }
         lastKnownStatuses.add(subscribeStreamResponse.toString());

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -27,7 +27,7 @@ import com.hedera.hapi.block.stream.protoc.BlockItem;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -44,7 +44,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     // State
     private final CountDownLatch streamLatch;
     private final int lastKnownStatusesCapacity;
-    private final ArrayDeque<String> lastKnownStatuses;
+    private final Deque<String> lastKnownStatuses;
 
     /**
      * Constructs a new ConsumerStreamObserver.
@@ -52,13 +52,14 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
      * @param metricsService The service for recording consumption metrics
      * @param streamLatch A latch used to coordinate stream completion
      * @param lastKnownStatuses List to store the most recent status messages
+     * @param lastKnownStatusesCapacity the capacity of the last known statuses
      * @throws NullPointerException if any parameter is null
      */
     public ConsumerStreamObserver(
             @NonNull final MetricsService metricsService,
             @NonNull final CountDownLatch streamLatch,
-            @NonNull final ArrayDeque<String> lastKnownStatuses,
-            @NonNull final int lastKnownStatusesCapacity) {
+            @NonNull final Deque<String> lastKnownStatuses,
+            final int lastKnownStatusesCapacity) {
         this.metricsService = requireNonNull(metricsService);
         this.streamLatch = requireNonNull(streamLatch);
         this.lastKnownStatuses = requireNonNull(lastKnownStatuses);
@@ -75,7 +76,7 @@ public class ConsumerStreamObserver implements StreamObserver<SubscribeStreamRes
     public void onNext(SubscribeStreamResponse subscribeStreamResponse) {
         final SubscribeStreamResponse.ResponseCase responseType = subscribeStreamResponse.getResponseCase();
         if (lastKnownStatuses.size() == lastKnownStatusesCapacity) {
-            lastKnownStatuses.removeFirst();
+            lastKnownStatuses.pollFirst();
         }
         lastKnownStatuses.add(subscribeStreamResponse.toString());
 

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -38,6 +38,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
@@ -64,7 +65,7 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
     // State
     private final AtomicBoolean streamEnabled;
     private final int lastKnownStatusesCapacity;
-    private final ArrayDeque<String> lastKnownStatuses;
+    private final Deque<String> lastKnownStatuses;
 
     /**
      * Creates a new PublishStreamGrpcClientImpl with the specified dependencies.

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -37,7 +37,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.inject.Inject;
@@ -63,7 +63,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
 
     // State
     private final AtomicBoolean streamEnabled;
-    private final List<String> lastKnownStatuses = new ArrayList<>();
+    private final int lastKnownStatusesCapacity;
+    private final ArrayDeque<String> lastKnownStatuses;
 
     /**
      * Creates a new PublishStreamGrpcClientImpl with the specified dependencies.
@@ -84,6 +85,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
         this.blockStreamConfig = requireNonNull(blockStreamConfig);
         this.metricsService = requireNonNull(metricsService);
         this.streamEnabled = requireNonNull(streamEnabled);
+        this.lastKnownStatusesCapacity = blockStreamConfig.lastKnownStatusesCapacity();
+        lastKnownStatuses = new ArrayDeque<>(this.lastKnownStatusesCapacity);
     }
 
     /**
@@ -95,7 +98,8 @@ public class PublishStreamGrpcClientImpl implements PublishStreamGrpcClient {
                 .usePlaintext()
                 .build();
         BlockStreamServiceGrpc.BlockStreamServiceStub stub = BlockStreamServiceGrpc.newStub(channel);
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
+        PublishStreamObserver publishStreamObserver =
+                new PublishStreamObserver(streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
         requestStreamObserver = stub.publishBlockStream(publishStreamObserver);
         lastKnownStatuses.clear();
     }

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -63,7 +63,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
      */
     @Override
     public void onNext(PublishStreamResponse publishStreamResponse) {
-        if (lastKnownStatuses.size() == lastKnownStatusesCapacity) {
+        if (lastKnownStatuses.size() >= lastKnownStatusesCapacity) {
             lastKnownStatuses.pollFirst();
         }
         lastKnownStatuses.add(publishStreamResponse.toString());

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -24,7 +24,7 @@ import com.hedera.hapi.block.protoc.PublishStreamResponse;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -37,19 +37,20 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     // State
     private final AtomicBoolean streamEnabled;
     private final int lastKnownStatusesCapacity;
-    private final ArrayDeque<String> lastKnownStatuses;
+    private final Deque<String> lastKnownStatuses;
 
     /**
      * Creates a new PublishStreamObserver instance.
      *
      * @param streamEnabled Controls whether streaming should continue
      * @param lastKnownStatuses List to store the most recent status messages
+     * @param lastKnownStatusesCapacity the capacity of the last known statuses
      * @throws NullPointerException if any parameter is null
      */
     public PublishStreamObserver(
             @NonNull final AtomicBoolean streamEnabled,
-            @NonNull final ArrayDeque<String> lastKnownStatuses,
-            @NonNull final int lastKnownStatusesCapacity) {
+            @NonNull final Deque<String> lastKnownStatuses,
+            final int lastKnownStatusesCapacity) {
         this.streamEnabled = requireNonNull(streamEnabled);
         this.lastKnownStatuses = requireNonNull(lastKnownStatuses);
         this.lastKnownStatusesCapacity = lastKnownStatusesCapacity;
@@ -63,7 +64,7 @@ public class PublishStreamObserver implements StreamObserver<PublishStreamRespon
     @Override
     public void onNext(PublishStreamResponse publishStreamResponse) {
         if (lastKnownStatuses.size() == lastKnownStatusesCapacity) {
-            lastKnownStatuses.removeFirst();
+            lastKnownStatuses.pollFirst();
         }
         lastKnownStatuses.add(publishStreamResponse.toString());
         LOGGER.log(INFO, "Received Response: " + publishStreamResponse.toString());

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -20,6 +20,7 @@ import static com.hedera.block.simulator.TestUtils.getTestMetrics;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -300,7 +301,7 @@ class BlockStreamSimulatorTest {
 
         assertNotNull(streamStatus, "StreamStatus should not be null");
         assertEquals(expectedPublishedBlocks, streamStatus.publishedBlocks(), "Published blocks should match");
-        assertEquals(
+        assertIterableEquals(
                 expectedLastKnownStatuses,
                 streamStatus.lastKnownPublisherStatuses(),
                 "Last known statuses should match");

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -35,6 +35,7 @@ class SimulatorMappedConfigSourceInitializerTest {
 
         // Block stream configuration
         new ConfigMapping("blockStream.simulatorMode", "BLOCK_STREAM_SIMULATOR_MODE"),
+        new ConfigMapping("blockStream.lastKnownStatusesCapacity", "BLOCK_STREAM_LAST_KNOWN_STATUSES_CAPACITY"),
         new ConfigMapping("blockStream.delayBetweenBlockItems", "BLOCK_STREAM_DELAY_BETWEEN_BLOCK_ITEMS"),
         new ConfigMapping("blockStream.maxBlockItemsToStream", "BLOCK_STREAM_MAX_BLOCK_ITEMS_TO_STREAM"),
         new ConfigMapping("blockStream.streamingMode", "BLOCK_STREAM_STREAMING_MODE"),

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -79,6 +79,16 @@ class BlockStreamConfigTest {
     }
 
     @Test
+    void testLastKnownStatusesCapacity() {
+        final int capacity = 20;
+        BlockStreamConfig config = getBlockStreamConfigBuilder()
+                .lastKnownStatusesCapacity(capacity)
+                .build();
+
+        assertEquals(capacity, config.lastKnownStatusesCapacity());
+    }
+
+    @Test
     void testValidAbsolutePath() {
         // Setup valid folder path and generation mode
         String gzRootFolder = "src/main/resources/block-0.0.3/";

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
@@ -17,6 +17,7 @@
 package com.hedera.block.simulator.config.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -54,11 +55,11 @@ class StreamStatusTest {
 
         assertEquals(10, streamStatus.publishedBlocks(), "publishedBlocks should be 10");
         assertEquals(8, streamStatus.consumedBlocks(), "consumedBlocks should be 8");
-        assertEquals(
+        assertIterableEquals(
                 publisherStatuses,
                 streamStatus.lastKnownPublisherStatuses(),
                 "lastKnownPublisherStatuses should match");
-        assertEquals(
+        assertIterableEquals(
                 consumerStatuses, streamStatus.lastKnownConsumersStatuses(), "lastKnownConsumersStatuses should match");
     }
 
@@ -75,11 +76,11 @@ class StreamStatusTest {
 
         assertEquals(5, streamStatus.publishedBlocks(), "publishedBlocks should be 5");
         assertEquals(3, streamStatus.consumedBlocks(), "consumedBlocks should be 3");
-        assertEquals(
+        assertIterableEquals(
                 List.of("PubStatus"),
                 streamStatus.lastKnownPublisherStatuses(),
                 "lastKnownPublisherStatuses should match");
-        assertEquals(
+        assertIterableEquals(
                 List.of("ConStatus"),
                 streamStatus.lastKnownConsumersStatuses(),
                 "lastKnownConsumersStatuses should match");
@@ -120,8 +121,14 @@ class StreamStatusTest {
                 .lastKnownConsumersStatuses(consumerStatuses)
                 .build();
 
-        assertEquals(streamStatus1, streamStatus2, "StreamStatus instances should be equal");
-        assertEquals(streamStatus1.hashCode(), streamStatus2.hashCode(), "Hash codes should be equal");
+        assertIterableEquals(
+                streamStatus1.lastKnownPublisherStatuses(),
+                streamStatus2.lastKnownPublisherStatuses(),
+                "lastKnownPublisherStatuses should match");
+        assertIterableEquals(
+                streamStatus1.lastKnownConsumersStatuses(),
+                streamStatus2.lastKnownConsumersStatuses(),
+                "lastKnownConsumersStatuses should match");
     }
 
     @Test
@@ -209,11 +216,11 @@ class StreamStatusTest {
 
         assertEquals(2, streamStatus.publishedBlocks(), "publishedBlocks should be 2");
         assertEquals(2, streamStatus.consumedBlocks(), "consumedBlocks should be 2");
-        assertEquals(
+        assertIterableEquals(
                 List.of("PubStatus"),
                 streamStatus.lastKnownPublisherStatuses(),
                 "lastKnownPublisherStatuses should match");
-        assertEquals(
+        assertIterableEquals(
                 List.of("ConStatus"),
                 streamStatus.lastKnownConsumersStatuses(),
                 "lastKnownConsumersStatuses should match");

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import com.hedera.block.simulator.TestUtils;
+import com.hedera.block.simulator.config.data.BlockStreamConfig;
 import com.hedera.block.simulator.config.data.GrpcConfig;
 import com.hedera.block.simulator.grpc.ConsumerStreamGrpcClient;
 import com.hedera.block.simulator.metrics.MetricsService;
@@ -50,6 +51,9 @@ import org.mockito.MockitoAnnotations;
 public class ConsumerStreamGrpcClientImplTest {
     @Mock
     private GrpcConfig grpcConfig;
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
 
     private ConsumerStreamGrpcClient consumerStreamGrpcClientImpl;
     private Server server;
@@ -102,10 +106,11 @@ public class ConsumerStreamGrpcClientImplTest {
 
         when(grpcConfig.serverAddress()).thenReturn("localhost");
         when(grpcConfig.port()).thenReturn(serverPort);
+        when(blockStreamConfig.lastKnownStatusesCapacity()).thenReturn(10);
 
         final Configuration config = TestUtils.getTestConfiguration();
         final MetricsService metricsService = new MetricsServiceImpl(getTestMetrics(config));
-        consumerStreamGrpcClientImpl = new ConsumerStreamGrpcClientImpl(grpcConfig, metricsService);
+        consumerStreamGrpcClientImpl = new ConsumerStreamGrpcClientImpl(grpcConfig, blockStreamConfig, metricsService);
         consumerStreamGrpcClientImpl.init();
     }
 

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
@@ -36,8 +36,7 @@ import com.hedera.hapi.block.stream.protoc.BlockItem;
 import com.hedera.hapi.block.stream.protoc.BlockProof;
 import com.swirlds.config.api.Configuration;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,8 +45,9 @@ class ConsumerStreamObserverTest {
 
     private MetricsService metricsService;
     private CountDownLatch streamLatch;
-    private List<String> lastKnownStatuses;
+    private ArrayDeque<String> lastKnownStatuses;
     private ConsumerStreamObserver observer;
+    private int lastKnownStatusesCapacity;
 
     @BeforeEach
     void setUp() throws IOException {
@@ -55,18 +55,24 @@ class ConsumerStreamObserverTest {
 
         metricsService = spy(new MetricsServiceImpl(getTestMetrics(config)));
         streamLatch = mock(CountDownLatch.class);
-        List<String> lastKnownStatuses = new ArrayList<>();
+        ArrayDeque<String> lastKnownStatuses = new ArrayDeque<>();
+        lastKnownStatusesCapacity = 10;
 
-        observer = new ConsumerStreamObserver(metricsService, streamLatch, lastKnownStatuses);
+        observer =
+                new ConsumerStreamObserver(metricsService, streamLatch, lastKnownStatuses, lastKnownStatusesCapacity);
     }
 
     @Test
     void testConstructorWithNullArguments() {
         assertThrows(
-                NullPointerException.class, () -> new ConsumerStreamObserver(null, streamLatch, lastKnownStatuses));
+                NullPointerException.class,
+                () -> new ConsumerStreamObserver(null, streamLatch, lastKnownStatuses, lastKnownStatusesCapacity));
         assertThrows(
-                NullPointerException.class, () -> new ConsumerStreamObserver(metricsService, null, lastKnownStatuses));
-        assertThrows(NullPointerException.class, () -> new ConsumerStreamObserver(metricsService, streamLatch, null));
+                NullPointerException.class,
+                () -> new ConsumerStreamObserver(metricsService, null, lastKnownStatuses, lastKnownStatusesCapacity));
+        assertThrows(
+                NullPointerException.class,
+                () -> new ConsumerStreamObserver(metricsService, streamLatch, null, lastKnownStatusesCapacity));
     }
 
     @Test

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
@@ -21,8 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.hapi.block.protoc.PublishStreamResponse;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.ArrayDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +31,10 @@ class PublishStreamObserverTest {
     void onNext() {
         PublishStreamResponse response = PublishStreamResponse.newBuilder().build();
         AtomicBoolean streamEnabled = new AtomicBoolean(true);
-        List<String> lastKnownStatuses = new ArrayList<>();
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
+        ArrayDeque<String> lastKnownStatuses = new ArrayDeque<>();
+        final int lastKnownStatusesCapacity = 10;
+        PublishStreamObserver publishStreamObserver =
+                new PublishStreamObserver(streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
 
         publishStreamObserver.onNext(response);
         assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");
@@ -43,8 +44,10 @@ class PublishStreamObserverTest {
     @Test
     void onError() {
         AtomicBoolean streamEnabled = new AtomicBoolean(true);
-        List<String> lastKnownStatuses = new ArrayList<>();
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
+        ArrayDeque<String> lastKnownStatuses = new ArrayDeque<>();
+        final int lastKnownStatusesCapacity = 10;
+        PublishStreamObserver publishStreamObserver =
+                new PublishStreamObserver(streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
 
         publishStreamObserver.onError(new Throwable());
         assertFalse(streamEnabled.get(), "streamEnabled should be set to false after onError");
@@ -54,8 +57,10 @@ class PublishStreamObserverTest {
     @Test
     void onCompleted() {
         AtomicBoolean streamEnabled = new AtomicBoolean(true);
-        List<String> lastKnownStatuses = new ArrayList<>();
-        PublishStreamObserver publishStreamObserver = new PublishStreamObserver(streamEnabled, lastKnownStatuses);
+        ArrayDeque<String> lastKnownStatuses = new ArrayDeque<>();
+        final int lastKnownStatusesCapacity = 10;
+        PublishStreamObserver publishStreamObserver =
+                new PublishStreamObserver(streamEnabled, lastKnownStatuses, lastKnownStatusesCapacity);
 
         publishStreamObserver.onCompleted();
         assertTrue(streamEnabled.get(), "streamEnabled should remain true after onCompleted");

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -74,8 +74,9 @@ public class PositiveEndpointBehaviourTests extends BaseSuite {
         blockStreamSimulatorApp.stop();
         StreamStatus streamStatus = blockStreamSimulatorApp.getStreamStatus();
         assertTrue(streamStatus.publishedBlocks() > 0);
-        assertEquals(
-                streamStatus.publishedBlocks(),
+        // We just need to make sure that number of published blocks is equal or greater than the statuses. Statuses are tracked in a queue to avoid unnecessary memory usage, therefore will always be less or equal to published.
+        assertTrue(
+                streamStatus.publishedBlocks() >=
                 streamStatus.lastKnownPublisherStatuses().size());
 
         // Verify each status contains the word "acknowledgement"

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -16,7 +16,6 @@
 
 package com.hedera.block.suites.grpc.positive;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.block.simulator.BlockStreamSimulatorApp;
@@ -74,10 +73,10 @@ public class PositiveEndpointBehaviourTests extends BaseSuite {
         blockStreamSimulatorApp.stop();
         StreamStatus streamStatus = blockStreamSimulatorApp.getStreamStatus();
         assertTrue(streamStatus.publishedBlocks() > 0);
-        // We just need to make sure that number of published blocks is equal or greater than the statuses. Statuses are tracked in a queue to avoid unnecessary memory usage, therefore will always be less or equal to published.
-        assertTrue(
-                streamStatus.publishedBlocks() >=
-                streamStatus.lastKnownPublisherStatuses().size());
+        // We just need to make sure that number of published blocks is equal or greater than the statuses. Statuses are
+        // tracked in a queue to avoid unnecessary memory usage, therefore will always be less or equal to published.
+        assertTrue(streamStatus.publishedBlocks()
+                >= streamStatus.lastKnownPublisherStatuses().size());
 
         // Verify each status contains the word "acknowledgement"
         streamStatus


### PR DESCRIPTION
**Description**:
This PR aims to resolve unbounded memory growth within the simulator, when running in consumer mode. It's was caused by the uncontrollable grow of the lastKnownStatuses list, when running in "high-speed" mode.
- Changed to ArrayDeque with predefined capacity.
- Added new blockStreamConfig called lastKnownStatusesCapacity, set to be 10 by default

**Related issue(s)**:

Fixes #404 

**Notes for reviewer**:
Here is image of the heap size before the fix:
![image](https://github.com/user-attachments/assets/810694f4-58ad-413a-ad90-2485a531cb72)
Here is image of the heap size after the fix:
![image](https://github.com/user-attachments/assets/a97a0ae5-e1f4-4a7c-83d3-bd661069c31b)


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
