### PR TITLE
chore: Switch license declarations to SPDX

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 changelog:
   exclude:
     labels: ['wontfix', 'question', 'duplicate', 'invalid']

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "E2E Test Suites"
 on:
   push:

--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: Lint and Test Charts
 
 on: pull_request

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "PR Gradle Checks"
 on:
   push:

--- a/.github/workflows/pr-formatting.yaml
+++ b/.github/workflows/pr-formatting.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "PR Formatting Checks"
 on:
   pull_request:

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: Release Automation
 
 on:

--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: Release Workflow
 
 on:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "Smoke Test"
 on:
   push:

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "ZXC: Verify Docker Build Determinism"
 on:
   workflow_call:

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -1,18 +1,4 @@
-##
-# Copyright (C) 2023-2024 Hedera Hashgraph, LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-##
+# SPDX-License-Identifier: Apache-2.0
 name: "ZXC: Verify Gradle Build Determinism"
 # Here, the ZXC prefix:
 # Z - Ensures sort order such that this script appears at the bottom of the UI

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("com.hedera.block.root")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { `kotlin-dsl` }
 
 repositories { gradlePluginPortal() }

--- a/buildSrc/src/main/kotlin/Utils.kt
+++ b/buildSrc/src/main/kotlin/Utils.kt
@@ -1,24 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
 import net.swiftzer.semver.SemVer
 import org.gradle.api.Project
 import java.io.File
 import java.io.OutputStream
 import java.io.PrintStream
