### PR TITLE
test: add automatic unit test detection of missing configuration to environment variable mapping

### DIFF
--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -79,7 +79,7 @@ class ServerMappedConfigSourceInitializerTest {
     @MethodSource("allConfigDataTypes")
     void testVerifyAllFieldsInRecordsAreMapped(final Class<? extends Record> config) {
         if (!config.isAnnotationPresent(ConfigData.class)) {
-            fail("Class %s is missing the ConfigData annotation! All config classes MUST have that annotation present!"
+            fail("Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
                     .formatted(config.getSimpleName()));
         } else {
             final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
@@ -87,7 +87,7 @@ class ServerMappedConfigSourceInitializerTest {
             for (final RecordComponent recordComponent : config.getRecordComponents()) {
                 if (!recordComponent.isAnnotationPresent(ConfigProperty.class)) {
                     fail(
-                            "Field %s in %s is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
+                            "Field [%s] in [%s] is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
                                     .formatted(recordComponent.getName(), config.getSimpleName()));
                 } else {
                     final String expectedMappedName = "%s.%s".formatted(prefix, recordComponent.getName());

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -43,19 +43,34 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class ServerMappedConfigSourceInitializerTest {
     private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
+        // Consumer Config
         new ConfigMapping("consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
+
+        // Persistence Config
         new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
         new ConfigMapping("persistence.storage.archiveRootPath", "PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH"),
         new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
         new ConfigMapping("persistence.storage.compression", "PERSISTENCE_STORAGE_COMPRESSION"),
         new ConfigMapping("persistence.storage.compressionLevel", "PERSISTENCE_STORAGE_COMPRESSION_LEVEL"),
+
+        // Service Config
         new ConfigMapping("service.delayMillis", "SERVICE_DELAY_MILLIS"),
+
+        // Mediator Config
         new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
         new ConfigMapping("mediator.type", "MEDIATOR_TYPE"),
+
+        // Notifier Config
         new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE"),
+
+        // Producer Config
         new ConfigMapping("producer.type", "PRODUCER_TYPE"),
+
+        // Server Config
         new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
         new ConfigMapping("server.port", "SERVER_PORT"),
+
+        // Prometheus Config (external)
         new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
         new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER")
     };
@@ -79,8 +94,9 @@ class ServerMappedConfigSourceInitializerTest {
     @MethodSource("allConfigDataTypes")
     void testVerifyAllFieldsInRecordsAreMapped(final Class<? extends Record> config) {
         if (!config.isAnnotationPresent(ConfigData.class)) {
-            fail("Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
-                    .formatted(config.getSimpleName()));
+            fail(
+                    "Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
+                            .formatted(config.getSimpleName()));
         } else {
             final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
             final String prefix = configDataAnnotation.value();
@@ -152,12 +168,6 @@ class ServerMappedConfigSourceInitializerTest {
         }
     }
 
-    private static String transformToEnvVarConvention(final String input) {
-        String underscored = input.replace(".", "_");
-        String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
-        return resolved.toUpperCase();
-    }
-
     @SuppressWarnings("unchecked")
     private static Queue<ConfigMapping> extractConfigMappings() throws ReflectiveOperationException {
         final Field configMappings = MappedConfigSource.class.getDeclaredField("configMappings");
@@ -168,6 +178,12 @@ class ServerMappedConfigSourceInitializerTest {
         } finally {
             configMappings.setAccessible(false);
         }
+    }
+
+    private static String transformToEnvVarConvention(final String input) {
+        String underscored = input.replace(".", "_");
+        String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
+        return resolved.toUpperCase();
     }
 
     private static Stream<Arguments> allConfigDataTypes() {

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -31,6 +31,7 @@ import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -213,8 +214,10 @@ class ServerMappedConfigSourceInitializerTest {
         // mappings to be present in our scope, so we exclude all other fields. We must do the strategy
         // of exclusion and not inclusion because fields in the config classes can be added or removed, we want
         // to detect that.
+        final Entry<Class<PrometheusConfig>, List<String>> prometheusFieldsToExclude =
+                Map.entry(PrometheusConfig.class, List.of("endpointMaxBacklogAllowed"));
         final Map<Class<? extends Record>, List<String>> fieldNamesToExcludeForConfig =
-                Map.ofEntries(Map.entry(PrometheusConfig.class, List.of("endpointMaxBacklogAllowed")));
+                Map.ofEntries(prometheusFieldsToExclude);
 
         // Here are all the config classes that we need to check mappings for
         final Set<Class<? extends Record>> allRegisteredRecordsFilteredWithExcluded = new BlockNodeConfigExtension()

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -96,6 +96,7 @@ class ServerMappedConfigSourceInitializerTest {
      *       in {@link #allManagedConfigDataTypes()}.
      * </pre>
      * @param config parameterized, config class to test
+     * @param fieldNamesToExclude parameterized, fields to exclude from the test
      */
     @ParameterizedTest
     @MethodSource("allManagedConfigDataTypes")

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -222,8 +222,8 @@ class ServerMappedConfigSourceInitializerTest {
                         .filter(configType -> !excluded.contains(configType))
                         .collect(Collectors.toSet());
 
-        // Here we return all config classes that we need to check mappings for and a list of field names to check
-        // for the given config class, if list is empty, we check all fields
+        // Here we return all config classes that we need to check mappings for and a list of field names to
+        // exclude from the test for the given config class. If the list is empty, all fields will be checked.
         return allRegisteredRecordsFilteredWithExcluded.stream().map(config -> {
             final List<String> fieldsToExclude = fieldNamesToExcludeForConfig.getOrDefault(config, List.of());
             return Arguments.of(config, fieldsToExclude);

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -198,8 +198,8 @@ class ServerMappedConfigSourceInitializerTest {
     }
 
     private static String transformToEnvVarConvention(final String input) {
-        String underscored = input.replace(".", "_");
-        String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
+        final String underscored = input.replace(".", "_");
+        final String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
         return resolved.toUpperCase();
     }
 

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -103,10 +103,11 @@ class ServerMappedConfigSourceInitializerTest {
     @MethodSource("allManagedConfigDataTypes")
     void testVerifyAllFieldsInRecordsAreMapped(
             final Class<? extends Record> config, final List<String> fieldNamesToExclude) {
+        final String configClassName = config.getSimpleName();
         if (!config.isAnnotationPresent(ConfigData.class)) {
             fail(
                     "Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
-                            .formatted(config.getSimpleName()));
+                            .formatted(configClassName));
         } else {
             final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
             final String prefix = configDataAnnotation.value();
@@ -116,13 +117,13 @@ class ServerMappedConfigSourceInitializerTest {
             LOGGER.log(
                     Level.INFO,
                     "Checking fields %s\nfor config class [%s]."
-                            .formatted(Arrays.toString(fieldsToVerify), config.getSimpleName()));
+                            .formatted(Arrays.toString(fieldsToVerify), configClassName));
             for (final RecordComponent recordComponent : fieldsToVerify) {
                 final String fieldName = recordComponent.getName();
                 if (!recordComponent.isAnnotationPresent(ConfigProperty.class)) {
                     fail(
                             "Field [%s] in [%s] is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
-                                    .formatted(fieldName, config.getSimpleName()));
+                                    .formatted(fieldName, configClassName));
                 } else {
                     final String expectedMappedName = "%s.%s".formatted(prefix, fieldName);
                     final Optional<ConfigMapping> matchingMapping = Arrays.stream(SUPPORTED_MAPPINGS)
@@ -133,7 +134,7 @@ class ServerMappedConfigSourceInitializerTest {
                             .withFailMessage(
                                     "Field [%s] in [%s] is not present in the environment variable mappings! Expected config key [%s] to be present and to be mapped to [%s]",
                                     fieldName,
-                                    config.getSimpleName(),
+                                    configClassName,
                                     expectedMappedName,
                                     transformToEnvVarConvention(expectedMappedName))
                             .isPresent();

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.swirlds.common.metrics.config.MetricsConfig;
+import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.extensions.sources.ConfigMapping;
@@ -32,7 +33,6 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -75,7 +75,6 @@ class ServerMappedConfigSourceInitializerTest {
      * </pre>
      * @param config parameterized, config class to test
      */
-    @Disabled("This test is disabled because it will start passing only after #285 gets implemented")
     @ParameterizedTest
     @MethodSource("allConfigDataTypes")
     void testVerifyAllFieldsInRecordsAreMapped(final Class<? extends Record> config) {
@@ -173,8 +172,8 @@ class ServerMappedConfigSourceInitializerTest {
 
     private static Stream<Arguments> allConfigDataTypes() {
         // Add any classes that should be excluded from the test for any reason in the set below
-        // MetricsConfig is not supported by us
-        final Set<Class<? extends Record>> excluded = Set.of(MetricsConfig.class);
+        // MetricsConfig and PrometheusConfig are not managed by us
+        final Set<Class<? extends Record>> excluded = Set.of(MetricsConfig.class, PrometheusConfig.class);
         return new BlockNodeConfigExtension()
                 .getConfigDataTypes().stream()
                         .filter(configType -> !excluded.contains(configType))

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -76,7 +76,7 @@ class ServerMappedConfigSourceInitializerTest {
         new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
         new ConfigMapping("server.port", "SERVER_PORT"),
 
-        // Prometheus Config (external)
+        // Prometheus Config (externally managed, but we need this mapping)
         new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
         new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER")
     };

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -38,6 +38,7 @@ mainModuleInfo {
 
 testModuleInfo {
     requires("org.junit.jupiter.api")
+    requires("org.junit.jupiter.params")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
     requires("org.assertj.core")

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -40,6 +40,7 @@ testModuleInfo {
     requires("org.junit.jupiter.api")
     requires("org.mockito")
     requires("org.mockito.junit.jupiter")
+    requires("org.assertj.core")
     requiresStatic("com.github.spotbugs.annotations")
     requires("com.google.protobuf")
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -87,6 +87,7 @@ class SimulatorMappedConfigSourceInitializerTest {
      *       defined in {@link #allManagedConfigDataTypes()}.
      * </pre>
      * @param config parameterized, config class to test
+     * @param fieldNamesToExclude parameterized, fields to exclude from the test
      */
     @ParameterizedTest
     @MethodSource("allManagedConfigDataTypes")

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -67,7 +67,7 @@ class SimulatorMappedConfigSourceInitializerTest {
         new ConfigMapping("generator.startBlockNumber", "GENERATOR_START_BLOCK_NUMBER"),
         new ConfigMapping("generator.endBlockNumber", "GENERATOR_END_BLOCK_NUMBER"),
 
-        // Prometheus configuration
+        // Prometheus configuration (externally managed, but we need this mapping)
         new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
         new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER")
     };

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -189,8 +189,8 @@ class SimulatorMappedConfigSourceInitializerTest {
     }
 
     private static String transformToEnvVarConvention(final String input) {
-        String underscored = input.replace(".", "_");
-        String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
+        final String underscored = input.replace(".", "_");
+        final String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
         return resolved.toUpperCase();
     }
 

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -17,7 +17,6 @@
 package com.hedera.block.simulator.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.swirlds.common.metrics.config.MetricsConfig;
 import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
@@ -25,20 +24,27 @@ import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.extensions.sources.ConfigMapping;
 import com.swirlds.config.extensions.sources.MappedConfigSource;
+import java.lang.System.Logger.Level;
 import java.lang.reflect.Field;
 import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class SimulatorMappedConfigSourceInitializerTest {
+    private static final System.Logger LOGGER =
+            System.getLogger(SimulatorMappedConfigSourceInitializerTest.class.getName());
     private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
         // gRPC configuration
         new ConfigMapping("grpc.serverAddress", "GRPC_SERVER_ADDRESS"),
@@ -77,27 +83,37 @@ class SimulatorMappedConfigSourceInitializerTest {
      *     - all fields in all config classes are annotated with the
      *       {@link ConfigProperty} annotation.
      *     - a mapping for all fields in all config classes is present in the
-     *       {@link SimulatorMappedConfigSourceInitializer#MAPPINGS()}.
+     *       {@link SimulatorMappedConfigSourceInitializer#MAPPINGS()}, as
+     *       defined in {@link #allManagedConfigDataTypes()}.
      * </pre>
      * @param config parameterized, config class to test
      */
     @ParameterizedTest
-    @MethodSource("allConfigDataTypes")
-    void testVerifyAllFieldsInRecordsAreMapped(final Class<? extends Record> config) {
+    @MethodSource("allManagedConfigDataTypes")
+    void testVerifyAllFieldsInRecordsAreMapped(
+            final Class<? extends Record> config, final List<String> fieldNamesToExclude) {
         if (!config.isAnnotationPresent(ConfigData.class)) {
-            fail(
+            Assertions.fail(
                     "Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
                             .formatted(config.getSimpleName()));
         } else {
             final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
             final String prefix = configDataAnnotation.value();
-            for (final RecordComponent recordComponent : config.getRecordComponents()) {
+            final RecordComponent[] fieldsToVerify = Arrays.stream(config.getRecordComponents())
+                    .filter(recordComponent -> !fieldNamesToExclude.contains(recordComponent.getName()))
+                    .toArray(RecordComponent[]::new);
+            LOGGER.log(
+                    Level.INFO,
+                    "Checking fields %s\nfor config class [%s]."
+                            .formatted(Arrays.toString(fieldsToVerify), config.getSimpleName()));
+            for (final RecordComponent recordComponent : fieldsToVerify) {
+                final String fieldName = recordComponent.getName();
                 if (!recordComponent.isAnnotationPresent(ConfigProperty.class)) {
-                    fail(
+                    Assertions.fail(
                             "Field [%s] in [%s] is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
-                                    .formatted(recordComponent.getName(), config.getSimpleName()));
+                                    .formatted(fieldName, config.getSimpleName()));
                 } else {
-                    final String expectedMappedName = "%s.%s".formatted(prefix, recordComponent.getName());
+                    final String expectedMappedName = "%s.%s".formatted(prefix, fieldName);
                     final Optional<ConfigMapping> matchingMapping = Arrays.stream(SUPPORTED_MAPPINGS)
                             .filter(mapping -> mapping.mappedName().equals(expectedMappedName))
                             .findFirst();
@@ -105,7 +121,7 @@ class SimulatorMappedConfigSourceInitializerTest {
                             .isNotNull()
                             .withFailMessage(
                                     "Field [%s] in [%s] is not present in the environment variable mappings! Expected config key [%s] to be present and to be mapped to [%s]",
-                                    recordComponent.getName(),
+                                    fieldName,
                                     config.getSimpleName(),
                                     expectedMappedName,
                                     transformToEnvVarConvention(expectedMappedName))
@@ -177,13 +193,30 @@ class SimulatorMappedConfigSourceInitializerTest {
         return resolved.toUpperCase();
     }
 
-    private static Stream<Arguments> allConfigDataTypes() {
+    private static Stream<Arguments> allManagedConfigDataTypes() {
         // Add any classes that should be excluded from the test for any reason in the set below
-        // MetricsConfig and PrometheusConfig are not managed by us
-        final Set<Class<? extends Record>> excluded = Set.of(MetricsConfig.class, PrometheusConfig.class);
-        return new SimulatorConfigExtension()
+        // MetricsConfig is not managed by us.
+        final Set<Class<? extends Record>> excluded = Set.of(MetricsConfig.class);
+
+        // Add any classes that should be partially checked in the map below
+        // for example, we do not manage PrometheusConfig, but we need the endpointEnabled and endpointPortNumber
+        // mappings to be present in our scope, so we exclude all other fields. We must do the strategy
+        // of exclusion and not inclusion because fields in the config classes can be added or removed, we want
+        // to detect that.
+        final Map<Class<? extends Record>, List<String>> fieldNamesToExcludeForConfig =
+                Map.ofEntries(Map.entry(PrometheusConfig.class, List.of("endpointMaxBacklogAllowed")));
+
+        // Here are all the config classes that we need to check mappings for
+        final Set<Class<? extends Record>> allRegisteredRecordsFilteredWithExcluded = new SimulatorConfigExtension()
                 .getConfigDataTypes().stream()
                         .filter(configType -> !excluded.contains(configType))
-                        .map(Arguments::of);
+                        .collect(Collectors.toSet());
+
+        // Here we return all config classes that we need to check mappings for and a list of field names to check
+        // for the given config class, if list is empty, we check all fields
+        return allRegisteredRecordsFilteredWithExcluded.stream().map(config -> {
+            final List<String> fieldsToExclude = fieldNamesToExcludeForConfig.getOrDefault(config, List.of());
+            return Arguments.of(config, fieldsToExclude);
+        });
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -30,6 +30,7 @@ import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -204,8 +205,10 @@ class SimulatorMappedConfigSourceInitializerTest {
         // mappings to be present in our scope, so we exclude all other fields. We must do the strategy
         // of exclusion and not inclusion because fields in the config classes can be added or removed, we want
         // to detect that.
+        final Entry<Class<PrometheusConfig>, List<String>> prometheusFieldsToExclude =
+                Map.entry(PrometheusConfig.class, List.of("endpointMaxBacklogAllowed"));
         final Map<Class<? extends Record>, List<String>> fieldNamesToExcludeForConfig =
-                Map.ofEntries(Map.entry(PrometheusConfig.class, List.of("endpointMaxBacklogAllowed")));
+                Map.ofEntries(prometheusFieldsToExclude);
 
         // Here are all the config classes that we need to check mappings for
         final Set<Class<? extends Record>> allRegisteredRecordsFilteredWithExcluded = new SimulatorConfigExtension()

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -213,8 +213,8 @@ class SimulatorMappedConfigSourceInitializerTest {
                         .filter(configType -> !excluded.contains(configType))
                         .collect(Collectors.toSet());
 
-        // Here we return all config classes that we need to check mappings for and a list of field names to check
-        // for the given config class, if list is empty, we check all fields
+        // Here we return all config classes that we need to check mappings for and a list of field names to
+        // exclude from the test for the given config class. If the list is empty, all fields will be checked.
         return allRegisteredRecordsFilteredWithExcluded.stream().map(config -> {
             final List<String> fieldsToExclude = fieldNamesToExcludeForConfig.getOrDefault(config, List.of());
             return Arguments.of(config, fieldsToExclude);

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -94,10 +94,11 @@ class SimulatorMappedConfigSourceInitializerTest {
     @MethodSource("allManagedConfigDataTypes")
     void testVerifyAllFieldsInRecordsAreMapped(
             final Class<? extends Record> config, final List<String> fieldNamesToExclude) {
+        final String configClassName = config.getSimpleName();
         if (!config.isAnnotationPresent(ConfigData.class)) {
             Assertions.fail(
                     "Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
-                            .formatted(config.getSimpleName()));
+                            .formatted(configClassName));
         } else {
             final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
             final String prefix = configDataAnnotation.value();
@@ -107,13 +108,13 @@ class SimulatorMappedConfigSourceInitializerTest {
             LOGGER.log(
                     Level.INFO,
                     "Checking fields %s\nfor config class [%s]."
-                            .formatted(Arrays.toString(fieldsToVerify), config.getSimpleName()));
+                            .formatted(Arrays.toString(fieldsToVerify), configClassName));
             for (final RecordComponent recordComponent : fieldsToVerify) {
                 final String fieldName = recordComponent.getName();
                 if (!recordComponent.isAnnotationPresent(ConfigProperty.class)) {
                     Assertions.fail(
                             "Field [%s] in [%s] is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
-                                    .formatted(fieldName, config.getSimpleName()));
+                                    .formatted(fieldName, configClassName));
                 } else {
                     final String expectedMappedName = "%s.%s".formatted(prefix, fieldName);
                     final Optional<ConfigMapping> matchingMapping = Arrays.stream(SUPPORTED_MAPPINGS)
@@ -124,7 +125,7 @@ class SimulatorMappedConfigSourceInitializerTest {
                             .withFailMessage(
                                     "Field [%s] in [%s] is not present in the environment variable mappings! Expected config key [%s] to be present and to be mapped to [%s]",
                                     fieldName,
-                                    config.getSimpleName(),
+                                    configClassName,
                                     expectedMappedName,
                                     transformToEnvVarConvention(expectedMappedName))
                             .isPresent();

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -16,16 +16,27 @@
 
 package com.hedera.block.simulator.config;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
+import com.swirlds.common.metrics.config.MetricsConfig;
+import com.swirlds.common.metrics.platform.prometheus.PrometheusConfig;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
 import com.swirlds.config.extensions.sources.ConfigMapping;
 import com.swirlds.config.extensions.sources.MappedConfigSource;
 import java.lang.reflect.Field;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Predicate;
-import org.junit.jupiter.api.BeforeAll;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SimulatorMappedConfigSourceInitializerTest {
     private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
@@ -54,11 +65,54 @@ class SimulatorMappedConfigSourceInitializerTest {
         new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
         new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER")
     };
-    private static MappedConfigSource toTest;
 
-    @BeforeAll
-    static void setUp() {
-        toTest = SimulatorMappedConfigSourceInitializer.getMappedConfigSource();
+    /**
+     * This test aims to verify the state of all config extensions we have
+     * added. These configs are the ones that are returned from
+     * {@link SimulatorConfigExtension#getConfigDataTypes()}. This test will
+     * verify:
+     * <pre>
+     *     - all added config classes are annotated with the {@link ConfigData}
+     *       annotation.
+     *     - all fields in all config classes are annotated with the
+     *       {@link ConfigProperty} annotation.
+     *     - a mapping for all fields in all config classes is present in the
+     *       {@link SimulatorMappedConfigSourceInitializer#MAPPINGS()}.
+     * </pre>
+     * @param config parameterized, config class to test
+     */
+    @ParameterizedTest
+    @MethodSource("allConfigDataTypes")
+    void testVerifyAllFieldsInRecordsAreMapped(final Class<? extends Record> config) {
+        if (!config.isAnnotationPresent(ConfigData.class)) {
+            fail(
+                    "Class [%s] is missing the ConfigData annotation! All config classes MUST have that annotation present!"
+                            .formatted(config.getSimpleName()));
+        } else {
+            final ConfigData configDataAnnotation = config.getDeclaredAnnotation(ConfigData.class);
+            final String prefix = configDataAnnotation.value();
+            for (final RecordComponent recordComponent : config.getRecordComponents()) {
+                if (!recordComponent.isAnnotationPresent(ConfigProperty.class)) {
+                    fail(
+                            "Field [%s] in [%s] is missing the ConfigProperty annotation! All fields in config classes MUST have that annotation present!"
+                                    .formatted(recordComponent.getName(), config.getSimpleName()));
+                } else {
+                    final String expectedMappedName = "%s.%s".formatted(prefix, recordComponent.getName());
+                    final Optional<ConfigMapping> matchingMapping = Arrays.stream(SUPPORTED_MAPPINGS)
+                            .filter(mapping -> mapping.mappedName().equals(expectedMappedName))
+                            .findFirst();
+                    assertThat(matchingMapping)
+                            .isNotNull()
+                            .withFailMessage(
+                                    "Field [%s] in [%s] is not present in the environment variable mappings! Expected config key [%s] to be present and to be mapped to [%s]",
+                                    recordComponent.getName(),
+                                    config.getSimpleName(),
+                                    expectedMappedName,
+                                    transformToEnvVarConvention(expectedMappedName))
+                            .isPresent();
+                }
+            }
+        }
     }
 
     /**
@@ -71,29 +125,65 @@ class SimulatorMappedConfigSourceInitializerTest {
      * SimulatorMappedConfigSourceInitializer#MAPPINGS} to make this pass.
      */
     @Test
-    void test_VerifyAllSupportedMappingsAreAddedToInstance() throws ReflectiveOperationException {
+    void testVerifyAllSupportedMappingsAreAddedToInstance() throws ReflectiveOperationException {
         final Queue<ConfigMapping> actual = extractConfigMappings();
 
-        assertEquals(SUPPORTED_MAPPINGS.length, actual.size());
+        // fail if the actual and this test have a different number of mappings
+        assertThat(SUPPORTED_MAPPINGS.length)
+                .withFailMessage(
+                        "The number of supported mappings has changed! Please update the test to reflect the change.\nRUNTIME_MAPPING: %s\nTEST_MAPPING: %s",
+                        actual, Arrays.toString(SUPPORTED_MAPPINGS))
+                .isEqualTo(actual.size());
 
+        // test this test against actual
         for (final ConfigMapping current : SUPPORTED_MAPPINGS) {
             final Predicate<ConfigMapping> predicate =
                     cm -> current.mappedName().equals(cm.mappedName())
                             && current.originalName().equals(cm.originalName());
-            assertTrue(
-                    actual.stream().anyMatch(predicate),
-                    () -> "when testing for: [%s] it is not contained in mappings of the actual initialized object %s"
-                            .formatted(current, actual));
+            assertThat(actual.stream().anyMatch(predicate))
+                    .withFailMessage(
+                            "When testing for: [%s] it is not contained in mappings of the actual initialized object %s",
+                            current, actual)
+                    .isTrue();
+        }
+
+        // test actual against this test
+        for (final ConfigMapping current : actual) {
+            final Predicate<ConfigMapping> predicate =
+                    cm -> current.mappedName().equals(cm.mappedName())
+                            && current.originalName().equals(cm.originalName());
+            assertThat(Arrays.stream(SUPPORTED_MAPPINGS).anyMatch(predicate))
+                    .withFailMessage(
+                            "When testing for: [%s] it is not contained in mappings of this test %s", current, actual)
+                    .isTrue();
         }
     }
 
+    @SuppressWarnings("unchecked")
     private static Queue<ConfigMapping> extractConfigMappings() throws ReflectiveOperationException {
         final Field configMappings = MappedConfigSource.class.getDeclaredField("configMappings");
         try {
             configMappings.setAccessible(true);
-            return (Queue<ConfigMapping>) configMappings.get(toTest);
+            return (Queue<ConfigMapping>)
+                    configMappings.get(SimulatorMappedConfigSourceInitializer.getMappedConfigSource());
         } finally {
             configMappings.setAccessible(false);
         }
+    }
+
+    private static String transformToEnvVarConvention(final String input) {
+        String underscored = input.replace(".", "_");
+        String resolved = underscored.replaceAll("(?<!_)([A-Z])", "_$1");
+        return resolved.toUpperCase();
+    }
+
+    private static Stream<Arguments> allConfigDataTypes() {
+        // Add any classes that should be excluded from the test for any reason in the set below
+        // MetricsConfig and PrometheusConfig are not managed by us
+        final Set<Class<? extends Record>> excluded = Set.of(MetricsConfig.class, PrometheusConfig.class);
+        return new SimulatorConfigExtension()
+                .getConfigDataTypes().stream()
+                        .filter(configType -> !excluded.contains(configType))
+                        .map(Arguments::of);
     }
 }


### PR DESCRIPTION
**Description**:

- make a test that will be able to:
  - verify the correct usage and declaration of any configuration record
  - proactively fail and notify when we have added a configuration that has not the matching environment variable mapping

**Related issue(s)**:

Fixes #420 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
