### PR TITLE
feat: Add Loki to Helm chart deployment

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -55,6 +55,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run:  |
           helm repo add prometheus-community  https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
           helm dependency update charts/hedera-block-node
 
       - name: Run chart-testing (install)

--- a/charts/hedera-block-node/Chart.yaml
+++ b/charts/hedera-block-node/Chart.yaml
@@ -20,3 +20,11 @@ dependencies:
     condition: kubepromstack.enabled
     version: "51.2.0"  # Use the latest stable version
     repository: "https://prometheus-community.github.io/helm-charts"
+  - name: "loki"
+    condition: loki.enabled
+    repository: "https://grafana.github.io/helm-charts"
+    version: "^2.15.2"
+  - name: "promtail"
+    condition: promtail.enabled
+    repository: "https://grafana.github.io/helm-charts"
+    version: "^6.7.4"

--- a/charts/hedera-block-node/README.md
+++ b/charts/hedera-block-node/README.md
@@ -85,6 +85,17 @@ kubepromstack:
   enabled: false
 ```
 
+### Enable Loki + Promtail
+By default the stack includes chart dependencies for a loki + promtail stack, to collect logs from the Hedera Block Node and the K8 cluster.
+If you prefer to use your own loki+promtail stack, you can disable the stack by setting the following values:
+```yaml
+loki:
+  enabled: false
+
+promtail:
+  enabled: false
+```
+
 ## Using
 Follow the `NOTES` instructions after installing the chart to perform `port-forward` to the Hedera Block Node and be able to use it.
 

--- a/charts/hedera-block-node/templates/_helpers.tpl
+++ b/charts/hedera-block-node/templates/_helpers.tpl
@@ -78,3 +78,21 @@ Usage: {{ include "hedera-block-node.app.version" . }}
 {{- define "hedera-block-node.appVersion" -}}
 {{- default .Chart.AppVersion .Values.blockNode.version -}}
 {{- end -}}
+
+{{/*
+The service name to connect to Loki. Defaults to the same logic as "loki.fullname"
+*/}}
+{{- define "loki.serviceName" -}}
+{{- if .Values.loki.serviceName -}}
+{{- .Values.loki.serviceName -}}
+{{- else if .Values.loki.fullnameOverride -}}
+{{- .Values.loki.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "loki" .Values.loki.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/hedera-block-node/templates/grafana-datasource.yaml
+++ b/charts/hedera-block-node/templates/grafana-datasource.yaml
@@ -17,5 +17,14 @@ data:
         editable: true
         jsonData:
           timeInterval: "15s"
+          
+    {{- if .Values.loki.enabled }}
+      - name: Loki
+        type: loki
+        url: http://{{ .Release.Name }}-loki:3100
+        access: proxy
+        isDefault: false
+        editable: true
+    {{- end }}
 
 {{- end }}

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -121,3 +121,29 @@ kubepromstack:
 
   nodeExporter:
     enabled: true
+
+loki:
+  enabled: true
+  isDefault: true
+  url: http://{{(include "loki.serviceName" .)}}:{{ .Values.loki.service.port }}
+  readinessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  livenessProbe:
+    httpGet:
+      path: /ready
+      port: http-metrics
+    initialDelaySeconds: 45
+  datasource:
+    jsonData: "{}"
+    uid: ""
+
+promtail:
+  enabled: true
+  config:
+    logLevel: info
+    serverPort: 3101
+    clients:
+      - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -147,3 +147,17 @@ promtail:
     serverPort: 3101
     clients:
       - url: http://{{ .Release.Name }}-loki:3100/loki/api/v1/push
+    snippets:
+      pipelineStages:
+        - docker:
+            label_fields:
+              stream: stream
+        - multiline:
+            # A regex that identifies the start of a new log entry
+            firstline: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+            # Maximum wait time for more lines before sending the collected log upstream
+            max_wait_time: 3s
+            separator: ''
+        - replace:
+            expression: '(\n){2,}'
+            replace: ''


### PR DESCRIPTION
**Description**:
In order to access logs from grafana, create panels and alerts based on logs we need to export them using promtail + loki and add them as provisioned datasources into the already existing grafana instance included on the helm chart.

Also configures multiline log merging for promtail.

This PR adds that functionality.

**Related issue(s)**:

Fixes #433 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