-
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 class Utils {
     companion object {

--- a/buildSrc/src/main/kotlin/com.hedera.block.aggregate-reports.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.aggregate-reports.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import java.io.BufferedOutputStream
 import net.swiftzer.semver.SemVer
 

--- a/buildSrc/src/main/kotlin/com.hedera.block.common.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.common.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java-library")
     id("com.hedera.block.conventions")

--- a/buildSrc/src/main/kotlin/com.hedera.block.conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.conventions.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import com.adarshr.gradle.testlogger.theme.ThemeType
 
 plugins {

--- a/buildSrc/src/main/kotlin/com.hedera.block.jpms-modules.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.jpms-modules.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.gradlex.jvm-dependency-conflict-resolution")
     id("org.gradlex.extra-java-module-info")

--- a/buildSrc/src/main/kotlin/com.hedera.block.maven-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.maven-publish.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("maven-publish")

--- a/buildSrc/src/main/kotlin/com.hedera.block.protobuf.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.protobuf.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import com.google.protobuf.gradle.id
 import com.hedera.block.tasks.GitClone
 

--- a/buildSrc/src/main/kotlin/com.hedera.block.protos.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.protos.gradle.kts
@@ -5,13 +5,7 @@ plugins {
     id("com.hedera.block.conventions")
 }
 
-sourceSets {
-    main {
-        proto {
-            srcDir("src/main/protobuf")
-        }
-    }
-}
+sourceSets { main { proto { srcDir("src/main/protobuf") } } }
 
 protobuf {
     // Configure the protoc executable
@@ -20,4 +14,3 @@ protobuf {
         artifact = "com.google.protobuf:protoc:3.21.10"
     }
 }
-

--- a/buildSrc/src/main/kotlin/com.hedera.block.protos.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.protos.gradle.kts
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java")
     id("com.google.protobuf")

--- a/buildSrc/src/main/kotlin/com.hedera.block.repositories.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.repositories.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 repositories {
     mavenCentral()
     maven {

--- a/buildSrc/src/main/kotlin/com.hedera.block.root.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.root.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import io.github.gradlenexus.publishplugin.CloseNexusStagingRepository
 
 plugins {

--- a/buildSrc/src/main/kotlin/com.hedera.block.server.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.server.gradle.kts
@@ -8,4 +8,3 @@ plugins {
 val maven = publishing.publications.create<MavenPublication>("maven") { from(components["java"]) }
 
 signing.sign(maven)
-

--- a/buildSrc/src/main/kotlin/com.hedera.block.server.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.server.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.conventions")

--- a/buildSrc/src/main/kotlin/com.hedera.block.simulator.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.simulator.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.conventions")

--- a/buildSrc/src/main/kotlin/com.hedera.block.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.spotless-conventions.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {
@@ -42,21 +27,7 @@ spotless {
 
         licenseHeader(
             """
-            ##
-            # Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            #
-            # Licensed under the Apache License, Version 2.0 (the "License");
-            # you may not use this file except in compliance with the License.
-            # You may obtain a copy of the License at
-            #
-            #      http://www.apache.org/licenses/LICENSE-2.0
-            #
-            # Unless required by applicable law or agreed to in writing, software
-            # distributed under the License is distributed on an "AS IS" BASIS,
-            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            # See the License for the specific language governing permissions and
-            # limitations under the License.
-            ##
+            # SPDX-License-Identifier: Apache-2.0
         """
                 .trimIndent(),
             "(name|on)"

--- a/buildSrc/src/main/kotlin/com.hedera.block.spotless-java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.spotless-java-conventions.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {
@@ -31,28 +16,12 @@ spotless {
         indentWithSpaces(4)
         trimTrailingWhitespace()
         endWithNewline()
-        // make sure every file has the following copyright header.
-        // optionally, Spotless can set copyright years by digging
-        // through git history (see "license" section below).
+        // make sure every file has the following SPDX header.
         // The delimiter override below is required to support some
         // of our test classes which are in the default package.
         licenseHeader(
             """
-           /*
-            * Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */${"\n\n"}
+           // SPDX-License-Identifier: Apache-2.0
         """
                 .trimIndent(),
             "(package|import)"

--- a/buildSrc/src/main/kotlin/com.hedera.block.spotless-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.spotless-kotlin-conventions.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins { id("com.diffplug.spotless") }
 
 spotless {
@@ -22,21 +7,7 @@ spotless {
 
         licenseHeader(
             """
-           /*
-            * Copyright (C) ${'$'}YEAR Hedera Hashgraph, LLC
-            *
-            * Licensed under the Apache License, Version 2.0 (the "License");
-            * you may not use this file except in compliance with the License.
-            * You may obtain a copy of the License at
-            *
-            *      http://www.apache.org/licenses/LICENSE-2.0
-            *
-            * Unless required by applicable law or agreed to in writing, software
-            * distributed under the License is distributed on an "AS IS" BASIS,
-            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            * See the License for the specific language governing permissions and
-            * limitations under the License.
-            */${"\n\n"}
+            // SPDX-License-Identifier: Apache-2.0
             """
                 .trimIndent(),
             "(import|plugins|repositories)",

--- a/buildSrc/src/main/kotlin/com.hedera.block.suites.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.suites.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.conventions")

--- a/buildSrc/src/main/kotlin/com.hedera.block.tools.gradle.kts
+++ b/buildSrc/src/main/kotlin/com.hedera.block.tools.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.conventions")

--- a/buildSrc/src/main/kotlin/com/hedera/block/tasks/GitClone.kt
+++ b/buildSrc/src/main/kotlin/com/hedera/block/tasks/GitClone.kt
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tasks
 
 import javax.inject.Inject

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("java-library")
     id("com.hedera.block.common")

--- a/common/src/main/java/com/hedera/block/common/constants/StringsConstants.java
+++ b/common/src/main/java/com/hedera/block/common/constants/StringsConstants.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.constants;
 
 /** A class that hold common String literals used across projects. */

--- a/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
+++ b/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
@@ -19,8 +19,7 @@ public final class ChunkUtils {
      * @param <T> the type of the collection
      * @return a list of lists of the specified size
      *  */
-    public static <T> List<List<T>> chunkify(
-            @NonNull final Collection<T> dataToSplit, final int chunkSize) {
+    public static <T> List<List<T>> chunkify(@NonNull final Collection<T> dataToSplit, final int chunkSize) {
         Objects.requireNonNull(dataToSplit);
         if (chunkSize <= 0) {
             throw new IllegalArgumentException("Chunk size must be greater than 0");

--- a/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
+++ b/common/src/main/java/com/hedera/block/common/utils/ChunkUtils.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/common/src/main/java/com/hedera/block/common/utils/FileUtilities.java
+++ b/common/src/main/java/com/hedera/block/common/utils/FileUtilities.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/common/src/main/java/com/hedera/block/common/utils/MathUtilities.java
+++ b/common/src/main/java/com/hedera/block/common/utils/MathUtilities.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 /**

--- a/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
+++ b/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/common/src/main/java/com/hedera/block/common/utils/StringUtilities.java
+++ b/common/src/main/java/com/hedera/block/common/utils/StringUtilities.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import java.util.Objects;

--- a/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
+++ b/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common;
 
 import java.util.stream.Stream;

--- a/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
@@ -22,16 +22,14 @@ public class ChunkUtilsTest {
     @Test
     public void testChunkSizeZero() {
         List<Integer> list = Arrays.asList(1, 2, 3);
-        Exception exception =
-                assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, 0));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, 0));
         assertEquals("Chunk size must be greater than 0", exception.getMessage());
     }
 
     @Test
     public void testChunkSizeNegative() {
         List<Integer> list = Arrays.asList(1, 2, 3);
-        Exception exception =
-                assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, -1));
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> ChunkUtils.chunkify(list, -1));
         assertEquals("Chunk size must be greater than 0", exception.getMessage());
     }
 

--- a/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/ChunkUtilsTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/common/src/test/java/com/hedera/block/common/utils/FileUtilitiesTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/FileUtilitiesTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/common/src/test/java/com/hedera/block/common/utils/MathUtilitiesTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/MathUtilitiesTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/common/src/test/java/com/hedera/block/common/utils/StringUtilitiesTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/StringUtilitiesTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.server")

--- a/server/src/main/java/com/hedera/block/server/BlockNodeApp.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeApp.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import static com.hedera.block.server.Constants.PBJ_PROTOCOL_PROVIDER_CONFIG_NAME;

--- a/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionComponent.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionComponent.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import com.hedera.block.server.config.ConfigInjectionModule;

--- a/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/BlockNodeAppInjectionModule.java
@@ -25,8 +25,7 @@ public interface BlockNodeAppInjectionModule {
      */
     @Singleton
     @Provides
-    static BlockNodeContext provideBlockNodeContext(
-            Configuration config, MetricsService metricsService) {
+    static BlockNodeContext provideBlockNodeContext(Configuration config, MetricsService metricsService) {
         return new BlockNodeContext(metricsService, config);
     }
 

--- a/server/src/main/java/com/hedera/block/server/Constants.java
+++ b/server/src/main/java/com/hedera/block/server/Constants.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 /** Constants used in the BlockNode service. */

--- a/server/src/main/java/com/hedera/block/server/Server.java
+++ b/server/src/main/java/com/hedera/block/server/Server.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import static com.hedera.block.common.constants.StringsConstants.APPLICATION_PROPERTIES;

--- a/server/src/main/java/com/hedera/block/server/ServerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/ServerConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import com.swirlds.config.api.ConfigData;

--- a/server/src/main/java/com/hedera/block/server/config/BlockNodeConfigExtension.java
+++ b/server/src/main/java/com/hedera/block/server/config/BlockNodeConfigExtension.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import com.google.auto.service.AutoService;

--- a/server/src/main/java/com/hedera/block/server/config/BlockNodeContext.java
+++ b/server/src/main/java/com/hedera/block/server/config/BlockNodeContext.java
@@ -12,5 +12,4 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * @param metricsService the service responsible for handling metrics
  * @param configuration the configuration settings for the block node
  */
-public record BlockNodeContext(
-        @NonNull MetricsService metricsService, @NonNull Configuration configuration) {}
+public record BlockNodeContext(@NonNull MetricsService metricsService, @NonNull Configuration configuration) {}

--- a/server/src/main/java/com/hedera/block/server/config/BlockNodeContext.java
+++ b/server/src/main/java/com/hedera/block/server/config/BlockNodeContext.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import com.hedera.block.server.metrics.MetricsService;

--- a/server/src/main/java/com/hedera/block/server/config/ConfigInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/config/ConfigInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import com.hedera.block.server.ServerConfig;

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import com.swirlds.config.extensions.sources.ConfigMapping;

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
@@ -25,7 +25,6 @@ public record ConsumerConfig(@ConfigProperty(defaultValue = "1500") long timeout
         }
 
         LOGGER.log(
-                System.Logger.Level.INFO,
-                "Consumer configuration timeoutThresholdMillis: " + timeoutThresholdMillis);
+                System.Logger.Level.INFO, "Consumer configuration timeoutThresholdMillis: " + timeoutThresholdMillis);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
 import com.swirlds.config.api.ConfigData;

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
 import static java.lang.System.Logger;

--- a/server/src/main/java/com/hedera/block/server/events/BlockNodeEventHandler.java
+++ b/server/src/main/java/com/hedera/block/server/events/BlockNodeEventHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.events;
 
 import com.lmax.disruptor.EventHandler;

--- a/server/src/main/java/com/hedera/block/server/events/LivenessCalculator.java
+++ b/server/src/main/java/com/hedera/block/server/events/LivenessCalculator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.events;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/events/LivenessCalculator.java
+++ b/server/src/main/java/com/hedera/block/server/events/LivenessCalculator.java
@@ -20,8 +20,7 @@ public final class LivenessCalculator {
      * @param clock the clock to use for time calculations
      * @param timeoutThresholdMillis the timeout threshold in milliseconds
      */
-    public LivenessCalculator(
-            @NonNull final InstantSource clock, final long timeoutThresholdMillis) {
+    public LivenessCalculator(@NonNull final InstantSource clock, final long timeoutThresholdMillis) {
 
         this.clock = clock;
         this.timeoutThresholdMillis = timeoutThresholdMillis;

--- a/server/src/main/java/com/hedera/block/server/events/ObjectEvent.java
+++ b/server/src/main/java/com/hedera/block/server/events/ObjectEvent.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.events;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/exception/BlockStreamProtocolException.java
+++ b/server/src/main/java/com/hedera/block/server/exception/BlockStreamProtocolException.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.exception;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/health/HealthInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/health/HealthInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.health;
 
 import dagger.Binds;

--- a/server/src/main/java/com/hedera/block/server/health/HealthService.java
+++ b/server/src/main/java/com/hedera/block/server/health/HealthService.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.health;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/health/HealthServiceImpl.java
+++ b/server/src/main/java/com/hedera/block/server/health/HealthServiceImpl.java
@@ -51,8 +51,7 @@ public class HealthServiceImpl implements HealthService {
      * @param res the server response
      */
     @Override
-    public final void handleLivez(
-            @NonNull final ServerRequest req, @NonNull final ServerResponse res) {
+    public final void handleLivez(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         if (serviceStatus.isRunning()) {
             res.status(200).send("OK");
         } else {
@@ -68,8 +67,7 @@ public class HealthServiceImpl implements HealthService {
      * @param res the server response
      */
     @Override
-    public final void handleReadyz(
-            @NonNull final ServerRequest req, @NonNull final ServerResponse res) {
+    public final void handleReadyz(@NonNull final ServerRequest req, @NonNull final ServerResponse res) {
         if (serviceStatus.isRunning()) {
             res.status(200).send("OK");
         } else {

--- a/server/src/main/java/com/hedera/block/server/health/HealthServiceImpl.java
+++ b/server/src/main/java/com/hedera/block/server/health/HealthServiceImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.health;
 
 import com.hedera.block.server.service.ServiceStatus;

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.notifier.Notifiable;

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorBuilder.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItems;

--- a/server/src/main/java/com/hedera/block/server/mediator/MediatorConfig.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/MediatorConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static java.lang.System.Logger.Level.INFO;

--- a/server/src/main/java/com/hedera/block/server/mediator/MediatorInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/MediatorInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/main/java/com/hedera/block/server/mediator/NoOpLiveStreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/NoOpLiveStreamMediator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItems;

--- a/server/src/main/java/com/hedera/block/server/mediator/Publisher.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/Publisher.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/mediator/StreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/StreamMediator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/mediator/SubscriptionHandler.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/SubscriptionHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.events.BlockNodeEventHandler;

--- a/server/src/main/java/com/hedera/block/server/mediator/SubscriptionHandlerBase.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/SubscriptionHandlerBase.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.events.BlockNodeEventHandler;

--- a/server/src/main/java/com/hedera/block/server/metrics/BlockNodeMetricTypes.java
+++ b/server/src/main/java/com/hedera/block/server/metrics/BlockNodeMetricTypes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/metrics/MetricsInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/metrics/MetricsInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import com.swirlds.common.metrics.platform.DefaultMetricsProvider;

--- a/server/src/main/java/com/hedera/block/server/metrics/MetricsService.java
+++ b/server/src/main/java/com/hedera/block/server/metrics/MetricsService.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import com.swirlds.metrics.api.Counter;

--- a/server/src/main/java/com/hedera/block/server/metrics/MetricsServiceImpl.java
+++ b/server/src/main/java/com/hedera/block/server/metrics/MetricsServiceImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import com.swirlds.metrics.api.Counter;

--- a/server/src/main/java/com/hedera/block/server/notifier/Notifiable.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/Notifiable.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 /** Use this interface contract to notify the implementation of critical system events. */

--- a/server/src/main/java/com/hedera/block/server/notifier/Notifier.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/Notifier.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import com.hedera.block.server.mediator.StreamMediator;

--- a/server/src/main/java/com/hedera/block/server/notifier/NotifierConfig.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/NotifierConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import static java.lang.System.Logger.Level.INFO;

--- a/server/src/main/java/com/hedera/block/server/notifier/NotifierImpl.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/NotifierImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SuccessfulPubStreamResp;

--- a/server/src/main/java/com/hedera/block/server/notifier/NotifierInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/notifier/NotifierInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import dagger.Binds;

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjBlockAccessService.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjBlockAccessService.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static com.hedera.block.server.Constants.FULL_SERVICE_NAME_BLOCK_ACCESS;

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjBlockAccessServiceProxy.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjBlockAccessServiceProxy.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.SingleBlocksNotFound;

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamService.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamService.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static com.hedera.block.server.Constants.FULL_SERVICE_NAME_BLOCK_STREAM;

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamServiceProxy.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamServiceProxy.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static java.lang.System.Logger.Level.DEBUG;

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import dagger.Binds;

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.StreamPersistenceHandlerError;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage;
 
 import static com.hedera.block.server.Constants.BLOCK_NODE_ARCHIVE_ROOT_DIRECTORY_SEMANTIC_NAME;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/Compression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/Compression.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/NoOpCompression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/NoOpCompression.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/ZstdCompression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/ZstdCompression.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
 import com.github.luben.zstd.ZstdOutputStream;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import com.hedera.block.common.utils.Preconditions;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import com.hedera.block.common.utils.Preconditions;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalDirReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalDirReader.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import static com.hedera.block.server.Constants.BLOCK_FILE_EXTENSION;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import com.hedera.block.common.utils.Preconditions;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockReader.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import com.hedera.pbj.runtime.ParseException;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/LocalBlockReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/LocalBlockReader.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/NoOpBlockReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/NoOpBlockReader.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import com.hedera.hapi.block.BlockUnparsed;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalDirRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalDirRemover.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import static java.lang.System.Logger;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemover.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import com.hedera.block.common.utils.Preconditions;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/BlockRemover.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import java.io.IOException;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/LocalBlockRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/LocalBlockRemover.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemover.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemover.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalDirWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalDirWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import static com.hedera.block.server.Constants.BLOCK_FILE_EXTENSION;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.BlocksPersisted;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/BlockWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import com.hedera.pbj.runtime.ParseException;

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/LocalBlockWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/LocalBlockWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 /**

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/write/NoOpBlockWriter.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/write/NoOpBlockWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import com.hedera.hapi.block.BlockItemUnparsed;

--- a/server/src/main/java/com/hedera/block/server/producer/NoOpProducerObserver.java
+++ b/server/src/main/java/com/hedera/block/server/producer/NoOpProducerObserver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.producer;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItemsReceived;

--- a/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
+++ b/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.producer;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItemsReceived;

--- a/server/src/main/java/com/hedera/block/server/producer/ProducerConfig.java
+++ b/server/src/main/java/com/hedera/block/server/producer/ProducerConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.producer;
 
 import static java.lang.System.Logger.Level.INFO;

--- a/server/src/main/java/com/hedera/block/server/producer/Util.java
+++ b/server/src/main/java/com/hedera/block/server/producer/Util.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.producer;
 
 import com.hedera.hapi.block.BlockItemUnparsed;

--- a/server/src/main/java/com/hedera/block/server/service/ServiceConfig.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceConfig.java
@@ -25,8 +25,6 @@ public record ServiceConfig(@ConfigProperty(defaultValue = "500") int delayMilli
             throw new IllegalArgumentException("Delay milliseconds must be greater than 0");
         }
 
-        LOGGER.log(
-                System.Logger.Level.INFO,
-                "Service configuration service.delayMillis: " + delayMillis);
+        LOGGER.log(System.Logger.Level.INFO, "Service configuration service.delayMillis: " + delayMillis);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/service/ServiceConfig.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.service;
 
 import com.swirlds.config.api.ConfigData;

--- a/server/src/main/java/com/hedera/block/server/service/ServiceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.service;
 
 import dagger.Binds;

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatus.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.service;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.service;
 
 import static java.lang.System.Logger.Level.DEBUG;

--- a/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
+++ b/server/src/main/java/com/hedera/block/server/service/ServiceStatusImpl.java
@@ -33,8 +33,10 @@ public class ServiceStatusImpl implements ServiceStatus {
      */
     @Inject
     public ServiceStatusImpl(@NonNull final BlockNodeContext blockNodeContext) {
-        this.delayMillis =
-                blockNodeContext.configuration().getConfigData(ServiceConfig.class).delayMillis();
+        this.delayMillis = blockNodeContext
+                .configuration()
+                .getConfigData(ServiceConfig.class)
+                .delayMillis();
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppInjectionModuleTest.java
@@ -21,11 +21,14 @@ import org.mockito.Mock;
 
 class BlockNodeAppInjectionModuleTest {
 
-    @Mock private StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> streamMediator;
+    @Mock
+    private StreamMediator<BlockItem, ObjectEvent<SubscribeStreamResponse>> streamMediator;
 
-    @Mock private BlockReader<Block> blockReader;
+    @Mock
+    private BlockReader<Block> blockReader;
 
-    @Mock private ServiceStatus serviceStatus;
+    @Mock
+    private ServiceStatus serviceStatus;
 
     private BlockNodeContext blockNodeContext;
 
@@ -43,16 +46,13 @@ class BlockNodeAppInjectionModuleTest {
                 BlockNodeAppInjectionModule.provideBlockNodeContext(configuration, metricsService);
 
         Assertions.assertEquals(blockNodeContext, providedBlockNodeContext);
-        Assertions.assertEquals(
-                blockNodeContext.configuration(), providedBlockNodeContext.configuration());
-        Assertions.assertEquals(
-                blockNodeContext.metricsService(), providedBlockNodeContext.metricsService());
+        Assertions.assertEquals(blockNodeContext.configuration(), providedBlockNodeContext.configuration());
+        Assertions.assertEquals(blockNodeContext.metricsService(), providedBlockNodeContext.metricsService());
     }
 
     @Test
     void testProvideWebServerConfigBuilder() {
-        WebServerConfig.Builder webServerConfigBuilder =
-                BlockNodeAppInjectionModule.provideWebServerConfigBuilder();
+        WebServerConfig.Builder webServerConfigBuilder = BlockNodeAppInjectionModule.provideWebServerConfigBuilder();
 
         Assertions.assertNotNull(webServerConfigBuilder);
     }

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import static org.mockito.Mockito.any;

--- a/server/src/test/java/com/hedera/block/server/ServerConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/ServerConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/server/src/test/java/com/hedera/block/server/config/BlockNodeContextTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/BlockNodeContextTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/server/src/test/java/com/hedera/block/server/config/ConfigInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ConfigInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
+++ b/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
@@ -75,8 +75,7 @@ public class TestConfigBuilder {
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(
-            @NonNull final String propertyName, @Nullable final String value) {
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -136,8 +135,7 @@ public class TestConfigBuilder {
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(
-            @NonNull final String propertyName, @NonNull final Object value) {
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
         Objects.requireNonNull(value, "value must not be null");
         return withSource(new SimpleConfigSource(propertyName, value.toString()));
     }

--- a/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
+++ b/server/src/test/java/com/hedera/block/server/config/TestConfigBuilder.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.config;
 
 import com.swirlds.common.config.singleton.ConfigurationHolder;

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerConfigTest.java
@@ -16,8 +16,7 @@ public class ConsumerConfigTest {
 
     @Test
     public void testConsumerConfig_negativeTimeoutThresholdMillis() {
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new ConsumerConfig(-1));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new ConsumerConfig(-1));
         assertEquals("Timeout threshold must be greater than 0", exception.getMessage());
     }
 }

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/grpc/BlockAccessServiceTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.grpc;
 
 import static com.hedera.block.server.Constants.FULL_SERVICE_NAME_BLOCK_ACCESS;

--- a/server/src/test/java/com/hedera/block/server/health/HealthServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/health/HealthServiceTest.java
@@ -20,11 +20,14 @@ class HealthServiceTest {
     private static final String LIVENESS_PATH = "/livez";
     private static final String HEALTH_PATH = "/healthz";
 
-    @Mock private ServiceStatus serviceStatus;
+    @Mock
+    private ServiceStatus serviceStatus;
 
-    @Mock ServerRequest serverRequest;
+    @Mock
+    ServerRequest serverRequest;
 
-    @Mock ServerResponse serverResponse;
+    @Mock
+    ServerResponse serverResponse;
 
     @Test
     public void testHandleLivez() {

--- a/server/src/test/java/com/hedera/block/server/health/HealthServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/health/HealthServiceTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.health;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.LiveBlockItems;

--- a/server/src/test/java/com/hedera/block/server/mediator/MediatorConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/MediatorConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.mediator;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/server/src/test/java/com/hedera/block/server/metrics/MetricsInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/metrics/MetricsInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/server/src/test/java/com/hedera/block/server/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/metrics/MetricsServiceTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.metrics;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.BlocksPersisted;

--- a/server/src/test/java/com/hedera/block/server/metrics/MetricsServiceTest.java
+++ b/server/src/test/java/com/hedera/block/server/metrics/MetricsServiceTest.java
@@ -39,8 +39,7 @@ public class MetricsServiceTest {
         final BlockNodeContext context = TestConfigUtil.getTestBlockNodeContext();
         final Configuration configuration = context.configuration();
         final MetricsServiceTestComponent testComponent =
-                DaggerMetricsServiceTest_MetricsServiceTestComponent.factory()
-                        .create(configuration);
+                DaggerMetricsServiceTest_MetricsServiceTestComponent.factory().create(configuration);
         this.metricsService = testComponent.getMetricsService();
     }
 
@@ -51,7 +50,9 @@ public class MetricsServiceTest {
             metricsService.get(LiveBlockItems).increment();
         }
 
-        assertEquals(LiveBlockItems.grafanaLabel(), metricsService.get(LiveBlockItems).getName());
+        assertEquals(
+                LiveBlockItems.grafanaLabel(),
+                metricsService.get(LiveBlockItems).getName());
         assertEquals(
                 LiveBlockItems.description(), metricsService.get(LiveBlockItems).getDescription());
         assertEquals(10, metricsService.get(LiveBlockItems).get());
@@ -64,7 +65,9 @@ public class MetricsServiceTest {
             metricsService.get(BlocksPersisted).increment();
         }
 
-        assertEquals(BlocksPersisted.grafanaLabel(), metricsService.get(BlocksPersisted).getName());
+        assertEquals(
+                BlocksPersisted.grafanaLabel(),
+                metricsService.get(BlocksPersisted).getName());
         assertEquals(
                 BlocksPersisted.description(),
                 metricsService.get(BlocksPersisted).getDescription());

--- a/server/src/test/java/com/hedera/block/server/notifier/NotifierConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/notifier/NotifierConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.notifier;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Gauge.Producers;

--- a/server/src/test/java/com/hedera/block/server/pbj/PbjBlockAccessServiceProxyTest.java
+++ b/server/src/test/java/com/hedera/block/server/pbj/PbjBlockAccessServiceProxyTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.pbj;
 
 import static com.hedera.block.server.util.PbjProtoTestUtils.buildAck;

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.StreamPersistenceHandlerError;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/compression/NoOpCompressionTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/compression/NoOpCompressionTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/compression/ZstdCompressionTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/compression/ZstdCompressionTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_COMPRESSION_LEVEL;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalFilePathResolverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.path;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalDirReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalDirReaderTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import static com.hedera.block.server.Constants.BLOCK_FILE_EXTENSION;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/NoOpBlockReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/NoOpBlockReaderTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.read;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalDirRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalDirRemoverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/BlockAsLocalFileRemoverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemoverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/remove/NoOpBlockRemoverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.remove;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalDirWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalDirWriterTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import static com.hedera.block.server.persistence.storage.read.BlockAsLocalDirReaderTest.removeBlockReadPerms;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriterTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import static com.hedera.block.server.util.PersistTestUtils.PERSISTENCE_STORAGE_LIVE_ROOT_PATH_KEY;

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/NoOpBlockWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/NoOpBlockWriterTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.write;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.producer;
 
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItemsUnparsed;

--- a/server/src/test/java/com/hedera/block/server/service/ServiceConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/service/ServiceConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/server/src/test/java/com/hedera/block/server/service/ServiceConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/service/ServiceConfigTest.java
@@ -15,8 +15,7 @@ public class ServiceConfigTest {
 
     @Test
     public void testServiceConfig_negativeDelayMillis() {
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new ServiceConfig(-1));
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> new ServiceConfig(-1));
         assertEquals("Delay milliseconds must be greater than 0", exception.getMessage());
     }
 }

--- a/server/src/test/java/com/hedera/block/server/util/PbjProtoTestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/PbjProtoTestUtils.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.util;
 
 import static com.hedera.block.server.producer.Util.getFakeHash;

--- a/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/PersistTestUtils.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.util;
 
 import static java.lang.System.Logger;

--- a/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestConfigUtil.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.util;
 
 import com.hedera.block.server.config.BlockNodeContext;

--- a/server/src/test/java/com/hedera/block/server/util/TestUtils.java
+++ b/server/src/test/java/com/hedera/block/server/util/TestUtils.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.util;
 
 import java.io.File;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("com.gradle.enterprise").version("3.15.1")
 }

--- a/simulator/build.gradle.kts
+++ b/simulator/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.simulator")

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulator.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 import static com.hedera.block.common.constants.StringsConstants.APPLICATION_PROPERTIES;

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorApp.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 import static com.hedera.block.common.constants.StringsConstants.LOGGING_PROPERTIES;

--- a/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/BlockStreamSimulatorInjectionComponent.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.ConfigInjectionModule;

--- a/simulator/src/main/java/com/hedera/block/simulator/Constants.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/Constants.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 /** The Constants class defines the constants for the block simulator. */

--- a/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/ConfigInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorConfigExtension.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import com.google.auto.service.AutoService;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializer.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import com.swirlds.config.extensions.sources.ConfigMapping;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockGeneratorConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import com.hedera.block.simulator.config.types.GenerationMode;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/BlockStreamConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import com.hedera.block.simulator.config.types.SimulatorMode;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/GrpcConfig.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/GrpcConfig.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import com.swirlds.config.api.ConfigData;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/data/StreamStatus.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import static com.hedera.block.common.utils.Preconditions.requireWhole;

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/GenerationMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/GenerationMode.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.types;
 
 /** The GenerationMode enum defines the modes of generation for the block stream. */

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/SimulatorMode.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.types;
 
 /** The SimulatorMode enum defines the work modes of the block stream simulator. */

--- a/simulator/src/main/java/com/hedera/block/simulator/config/types/StreamingMode.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/config/types/StreamingMode.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.types;
 
 /** The StreamingMode enum defines the different modes for streaming blocks. */

--- a/simulator/src/main/java/com/hedera/block/simulator/exception/BlockSimulatorParsingException.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/exception/BlockSimulatorParsingException.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.exception;
 
 /** Use this checked exception to represent a Block Simulator parsing exception. */

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManager.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static com.hedera.block.simulator.Constants.GZ_EXTENSION;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManager.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static com.hedera.block.simulator.Constants.GZ_EXTENSION;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSets.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static com.hedera.block.simulator.Constants.GZ_EXTENSION;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/BlockStreamManager.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import com.hedera.block.simulator.config.types.GenerationMode;

--- a/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/generator/GeneratorInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import com.hedera.block.simulator.config.data.BlockGeneratorConfig;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/ConsumerStreamGrpcClient.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc;
 
 import java.util.List;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/GrpcInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc;
 
 import com.hedera.block.simulator.grpc.impl.ConsumerStreamGrpcClientImpl;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/PublishStreamGrpcClient.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc;
 
 import com.hedera.hapi.block.stream.protoc.Block;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksConsumed;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlocksConsumed;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.metrics.SimulatorMetricTypes.Counter.LiveBlockItemsSent;

--- a/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserver.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static java.lang.System.Logger.Level.ERROR;

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsInjectionModule.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsInjectionModule.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import com.swirlds.common.metrics.platform.DefaultMetricsProvider;

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsService.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsService.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import com.swirlds.metrics.api.Counter;

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsServiceImpl.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/MetricsServiceImpl.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import com.swirlds.metrics.api.Counter;

--- a/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/metrics/SimulatorMetricTypes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/CombinedModeHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import com.hedera.block.simulator.config.data.BlockStreamConfig;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/ConsumerModeHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import static java.lang.System.Logger.Level.INFO;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/PublisherModeHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import static com.hedera.block.simulator.Constants.NANOS_PER_MILLI;

--- a/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
+++ b/simulator/src/main/java/com/hedera/block/simulator/mode/SimulatorModeHandler.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import com.hedera.block.simulator.exception.BlockSimulatorParsingException;

--- a/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/BlockStreamSimulatorTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;

--- a/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/TestUtils.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator;
 
 import com.hedera.block.simulator.config.TestConfigBuilder;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/ConfigInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/SimulatorMappedConfigSourceInitializerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/TestConfigBuilder.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/TestConfigBuilder.java
@@ -75,8 +75,7 @@ public class TestConfigBuilder {
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(
-            @NonNull final String propertyName, @Nullable final String value) {
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @Nullable final String value) {
         return withSource(new SimpleConfigSource(propertyName, value));
     }
 
@@ -136,8 +135,7 @@ public class TestConfigBuilder {
      * @return the {@link TestConfigBuilder} instance (for fluent API)
      */
     @NonNull
-    public TestConfigBuilder withValue(
-            @NonNull final String propertyName, @NonNull final Object value) {
+    public TestConfigBuilder withValue(@NonNull final String propertyName, @NonNull final Object value) {
         Objects.requireNonNull(value, "value must not be null");
         return withSource(new SimpleConfigSource(propertyName, value.toString()));
     }

--- a/simulator/src/test/java/com/hedera/block/simulator/config/TestConfigBuilder.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/TestConfigBuilder.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config;
 
 import com.swirlds.common.config.singleton.ConfigurationHolder;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/BlockStreamConfigTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/data/StreamStatusTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.data;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/types/GenerationModeTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/types/GenerationModeTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.types;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/simulator/src/test/java/com/hedera/block/simulator/config/types/StreamingModeTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/config/types/StreamingModeTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.config.types;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsDirBlockStreamManagerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileBlockStreamManagerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/BlockAsFileLargeDataSetsTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.generator;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/generator/GeneratorInjectionModuleTest.java
@@ -14,47 +14,36 @@ class GeneratorInjectionModuleTest {
     @Test
     void providesBlockStreamManager_AsFileLargeDataSets() throws IOException {
 
-        BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration(
-                                Map.of(
-                                        "generator.managerImplementation",
-                                        "BlockAsFileLargeDataSets"))
-                        .getConfigData(BlockGeneratorConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
+                        Map.of("generator.managerImplementation", "BlockAsFileLargeDataSets"))
+                .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
-        assertEquals(
-                blockStreamManager.getClass().getName(), BlockAsFileLargeDataSets.class.getName());
+        assertEquals(blockStreamManager.getClass().getName(), BlockAsFileLargeDataSets.class.getName());
     }
 
     @Test
     void providesBlockStreamManager_AsFile() throws IOException {
-        BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration(
-                                Map.of(
-                                        "generator.managerImplementation",
-                                        "BlockAsFileBlockStreamManager",
-                                        "generator.folderRootPath",
-                                        ""))
-                        .getConfigData(BlockGeneratorConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(Map.of(
+                        "generator.managerImplementation",
+                        "BlockAsFileBlockStreamManager",
+                        "generator.folderRootPath",
+                        ""))
+                .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
-        assertEquals(
-                blockStreamManager.getClass().getName(),
-                BlockAsFileBlockStreamManager.class.getName());
+        assertEquals(blockStreamManager.getClass().getName(), BlockAsFileBlockStreamManager.class.getName());
     }
 
     @Test
     void providesBlockStreamManager_AsDir() throws IOException {
-        BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration(
-                                Map.of(
-                                        "generator.managerImplementation",
-                                        "BlockAsDirBlockStreamManager"))
-                        .getConfigData(BlockGeneratorConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
+                        Map.of("generator.managerImplementation", "BlockAsDirBlockStreamManager"))
+                .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
@@ -66,20 +55,13 @@ class GeneratorInjectionModuleTest {
 
     @Test
     void providesBlockStreamManager_default() throws IOException {
-        BlockGeneratorConfig blockGeneratorConfig =
-                TestUtils.getTestConfiguration(
-                                Map.of(
-                                        "generator.managerImplementation",
-                                        "",
-                                        "generator.folderRootPath",
-                                        ""))
-                        .getConfigData(BlockGeneratorConfig.class);
+        BlockGeneratorConfig blockGeneratorConfig = TestUtils.getTestConfiguration(
+                        Map.of("generator.managerImplementation", "", "generator.folderRootPath", ""))
+                .getConfigData(BlockGeneratorConfig.class);
 
         BlockStreamManager blockStreamManager =
                 GeneratorInjectionModule.providesBlockStreamManager(blockGeneratorConfig);
 
-        assertEquals(
-                blockStreamManager.getClass().getName(),
-                BlockAsFileBlockStreamManager.class.getName());
+        assertEquals(blockStreamManager.getClass().getName(), BlockAsFileBlockStreamManager.class.getName());
     }
 }

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamGrpcClientImplTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.TestUtils.findFreePort;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/ConsumerStreamObserverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamGrpcClientImplTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static com.hedera.block.simulator.TestUtils.findFreePort;

--- a/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/grpc/impl/PublishStreamObserverTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.grpc.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsInjectionModuleTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsInjectionModuleTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/metrics/MetricsServiceTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.metrics;
 
 import static com.hedera.block.simulator.TestUtils.getTestMetrics;

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/CombinedModeHandlerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/ConsumerModeHandlerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
+++ b/simulator/src/test/java/com/hedera/block/simulator/mode/PublisherModeHandlerTest.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.simulator.mode;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("com.hedera.block.protobuf")
     alias(libs.plugins.pbj)

--- a/suites/build.gradle.kts
+++ b/suites/build.gradle.kts
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 plugins {
     id("application")
     id("com.hedera.block.suites")

--- a/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
+++ b/suites/src/main/java/com/hedera/block/suites/BaseSuite.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites;
 
 import com.hedera.block.simulator.BlockStreamSimulatorApp;

--- a/suites/src/main/java/com/hedera/block/suites/ErrorLoggingExecutor.java
+++ b/suites/src/main/java/com/hedera/block/suites/ErrorLoggingExecutor.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites;
 
 import static java.lang.System.Logger.Level.ERROR;

--- a/suites/src/main/java/com/hedera/block/suites/grpc/GrpcTestSuites.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/GrpcTestSuites.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.grpc;
 
 import com.hedera.block.suites.grpc.negative.NegativeServerAvailabilityTests;

--- a/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/negative/NegativeServerAvailabilityTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.grpc.negative;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveEndpointBehaviourTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.grpc.positive;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/grpc/positive/PositiveServerAvailabilityTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.grpc.positive;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/suites/src/main/java/com/hedera/block/suites/persistence/DataPersistenceTestSuites.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/DataPersistenceTestSuites.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.persistence;
 
 import com.hedera.block.suites.persistence.positive.PositiveDataPersistenceTests;

--- a/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
+++ b/suites/src/main/java/com/hedera/block/suites/persistence/positive/PositiveDataPersistenceTests.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.suites.persistence.positive;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/tool.sh
+++ b/tool.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
 # run gradle jar build and send output to /dev/null
 ./gradlew -q tool:shadowJar > /dev/null
 # check if last command failed and exit if so

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -1,38 +1,7 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 import com.github.jengelman.gradle.plugins.shadow.internal.DefaultDependencyFilter
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.gradlex.javamodule.dependencies.tasks.ModuleDirectivesScopeCheck
-
-/*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 plugins {
     id("application")

--- a/tools/src/main/java/com/hedera/block/tools/BlockStreamTool.java
+++ b/tools/src/main/java/com/hedera/block/tools/BlockStreamTool.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools;
 
 import com.hedera.block.tools.commands.BlockInfo;

--- a/tools/src/main/java/com/hedera/block/tools/commands/BlockInfo.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/BlockInfo.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands;
 
 import com.hedera.hapi.block.stream.Block;

--- a/tools/src/main/java/com/hedera/block/tools/commands/ConvertToJson.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/ConvertToJson.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands;
 
 import com.hedera.hapi.block.stream.Block;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/Record2BlockCommand.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/Record2BlockCommand.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks;
 
 import static com.hedera.block.tools.commands.record2blocks.mirrornode.FetchBlockQuery.getPreviousHashForBlock;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/gcp/AddNewerBlockTimes.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/gcp/AddNewerBlockTimes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.gcp;
 
 import static com.hedera.block.tools.commands.record2blocks.util.RecordFileDates.blockTimeLongToInstant;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/gcp/MainNetBucket.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/gcp/MainNetBucket.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.gcp;
 
 import com.google.cloud.storage.BlobInfo;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/ExtractBlockTimes.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/ExtractBlockTimes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.mirrornode;
 
 import static com.hedera.block.tools.commands.record2blocks.util.RecordFileDates.recordFileNameToBlockTimeLong;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/FetchBlockQuery.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/FetchBlockQuery.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.mirrornode;
 
 import com.google.gson.Gson;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/FetchMirrorNodeRecordsCsv.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/FetchMirrorNodeRecordsCsv.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.mirrornode;
 
 import com.google.auth.oauth2.GoogleCredentials;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/ValidateBlockTimes.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/mirrornode/ValidateBlockTimes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.mirrornode;
 
 import static com.hedera.block.tools.commands.record2blocks.util.RecordFileDates.blockTimeLongToRecordFilePrefix;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/BlockInfo.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/BlockInfo.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import com.hedera.block.tools.commands.record2blocks.model.ChainFile.Kind;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/BlockTimes.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/BlockTimes.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import java.nio.ByteBuffer;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ChainFile.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ChainFile.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import static com.hedera.block.tools.commands.record2blocks.util.RecordFileDates.blockTimeInstantToLong;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ChainFileAndCount.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ChainFileAndCount.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 /**

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/NumberedSidecarFile.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/NumberedSidecarFile.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import java.util.List;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ParsedSignatureFile.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/ParsedSignatureFile.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import com.hedera.block.tools.commands.record2blocks.gcp.MainNetBucket;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/RecordFileInfo.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/model/RecordFileInfo.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.model;
 
 import static com.hedera.block.tools.commands.record2blocks.model.ParsedSignatureFile.HASH_OBJECT_SIZE_BYTES;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/util/BlockWriter.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/util/BlockWriter.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.util;
 
 import com.github.luben.zstd.ZstdOutputStream;

--- a/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/util/RecordFileDates.java
+++ b/tools/src/main/java/com/hedera/block/tools/commands/record2blocks/util/RecordFileDates.java
@@ -1,19 +1,4 @@
-/*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.tools.commands.record2blocks.util;
 
 import java.time.Duration;


### PR DESCRIPTION
Change all license declarations to SPDX format and change spotless configuration to require the same.