### PR TITLE
ci: fix extract version steps

### DIFF
--- a/.github/workflows/release-push-image.yaml
+++ b/.github/workflows/release-push-image.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Extract version
         id: extract_version
         run: |
-          VERSION=$(grep 'version=' gradle.properties | cut -d '=' -f2)
+          VERSION=$(cat version.txt)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Server - Build and push image
@@ -147,7 +147,7 @@ jobs:
       - name: Extract version
         id: extract_version
         run: |
-          VERSION=$(grep 'version=' gradle.properties | cut -d '=' -f2)
+          VERSION=$(cat version.txt)
           echo "VERSION=${VERSION}" >> $GITHUB_ENV
 
       - name: Package helm chart


### PR DESCRIPTION
**Description**:

Follow up to #216 as it broke some steps on `main`.

The steps are only used on `main` and I was not aware of them.

