### PR TITLE
fix: Restoring javadocs verification

### DIFF
--- a/buildSrc/src/main/kotlin/com.hedera.block.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.conventions.gradle.kts
@@ -142,7 +142,8 @@ tasks.withType<Javadoc>().configureEach {
         )
         options.windowTitle = "Hedera Block Node"
         options.memberLevel = JavadocMemberLevel.PACKAGE
-        addStringOption("Xdoclint:all,-missing", "-Xwerror")
+        // Commenting this so we still get missing javadocs warnings
+        // addStringOption("Xdoclint:all,-missing", "-Xwerror")
     }
 }
 


### PR DESCRIPTION
**Description**:
Due to some of the work related to build deterministic we lost the ability to check for missing javadocs when build or assemble

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
