### PR TITLE
refactor: Logs improvements

### DIFF
--- a/charts/hedera-block-node/templates/configmap-logging.yaml
+++ b/charts/hedera-block-node/templates/configmap-logging.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hedera-block-node.fullname" . }}-logging-config
+data:
+  logging.properties: |
+    # Log properties
+    .level= {{ .Values.blockNode.logs.level }}
+    java.util.logging.SimpleFormatter.format= {{ .Values.blockNode.logs.format }}
+
+    {{- range .Values.blockNode.logs.loggingProperties }}
+    {{ .name }}={{ .value }}
+    {{- end }}

--- a/charts/hedera-block-node/templates/configmap-logging.yaml
+++ b/charts/hedera-block-node/templates/configmap-logging.yaml
@@ -6,8 +6,7 @@ data:
   logging.properties: |
     # Log properties
     .level= {{ .Values.blockNode.logs.level }}
-    java.util.logging.SimpleFormatter.format= {{ .Values.blockNode.logs.format }}
 
-    {{- range .Values.blockNode.logs.loggingProperties }}
-    {{ .name }}={{ .value }}
+    {{- range $key, $value := .Values.blockNode.logs.loggingProperties }}
+    {{ $key }}={{ $value }}
     {{- end }}

--- a/charts/hedera-block-node/templates/deployment.yaml
+++ b/charts/hedera-block-node/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
       serviceAccountName: {{ include "hedera-block-node.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: logging-config
+          configMap:
+            name: {{ include "hedera-block-node.fullname" . }}-logging-config
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -43,6 +47,10 @@ spec:
               name: {{ include "hedera-block-node.fullname" . }}-config
           - secretRef:
               name: {{ include "hedera-block-node.fullname" . }}-secret
+        volumeMounts:
+            - name: logging-config
+              mountPath: /app/logs/config
+              readOnly: true
         resources:
           requests:
             memory: {{ .Values.blockNode.resources.requests.memory }}

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -133,7 +133,7 @@ blockNode:
       java.util.logging.SimpleFormatter.format: "%1$tF %1$tT %4$-7s [%2$s] %5$s %n"
 
 kubepromstack:
-  enabled: false
+  enabled: true
   prometheusOperator:
     namespaces:
       releaseNamespace: true

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -101,50 +101,36 @@ blockNode:
     # Available Levels are (from most verbose to least verbose):
     # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
     level: "INFO"
-    ################################################################################
-    # SimpleFormatter single-line format configuration
-    ################################################################################
-    # The format syntax uses java.util.Formatter.
-    # The parameters are:
-    #   %1$ - date/time (java.util.Date)
-    #   %2$ - source (usually class and method)
-    #   %3$ - logger?s name
-    #   %4$ - log level
-    #   %5$ - log message
-    #   %6$ - throwable trace
-    #
-    # Example to produce a line such as:
-    # 2025-01-04 00:34:43 INFO [com.hedera.block.server.Server main] Starting BlockNode Server
-    #
-    format: "%1$tF %1$tT %4$-7s [%2$s] %5$s %n"
     loggingProperties:
-      # Add any additional logging configuration properties here
-      - name: "io.helidon.webserver.level"
-        value: "INFO"
-      - name: "io.helidon.config.level"
-        value: "SEVERE"
-      - name: "io.helidon.security.level"
-        value: "INFO"
-      - name: "io.helidon.common.level"
-        value: "INFO"
-      - name: "handlers"
-        value: "java.util.logging.ConsoleHandler, java.util.logging.FileHandler"
-      - name: "java.util.logging.ConsoleHandler.level"
-        value: "FINE"
-      - name: "java.util.logging.ConsoleHandler.formatter"
-        value: "java.util.logging.SimpleFormatter"
-      - name: "java.util.logging.FileHandler.pattern"
-        value: "/app/logs/blocknode-%g.log"
-      - name: "java.util.logging.FileHandler.append"
-        value: "true"
-      - name: "java.util.logging.FileHandler.limit"
-        value: "5000000"
-      - name: "java.util.logging.FileHandler.count"
-        value: "5"
-      - name: "java.util.logging.FileHandler.level"
-        value: "FINE"
-      - name: "java.util.logging.FileHandler.formatter"
-        value: "java.util.logging.SimpleFormatter"
+      io.helidon.webserver.level: "INFO"
+      io.helidon.webserver.access.level: "INFO"
+      io.helidon.config.level: "SEVERE"
+      io.helidon.security.level: "INFO"
+      io.helidon.common.level: "INFO"
+      handlers: "java.util.logging.ConsoleHandler, java.util.logging.FileHandler"
+      java.util.logging.ConsoleHandler.level: "FINE"
+      java.util.logging.ConsoleHandler.formatter: "java.util.logging.SimpleFormatter"
+      java.util.logging.FileHandler.pattern: "/app/logs/blocknode-%g.log"
+      java.util.logging.FileHandler.append: "true"
+      java.util.logging.FileHandler.limit: "5_000_000"
+      java.util.logging.FileHandler.count: "5"
+      java.util.logging.FileHandler.level: "FINE"
+      java.util.logging.FileHandler.formatter: "java.util.logging.SimpleFormatter"
+      ################################################################################
+      # SimpleFormatter single-line format configuration
+      ################################################################################
+      # The format syntax uses java.util.Formatter.
+      # The parameters are:
+      #   %1$ - date/time (java.util.Date)
+      #   %2$ - source (usually class and method)
+      #   %3$ - logger?s name
+      #   %4$ - log level
+      #   %5$ - log message
+      #   %6$ - throwable trace
+      #
+      # Example to produce a line such as:
+      # 2025-01-04 00:34:43 INFO [com.hedera.block.server.Server main] Starting BlockNode Server
+      java.util.logging.SimpleFormatter.format: "%1$tF %1$tT %4$-7s [%2$s] %5$s %n"
 
 kubepromstack:
   enabled: false

--- a/charts/hedera-block-node/values.yaml
+++ b/charts/hedera-block-node/values.yaml
@@ -79,6 +79,7 @@ blockNode:
     # Add any additional env configuration here
     # key: value
     BLOCKNODE_STORAGE_ROOT_PATH: "/app/storage"
+    JAVA_TOOL_OPTIONS: "-Djava.util.logging.config.file=/app/logs/config/logging.properties -Duser.timezone=UTC"
   secret:
     # if blank will use same as AppVersion of chart.
     PRIVATE_KEY: "fake_private_key"
@@ -96,9 +97,57 @@ blockNode:
     requests:
       cpu: "2"
       memory: "8Gi"
+  logs:
+    # Available Levels are (from most verbose to least verbose):
+    # ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
+    level: "INFO"
+    ################################################################################
+    # SimpleFormatter single-line format configuration
+    ################################################################################
+    # The format syntax uses java.util.Formatter.
+    # The parameters are:
+    #   %1$ - date/time (java.util.Date)
+    #   %2$ - source (usually class and method)
+    #   %3$ - logger?s name
+    #   %4$ - log level
+    #   %5$ - log message
+    #   %6$ - throwable trace
+    #
+    # Example to produce a line such as:
+    # 2025-01-04 00:34:43 INFO [com.hedera.block.server.Server main] Starting BlockNode Server
+    #
+    format: "%1$tF %1$tT %4$-7s [%2$s] %5$s %n"
+    loggingProperties:
+      # Add any additional logging configuration properties here
+      - name: "io.helidon.webserver.level"
+        value: "INFO"
+      - name: "io.helidon.config.level"
+        value: "SEVERE"
+      - name: "io.helidon.security.level"
+        value: "INFO"
+      - name: "io.helidon.common.level"
+        value: "INFO"
+      - name: "handlers"
+        value: "java.util.logging.ConsoleHandler, java.util.logging.FileHandler"
+      - name: "java.util.logging.ConsoleHandler.level"
+        value: "FINE"
+      - name: "java.util.logging.ConsoleHandler.formatter"
+        value: "java.util.logging.SimpleFormatter"
+      - name: "java.util.logging.FileHandler.pattern"
+        value: "/app/logs/blocknode-%g.log"
+      - name: "java.util.logging.FileHandler.append"
+        value: "true"
+      - name: "java.util.logging.FileHandler.limit"
+        value: "5000000"
+      - name: "java.util.logging.FileHandler.count"
+        value: "5"
+      - name: "java.util.logging.FileHandler.level"
+        value: "FINE"
+      - name: "java.util.logging.FileHandler.formatter"
+        value: "java.util.logging.SimpleFormatter"
 
 kubepromstack:
-  enabled: true
+  enabled: false
   prometheusOperator:
     namespaces:
       releaseNamespace: true

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -106,6 +106,9 @@ COPY --from=distributions server-${VERSION}.tar .
 # Extract the TAR file
 RUN tar -xvf server-${VERSION}.tar
 
+# Create a log directory
+RUN mkdir -p /app/logs
+
 # Copy the logging properties file
 COPY logging.properties logging.properties
 

--- a/server/docker/Dockerfile
+++ b/server/docker/Dockerfile
@@ -107,10 +107,10 @@ COPY --from=distributions server-${VERSION}.tar .
 RUN tar -xvf server-${VERSION}.tar
 
 # Create a log directory
-RUN mkdir -p /app/logs
+RUN mkdir -p /app/logs/config
 
 # Copy the logging properties file
-COPY logging.properties logging.properties
+COPY logging.properties /app/logs/config/logging.properties
 
 # HEALTHCHECK for liveness and readiness
 HEALTHCHECK --interval=30s --timeout=10s --start-period=3s --retries=3 \

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: block-node-server
     image: block-node-server:${VERSION}
     volumes:
-      - ./logging.properties:/app/logging.properties
+      - ./logging.properties:/app/logs/config/logging.properties
     env_file:
       - .env
     ports:

--- a/server/docker/docker-compose.yml
+++ b/server/docker/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   block-node-server:
     container_name: block-node-server
     image: block-node-server:${VERSION}
+    volumes:
+      - ./logging.properties:/app/logging.properties
     env_file:
       - .env
     ports:

--- a/server/docker/logging.properties
+++ b/server/docker/logging.properties
@@ -9,6 +9,8 @@
 # FINEST: provides the most detailed debugging information
 
 # Set the default logging level
+# Available Levels are (from most verbose to least verbose):
+# ALL FINEST FINER FINE CONFIG INFO WARNING SEVERE OFF
 .level=INFO
 
 # Helidon loggers
@@ -31,8 +33,30 @@ io.helidon.common.level=INFO
 # Helidon PBJ Plugin loggers
 #com.hedera.pbj.grpc.helidon.PbjProtocolHandler.level=FINE
 
-# Console handler configuration
+################################################################################
+# Handlers configuration
+################################################################################
 handlers = java.util.logging.ConsoleHandler
+
+################################################################################
+# ConsoleHandler configuration
+################################################################################
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
+################################################################################
+# SimpleFormatter single-line format configuration
+################################################################################
+# The format syntax uses java.util.Formatter.
+# The parameters are:
+#   %1$ - date/time (java.util.Date)
+#   %2$ - source (usually class and method)
+#   %3$ - logger?s name
+#   %4$ - log level
+#   %5$ - log message
+#   %6$ - throwable trace
+#
+# Example to produce a line such as:
+# 2025-01-04 00:34:43 INFO [com.hedera.block.server.Server main] Starting BlockNode Server
+#
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT %4$-7s [%2$s] %5$s %n

--- a/server/docker/logging.properties
+++ b/server/docker/logging.properties
@@ -36,13 +36,33 @@ io.helidon.common.level=INFO
 ################################################################################
 # Handlers configuration
 ################################################################################
-handlers = java.util.logging.ConsoleHandler
+handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 ################################################################################
 # ConsoleHandler configuration
 ################################################################################
 java.util.logging.ConsoleHandler.level = FINE
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+################################################################################
+# FileHandler properties
+################################################################################
+# The pattern for the output file name.
+java.util.logging.FileHandler.pattern = /app/logs/blocknode-%g.log
+# Set append to true if you want to keep appending to existing files
+java.util.logging.FileHandler.append = true
+# The limit in bytes before a new file is started.
+# e.g., 5,000,000 bytes ~= 5MB
+java.util.logging.FileHandler.limit = 5_000_000
+# Number of log files to cycle through.
+# If count is 5, you end up with:
+#  myapp-0.log ... myapp-4.log
+# Then it cycles back over the oldest.
+java.util.logging.FileHandler.count = 5
+# Log level for the FileHandler
+java.util.logging.FileHandler.level = FINE
+# Use your SimpleFormatter, or a custom format
+java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 
 ################################################################################
 # SimpleFormatter single-line format configuration

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -40,7 +40,7 @@ fi
 
 # Set the timezone to UTC and the logging properties file to /app/logging.properties
 # file is mounted in the docker-compose.yml, changes to the file will be reflected in the container
-echo "JAVA_TOOL_OPTIONS='-Djava.util.logging.config.file=/app/logging.properties -Duser.timezone=UTC'" >> .env
+echo "JAVA_TOOL_OPTIONS='-Djava.util.logging.config.file=/app/logs/config/logging.properties -Duser.timezone=UTC'" >> .env
 
 # Output the values
 echo ".env properties:"

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -38,6 +38,10 @@ else
   echo "JAVA_OPTS='-Xms16G -Xmx16G'" >> .env
 fi
 
+# Set the timezone to UTC and the logging properties file to /app/logging.properties
+# file is mounted in the docker-compose.yml, changes to the file will be reflected in the container
+echo "JAVA_TOOL_OPTIONS='-Djava.util.logging.config.file=/app/logging.properties -Duser.timezone=UTC'" >> .env
+
 # Output the values
 echo ".env properties:"
 cat .env

--- a/server/docker/update-env.sh
+++ b/server/docker/update-env.sh
@@ -38,8 +38,8 @@ else
   echo "JAVA_OPTS='-Xms16G -Xmx16G'" >> .env
 fi
 
-# Set the timezone to UTC and the logging properties file to /app/logging.properties
-# file is mounted in the docker-compose.yml, changes to the file will be reflected in the container
+# Set the timezone to UTC and the logging properties file
+# file is mounted in the docker-compose.yml, changes to the file will be reflected in the container by simply restarting it
 echo "JAVA_TOOL_OPTIONS='-Djava.util.logging.config.file=/app/logs/config/logging.properties -Duser.timezone=UTC'" >> .env
 
 # Output the values

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -34,14 +34,6 @@ public class Server {
     public static void main(final String[] args) throws IOException {
         LOGGER.log(INFO, "Starting BlockNode Server");
 
-        // Set the global configuration
-        final Config config = Config.builder()
-                .sources(file(Paths.get("/app", LOGGING_PROPERTIES)).optional())
-                .sources(classpath("helidon.properties"))
-                .build();
-
-        Config.global(config);
-
         // Init BlockNode Configuration
         final Configuration configuration = ConfigurationBuilder.create()
                 .withSource(ServerMappedConfigSourceInitializer.getMappedConfigSource())

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -2,9 +2,6 @@
 package com.hedera.block.server;
 
 import static com.hedera.block.common.constants.StringsConstants.APPLICATION_PROPERTIES;
-import static com.hedera.block.common.constants.StringsConstants.LOGGING_PROPERTIES;
-import static io.helidon.config.ConfigSources.classpath;
-import static io.helidon.config.ConfigSources.file;
 import static java.lang.System.Logger;
 import static java.lang.System.Logger.Level.INFO;
 
@@ -13,10 +10,8 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.ClasspathFileConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
-import io.helidon.config.Config;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /** Main class for the block node server */
 public class Server {

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -35,7 +35,6 @@ module com.hedera.block.server {
     requires com.swirlds.metrics.api;
     requires dagger;
     requires io.helidon.common;
-    requires io.helidon.config;
     requires io.helidon.webserver;
     requires javax.inject;
     requires static com.github.spotbugs.annotations;


### PR DESCRIPTION
**Description**:
Improves logs by doing the several changes:

Docker Image
- [x] Java uses UTC Timezone explicitly, so logs always have the UTC date time values.
- [x] Java loads the `logging.properties' from the very beginning.
- [x] Better Log Format is defined on `logging.properties` (mean to be single line)
- [x] FileHandler is added to the logs handlers, creating a log file backup on file
- [x] Removed the need to Set Helidon log config separately and manually on Server initialization.

Helm Chart - K8 (Cloud Env)
- [x] Defines a new values config with the default logging.properties content, and overridable.
- [x] Creates a ConfigMap that generates the `logging.properties` that the block-node server deployment will use.

Docker-Compose (Local Dev Env)
- [x] Mounts the `logging.properties` on `build/docker` where the docker stack is created to the server instance, so it can be easily configurable and properties changed.

**Related issue(s)**:

Fixes #445 
Fixes #444 
Fixes #443 

**Notes for reviewer**:
Example of how logs are looking now:

```
Picked up JAVA_TOOL_OPTIONS: -Djava.util.logging.config.file=/app/logs/config/logging.properties -Duser.timezone=UTC
2025-01-05 06:46:12 INFO    [com.hedera.block.server.Server main] Starting BlockNode Server 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.producer.ProducerConfig <init>] Producer configuration producer.type: PRODUCTION 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.ServerConfig <init>] Server configuration server.maxMessageSizeBytes: 4194304 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.ServerConfig <init>] Server configuration server.port: 8080 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.service.ServiceConfig <init>] Service configuration service.delayMillis: 500 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.mediator.MediatorConfig <init>] Mediator configuration mediator.ringBufferSize: 4194304 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.mediator.MediatorConfig <init>] Mediator configuration mediator.type: PRODUCTION 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.notifier.NotifierConfig <init>] Notifier configuration notifier.ringBufferSize: 1024 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.consumer.ConsumerConfig <init>] Consumer configuration timeoutThresholdMillis: 1500 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.persistence.storage.write.BlockAsLocalDirWriter <init>] Initializing com.hedera.block.server.persistence.storage.write.BlockAsLocalDirWriter... 
2025-01-05 06:46:12 INFO    [com.hedera.block.common.utils.FileUtilities createFolderPathIfNotExists] Requested [Block Node Live Root Directory] not created because the directory already exists at '/app/hashgraph/blocknode/data/live' 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.persistence.storage.read.BlockAsLocalDirReader <init>] Initializing com.hedera.block.server.persistence.storage.read.BlockAsLocalDirReader... 
2025-01-05 06:46:12 INFO    [io.helidon.webserver.ServerListener start] [0x6cc709a3] http://0.0.0.0:8080 bound for socket '@default' 
2025-01-05 06:46:12 INFO    [io.helidon.common.features.HelidonFeatures features] Helidon SE 4.1.1 features: [Config, Encoding, Media, Metrics, WebServer] 
2025-01-05 06:46:12 INFO    [io.helidon.logging.jul.JulProvider doConfigureLogging] Logging at runtime configured using /app/logs/config/logging.properties 
2025-01-05 06:46:12 INFO    [io.helidon.webserver.LoomServer startIt] Started all channels in 10 milliseconds. 914 milliseconds since JVM startup. Java 21.0.1+12-LTS 
2025-01-05 06:46:12 INFO    [com.hedera.block.server.BlockNodeApp start] Block Node Server started at port: 8080 
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
