### PR TITLE
feat: add block archiving support

### DIFF
--- a/common/src/main/java/com/hedera/block/common/utils/MathUtilities.java
+++ b/common/src/main/java/com/hedera/block/common/utils/MathUtilities.java
@@ -1,10 +1,37 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.common.utils;
 
+import java.util.Arrays;
+
 /**
  * A utility class that deals with logic related to Mathematics.
  */
 public final class MathUtilities {
+    /**
+     * This array contains the powers of ten from 10^0 to 10^18 (long).
+     */
+    private static final long[] POSITIVE_POWERS_OF_TEN = {
+        1L,
+        10L,
+        100L,
+        1_000L,
+        10_000L,
+        100_000L,
+        1_000_000L,
+        10_000_000L,
+        100_000_000L,
+        1_000_000_000L,
+        10_000_000_000L,
+        100_000_000_000L,
+        1_000_000_000_000L,
+        10_000_000_000_000L,
+        100_000_000_000_000L,
+        1_000_000_000_000_000L,
+        10_000_000_000_000_000L,
+        100_000_000_000_000_000L,
+        1_000_000_000_000_000_000L
+    };
+
     /**
      * This method checks if the given number is a power of two.
      *
@@ -27,6 +54,30 @@ public final class MathUtilities {
      */
     public static boolean isEven(final int toCheck) {
         return (toCheck & 1) == 0;
+    }
+
+    /**
+     * This method checks if a given long is a positive power of 10.
+     * E.G.
+     * <pre>
+     *     isPowerOf10(1) = true
+     *     isPowerOf10(10) = true
+     *     isPowerOf10(100) = true
+     *     isPowerOf10(1000) = true
+     *     isPowerOf10(11) = false
+     *     isPowerOf10(50) = false
+     *     isPowerOf10(99) = false
+     *     isPowerOf10(101) = false
+     * </pre>
+     * @param toCheck the long to check
+     * @return {@code true} if the given long is a power of 10 {@code false} otherwise
+     */
+    public static boolean isPositivePowerOf10(final long toCheck) {
+        if (toCheck <= 0) {
+            return false;
+        } else {
+            return Arrays.binarySearch(POSITIVE_POWERS_OF_TEN, toCheck) >= 0;
+        }
     }
 
     private MathUtilities() {}

--- a/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
+++ b/common/src/main/java/com/hedera/block/common/utils/Preconditions.java
@@ -16,6 +16,8 @@ public final class Preconditions {
     private static final String DEFAULT_REQUIRE_POWER_OF_TWO_MESSAGE =
             "The input number [%d] is required to be a power of two.";
     private static final String DEFAULT_REQUIRE_IS_EVEN = "The input number [%d] is required to be even.";
+    private static final String DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE =
+            "The input number [%d] is required to be a positive power of 10.";
 
     /**
      * This method asserts a given {@link String} is not blank.
@@ -292,6 +294,38 @@ public final class Preconditions {
      */
     public static int requireEven(final int toCheck) {
         return requireEven(toCheck, DEFAULT_REQUIRE_IS_EVEN);
+    }
+
+    /**
+     * This method asserts a given number is a positive power of 10.
+     *
+     * @param toCheck the number to check if it is a positive power of 10
+     * @return the number to check if it is a positive power of 10
+     * @throws IllegalArgumentException if the input number to check is not a
+     * positive power of 10
+     */
+    public static int requirePositivePowerOf10(final int toCheck) {
+        return requirePositivePowerOf10(toCheck, DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE);
+    }
+
+    /**
+     * This method asserts a given number is a positive power of 10.
+     *
+     * @param toCheck the number to check if it is a positive power of 10
+     * @param errorMessage a formatted string with one decimal parameter for
+     * {@code toCheck}, must not be {@code null}.<br/>
+     * Example error message: {@value #DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE}
+     * @return the number to check if it is a positive power of 10
+     * @throws IllegalArgumentException if the input number to check is not a
+     * positive power of 10
+     * @see java.util.Formatter for more information on error message formatting
+     */
+    public static int requirePositivePowerOf10(final int toCheck, @NonNull final String errorMessage) {
+        if (!MathUtilities.isPositivePowerOf10(toCheck)) {
+            throw new IllegalArgumentException(errorMessage.formatted(toCheck));
+        } else {
+            return toCheck;
+        }
     }
 
     private Preconditions() {}

--- a/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
+++ b/common/src/test/java/com/hedera/block/common/CommonsTestUtility.java
@@ -253,5 +253,90 @@ public final class CommonsTestUtility {
         return Stream.concat(Stream.of(Arguments.of(0)), negativeIntegers());
     }
 
+    public static Stream<Arguments> positivePowersOf10() {
+        return Stream.of(
+                Arguments.of(1L),
+                Arguments.of(10L),
+                Arguments.of(100L),
+                Arguments.of(1_000L),
+                Arguments.of(10_000L),
+                Arguments.of(100_000L),
+                Arguments.of(1_000_000L),
+                Arguments.of(10_000_000L),
+                Arguments.of(100_000_000L),
+                Arguments.of(1_000_000_000L),
+                Arguments.of(10_000_000_000L),
+                Arguments.of(100_000_000_000L),
+                Arguments.of(1_000_000_000_000L),
+                Arguments.of(10_000_000_000_000L),
+                Arguments.of(100_000_000_000_000L),
+                Arguments.of(1_000_000_000_000_000L),
+                Arguments.of(10_000_000_000_000_000L),
+                Arguments.of(100_000_000_000_000_000L),
+                Arguments.of(1_000_000_000_000_000_000L));
+    }
+
+    public static Stream<Arguments> negativePowersOf10() {
+        return Stream.of(
+                Arguments.of(-1L),
+                Arguments.of(-10L),
+                Arguments.of(-100L),
+                Arguments.of(-1_000L),
+                Arguments.of(-10_000L),
+                Arguments.of(-100_000L),
+                Arguments.of(-1_000_000L),
+                Arguments.of(-10_000_000L),
+                Arguments.of(-100_000_000L),
+                Arguments.of(-1_000_000_000L),
+                Arguments.of(-10_000_000_000L),
+                Arguments.of(-100_000_000_000L),
+                Arguments.of(-1_000_000_000_000L),
+                Arguments.of(-10_000_000_000_000L),
+                Arguments.of(-100_000_000_000_000L),
+                Arguments.of(-1_000_000_000_000_000L),
+                Arguments.of(-10_000_000_000_000_000L),
+                Arguments.of(-100_000_000_000_000_000L),
+                Arguments.of(-1_000_000_000_000_000_000L));
+    }
+
+    public static Stream<Arguments> positiveIntPowersOf10() {
+        return Stream.of(
+                Arguments.of(1),
+                Arguments.of(10),
+                Arguments.of(100),
+                Arguments.of(1_000),
+                Arguments.of(10_000),
+                Arguments.of(100_000),
+                Arguments.of(1_000_000),
+                Arguments.of(10_000_000),
+                Arguments.of(100_000_000),
+                Arguments.of(1_000_000_000));
+    }
+
+    public static Stream<Arguments> negativeIntPowersOf10() {
+        return Stream.of(
+                Arguments.of(-1),
+                Arguments.of(-10),
+                Arguments.of(-100),
+                Arguments.of(-1_000),
+                Arguments.of(-10_000),
+                Arguments.of(-100_000),
+                Arguments.of(-1_000_000),
+                Arguments.of(-10_000_000),
+                Arguments.of(-100_000_000),
+                Arguments.of(-1_000_000_000));
+    }
+
+    // @todo(517) add 0 and MIN MAX values here as well, also, make the same logic to test for longs as well
+    public static Stream<Arguments> nonPowersOf10() {
+        return Stream.of(
+                Arguments.of(2),
+                Arguments.of(11),
+                Arguments.of(20),
+                Arguments.of(50),
+                Arguments.of(101),
+                Arguments.of(10_100));
+    }
+
     private CommonsTestUtility() {}
 }

--- a/common/src/test/java/com/hedera/block/common/utils/MathUtilitiesTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/MathUtilitiesTest.java
@@ -56,4 +56,31 @@ class MathUtilitiesTest {
         final boolean actual = MathUtilities.isEven(toTest);
         assertThat(actual).isFalse();
     }
+
+    /**
+     * This test aims to verify that the
+     * {@link MathUtilities#isPositivePowerOf10(long)} returns {@code true} if
+     * the input to check is a positive power of 10.
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#positivePowersOf10")
+    void testIsPositivePowerOf10Pass(final long toTest) {
+        final boolean actual = MathUtilities.isPositivePowerOf10(toTest);
+        assertThat(actual).isTrue();
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link MathUtilities#isPositivePowerOf10(long)} returns {@code true} if
+     * the input to check is a positive power of 10.
+     */
+    @ParameterizedTest
+    @MethodSource({
+        "com.hedera.block.common.CommonsTestUtility#negativePowersOf10",
+        "com.hedera.block.common.CommonsTestUtility#nonPowersOf10"
+    })
+    void testIsPositivePowerOf10Fail(final long toTest) {
+        final boolean actual = MathUtilities.isPositivePowerOf10(toTest);
+        assertThat(actual).isFalse();
+    }
 }

--- a/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
+++ b/common/src/test/java/com/hedera/block/common/utils/PreconditionsTest.java
@@ -25,6 +25,8 @@ class PreconditionsTest {
     private static final String DEFAULT_REQUIRE_POWER_OF_TWO_MESSAGE =
             "The input number [%d] is required to be a power of two.";
     private static final String DEFAULT_REQUIRE_IS_EVEN = "The input number [%d] is required to be even.";
+    private static final String DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE =
+            "The input number [%d] is required to be a positive power of 10.";
 
     /**
      * This test aims to verify that the
@@ -362,6 +364,52 @@ class PreconditionsTest {
         final String expectedTestMessage = testMessage.formatted(toTest);
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> Preconditions.requireEven(toTest, testMessage))
+                .withMessage(expectedTestMessage);
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link Preconditions#requirePositivePowerOf10(int)} will return the input
+     * 'toTest' parameter if the positive power of 10 check passes. Test
+     * includes overloads.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource("com.hedera.block.common.CommonsTestUtility#positiveIntPowersOf10")
+    void testRequirePositivePowerOf10Pass(final int toTest) {
+        final Consumer<Integer> asserts =
+                actual -> assertThat(actual).isPositive().isEqualTo(toTest);
+
+        final int actual = Preconditions.requirePositivePowerOf10(toTest);
+        assertThat(actual).satisfies(asserts);
+
+        final int actualOverload = Preconditions.requirePositivePowerOf10(toTest, "test error message");
+        assertThat(actualOverload).satisfies(asserts);
+    }
+
+    /**
+     * This test aims to verify that the
+     * {@link Preconditions#requirePositivePowerOf10(int)} will throw an
+     * {@link IllegalArgumentException} if the positive power of 10 check fails.
+     * Test includes overloads.
+     *
+     * @param toTest parameterized, the number to test
+     */
+    @ParameterizedTest
+    @MethodSource({
+        "com.hedera.block.common.CommonsTestUtility#negativeIntPowersOf10",
+        "com.hedera.block.common.CommonsTestUtility#nonPowersOf10"
+    })
+    void testRequirePositivePowerOf10Fail(final int toTest) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> Preconditions.requirePositivePowerOf10(toTest))
+                .withMessage(DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE.formatted(toTest));
+
+        final String testMessage = DEFAULT_REQUIRE_POSITIVE_POWER_OF_10_MESSAGE.concat(" custom test error message");
+        final String expectedTestMessage = testMessage.formatted(toTest);
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> Preconditions.requirePositivePowerOf10(toTest, testMessage))
                 .withMessage(expectedTestMessage);
     }
 

--- a/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
+++ b/server/src/main/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializer.java
@@ -13,21 +13,41 @@ import java.util.List;
 public final class ServerMappedConfigSourceInitializer {
     private static final List<ConfigMapping> MAPPINGS = List.of(
             // Please add properties in alphabetical order
+
+            // Consumer Config
             new ConfigMapping("consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
+
+            // Mediator Config
             new ConfigMapping("mediator.ringBufferSize", "MEDIATOR_RING_BUFFER_SIZE"),
             new ConfigMapping("mediator.type", "MEDIATOR_TYPE"),
+
+            // Notifier Config
             new ConfigMapping("notifier.ringBufferSize", "NOTIFIER_RING_BUFFER_SIZE"),
+
+            // Persistence Config
             new ConfigMapping("persistence.storage.archiveRootPath", "PERSISTENCE_STORAGE_ARCHIVE_ROOT_PATH"),
             new ConfigMapping("persistence.storage.compression", "PERSISTENCE_STORAGE_COMPRESSION"),
             new ConfigMapping("persistence.storage.compressionLevel", "PERSISTENCE_STORAGE_COMPRESSION_LEVEL"),
             new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
             new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
+            new ConfigMapping("persistence.storage.archiveEnabled", "PERSISTENCE_STORAGE_ARCHIVE_ENABLED"),
+            new ConfigMapping("persistence.storage.archiveBatchSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
+
+            // Producer Config
             new ConfigMapping("producer.type", "PRODUCER_TYPE"),
+
+            // Prometheus Config (externally managed, but we need this mapping)
             new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
             new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER"),
+
+            // Server Config
             new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
             new ConfigMapping("server.port", "SERVER_PORT"),
+
+            // Service Config
             new ConfigMapping("service.shutdownDelayMillis", "SERVICE_SHUTDOWN_DELAY_MILLIS"),
+
+            // Verification Config
             new ConfigMapping("verification.hashCombineBatchSize", "VERIFICATION_HASH_COMBINE_BATCH_SIZE"),
             new ConfigMapping("verification.sessionType", "VERIFICATION_SESSION_TYPE"),
             new ConfigMapping("verification.type", "VERIFICATION_TYPE"));

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -64,7 +64,8 @@ public interface PersistenceInjectionModule {
         final StorageType persistenceType = config.type();
         try {
             return switch (persistenceType) {
-                case BLOCK_AS_LOCAL_FILE -> BlockAsLocalFileWriter.of(blockNodeContext, blockPathResolver, compression);
+                case BLOCK_AS_LOCAL_FILE -> BlockAsLocalFileWriter.of(
+                        config, blockNodeContext, blockPathResolver, compression);
                 case BLOCK_AS_LOCAL_DIRECTORY -> BlockAsLocalDirWriter.of(
                         blockNodeContext, blockRemover, blockPathResolver);
                 case NO_OP -> NoOpBlockWriter.newInstance();

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfig.java
@@ -36,7 +36,10 @@ public record PersistenceStorageConfig(
         @Loggable @ConfigProperty(defaultValue = "") String archiveRootPath,
         @Loggable @ConfigProperty(defaultValue = "BLOCK_AS_LOCAL_FILE") StorageType type,
         @Loggable @ConfigProperty(defaultValue = "ZSTD") CompressionType compression,
-        @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel) {
+        @Loggable @ConfigProperty(defaultValue = "3") @Min(0) @Max(20) int compressionLevel,
+        @Loggable @ConfigProperty(defaultValue = "true") boolean archiveEnabled,
+        @Loggable @ConfigProperty(defaultValue = "1_000")
+                int archiveBatchSize) { // @todo(517) rename batch to group size
     // @todo(#371) - the default life/archive root path must be absolute starting from /opt
     private static final String LIVE_ROOT_PATH =
             Path.of("hashgraph/blocknode/data/live/").toAbsolutePath().toString();
@@ -49,6 +52,7 @@ public record PersistenceStorageConfig(
      */
     public PersistenceStorageConfig {
         Objects.requireNonNull(type);
+        Preconditions.requirePositivePowerOf10(archiveBatchSize);
         compression.verifyCompressionLevel(compressionLevel);
         liveRootPath = resolvePath(liveRootPath, LIVE_ROOT_PATH, BLOCK_NODE_LIVE_ROOT_DIRECTORY_SEMANTIC_NAME);
         archiveRootPath =

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockArchiver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockArchiver.java
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.archive;
+
+// @todo(517) add documentation once we have the final implementation
+public interface BlockArchiver {
+    void signalBlockWritten(final long currentBlockNumber);
+
+    void stop() throws InterruptedException;
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockAsLocalFileArchiver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/BlockAsLocalFileArchiver.java
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.archive;
+
+import com.hedera.block.common.utils.FileUtilities;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.path.BlockPathResolver;
+import com.hedera.block.server.persistence.storage.path.LiveBlockPath;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.System.Logger.Level;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+// @todo(517) add documentation once we have the final implementation
+public final class BlockAsLocalFileArchiver implements LocalBlockArchiver {
+    private final BlockArchiverRunnable archiverRunnable;
+    private final ExecutorService executor;
+
+    private BlockAsLocalFileArchiver(
+            @NonNull final PersistenceStorageConfig config, @NonNull final BlockPathResolver blockPathResolver) {
+        this.archiverRunnable =
+                new BlockArchiverRunnable(Objects.requireNonNull(config), Objects.requireNonNull(blockPathResolver));
+        this.executor = Executors.newSingleThreadExecutor();
+        this.executor.submit(archiverRunnable);
+    }
+
+    public static BlockArchiver of(
+            @NonNull final PersistenceStorageConfig config, @NonNull final BlockPathResolver blockPathResolver) {
+        return new BlockAsLocalFileArchiver(config, blockPathResolver);
+    }
+
+    @Override
+    public void signalBlockWritten(final long latestBlockNumber) {
+        this.archiverRunnable.signalBlockWritten(latestBlockNumber);
+    }
+
+    @Override
+    public void stop() throws InterruptedException {
+        // @todo(517) this will change a bit once we move to task based solution
+        archiverRunnable.stop();
+        executor.shutdown();
+        final boolean terminatedGracefully = this.executor.awaitTermination(60, TimeUnit.SECONDS);
+        if (!terminatedGracefully) {
+            // todo log or do something
+        }
+    }
+
+    // @todo(517) this will become a task based solution, this is a temporary solution to v1 of archiving
+    private static final class BlockArchiverRunnable implements Runnable {
+        private static final System.Logger LOGGER = System.getLogger(BlockArchiverRunnable.class.getName());
+        private final Path archiveRootPath;
+        private final int archiveBatchSize;
+        private final BlockPathResolver blockPathResolver;
+        private volatile ThreadSignalCarrier threadSignalCarrier;
+        private volatile boolean running;
+        private volatile long lastWrittenBlockNumber = -1;
+        private volatile long lastArchivedBlockNumber = -1;
+        private int blockWrittenSignalCounter = 0;
+        // @todo(517) no state will be needed once we move to task based solution
+
+        private BlockArchiverRunnable(
+                @NonNull final PersistenceStorageConfig config, final BlockPathResolver blockPathResolver) {
+            this.archiveRootPath = Path.of(config.archiveRootPath());
+            this.archiveBatchSize = config.archiveBatchSize();
+            this.blockPathResolver = Objects.requireNonNull(blockPathResolver);
+        }
+
+        private void signalBlockWritten(final long latestBlockNumber) {
+            if (running) {
+                synchronized (this) {
+                    if (running) {
+                        // the logic inside this block should be accessed only by a single thread
+                        final int currentSignalCount = ++blockWrittenSignalCounter;
+                        if (currentSignalCount >= archiveBatchSize) {
+                            // if threshold is reached, notify the worker and reset counter
+                            blockWrittenSignalCounter = 0;
+                            lastWrittenBlockNumber = latestBlockNumber;
+                            threadSignalCarrier.doNotify();
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void run() { // @todo(517) this will be changed to task based solution
+            threadSignalCarrier = new ThreadSignalCarrier();
+            running = true;
+            while (running) {
+                try {
+                    if (running) {
+                        threadSignalCarrier.doWait();
+                    }
+                    if (running) {
+                        archive();
+                    }
+                } catch (final Exception e) {
+                    LOGGER.log(Level.ERROR, "Archiver failed", e);
+                }
+            }
+        }
+
+        // @todo(517) this is a temporary solution to v1 of archiving, which will change to task based implementation
+        // the archiving method will be given a latest block number written and out of that we can easily determine
+        // what to archive, since we have the trie structure, anything under the root we will resolved will be archived
+        // this also allows us to archive in parallel and not be limited to a single thread
+        private void archive() throws IOException {
+            final long localLastWrittenBlockNumber = lastWrittenBlockNumber;
+            if (localLastWrittenBlockNumber == -1) {
+                throw new IllegalStateException("No blocks to archive");
+            }
+
+            final long localLastArchivedBlockNumber = lastArchivedBlockNumber;
+            final long lastWrittenLastArchivedGap;
+            if (localLastArchivedBlockNumber == -1) {
+                lastWrittenLastArchivedGap = localLastWrittenBlockNumber;
+            } else {
+                lastWrittenLastArchivedGap = localLastWrittenBlockNumber - localLastArchivedBlockNumber;
+            }
+
+            final boolean shouldArchiveBlocks =
+                    lastWrittenLastArchivedGap >= (archiveBatchSize * 2L); // todo is this correct x2 ?
+
+            if (shouldArchiveBlocks) {
+                final long amountOfBlocksToWrite = lastWrittenLastArchivedGap - archiveBatchSize;
+                final List<Path> pathsToArchiveAscending = new ArrayList<>();
+                for (int i = 0; i < amountOfBlocksToWrite; i++) {
+                    final Optional<LiveBlockPath> block =
+                            blockPathResolver.findLiveBlock(localLastArchivedBlockNumber + 1 + i);
+                    if (block.isPresent()) {
+                        final LiveBlockPath liveBlockPath = block.get();
+                        pathsToArchiveAscending.add(liveBlockPath.dirPath().resolve(liveBlockPath.blockFileName()));
+                    }
+                }
+
+                // @todo(517) once we migrate to the task based solution all this will not be necessary, only we
+                // will need to resolve which dir in the trie we need to archive, then we recursively archive anything
+                // under that dir
+                TreeMap<Path, List<Path>> pathsToArchive = new TreeMap<>();
+                for (final Path path : pathsToArchiveAscending) {
+                    final long blockNumber =
+                            Long.parseLong(path.getFileName().toString().split("\\.")[0]);
+                    final Path zipPath =
+                            resolveArchivePathForZipOfBlockNumber(blockNumber, archiveBatchSize, archiveRootPath);
+                    if (pathsToArchive.containsKey(zipPath)) {
+                        pathsToArchive.get(zipPath).add(path);
+                    } else {
+                        final List<Path> paths = new ArrayList<>();
+                        paths.add(path);
+                        pathsToArchive.put(zipPath, paths);
+                    }
+                }
+
+                pathsToArchive = pathsToArchive.entrySet().stream()
+                        .filter(entry -> entry.getValue().size() == archiveBatchSize
+                                || entry.getKey()
+                                        .toString()
+                                        .endsWith("/0".repeat(19 - (int) Math.log10(archiveBatchSize)) + ".zip"))
+                        .collect(
+                                Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, TreeMap::new));
+
+                for (final Entry<Path, List<Path>> pathListEntry : pathsToArchive.entrySet()) {
+                    final Path zipFilePath = pathListEntry.getKey();
+                    if (Files.notExists(zipFilePath)) FileUtilities.createFile(zipFilePath);
+                    try (final ZipOutputStream zipOutputStream =
+                            new ZipOutputStream(Files.newOutputStream(zipFilePath))) {
+                        for (final Path path : pathListEntry.getValue()) {
+                            final ZipEntry zipEntry =
+                                    new ZipEntry(path.getFileName().toString());
+                            try {
+                                zipOutputStream.putNextEntry(zipEntry);
+                                Files.copy(path, zipOutputStream);
+                                zipOutputStream.closeEntry();
+                            } catch (final IOException e) {
+                                throw new UncheckedIOException(e);
+                            }
+                        }
+                    }
+                }
+
+                for (final Path folder : pathsToArchive.keySet()) {
+                    // @todo(517) for the symlink, the whole live root needs to be replaced with the whole archive root!
+                    final Path livePathSymlink = Path.of(folder.toString().replace("archive", "live"));
+                    Files.createSymbolicLink(livePathSymlink, folder);
+                    final Path toDelete = Path.of(livePathSymlink.toString().replace(".zip", ""));
+                    try (Stream<Path> paths = Files.walk(toDelete)) {
+                        paths.sorted(Comparator.reverseOrder())
+                                .map(Path::toFile)
+                                .forEach(File::delete);
+                    }
+                }
+
+                // @todo(517) will not be needed once we migrate to task based solution, all the state will be
+                // removed
+                this.lastArchivedBlockNumber = Long.parseLong(pathsToArchive
+                        .lastEntry()
+                        .getValue()
+                        .getLast()
+                        .getFileName()
+                        .toString()
+                        .split("\\.")[0]);
+            }
+        }
+
+        // @todo(517) this will be improved
+        public Path resolveArchivePathForZipOfBlockNumber(long blockNumber, int batchSize, Path archiveRootPath) {
+            // Calculate the batch start number
+            long batchStartNumber = (blockNumber / batchSize) * batchSize;
+
+            // Format the batch start number to a 19-digit string
+            String formattedBatchStartNumber = String.format("%0" + 19 + "d", batchStartNumber);
+
+            // Split the formatted number into an array of characters
+            String[] blockPath = formattedBatchStartNumber.split("");
+
+            // Determine the position of the zip file name
+            int zipFilePosition = blockPath.length - (int) (Math.log10(batchSize) + 1);
+
+            // Create the zip file name
+            String zipFileName = blockPath[zipFilePosition] + ".zip";
+
+            // Replace the appropriate position with the zip file name
+            blockPath[zipFilePosition] = zipFileName;
+
+            // Construct the path
+            Path result = archiveRootPath;
+            for (int i = 0; i < zipFilePosition; i++) {
+                result = result.resolve(blockPath[i]);
+            }
+            result = result.resolve(zipFileName);
+
+            return result;
+        }
+
+        // @todo(517) this will be removed, if we are in a task based solution, we will not need this probably
+        public void stop() {
+            running = false;
+            threadSignalCarrier.doNotify();
+        }
+    }
+
+    // @todo(517) remove this, this is a temporary solution to v1 of archiving, which will change to task based
+    // implementation
+    static final class ThreadSignalCarrier {
+        private final Thread toSignalFor;
+        private int signalRaisedCounter = 0;
+        private boolean wasSignaled = false;
+        private boolean isThreadWaiting = false;
+
+        ThreadSignalCarrier() {
+            this.toSignalFor = Thread.currentThread();
+        }
+
+        void doNotify() {
+            synchronized (this) {
+                if (!isThreadWaiting) {
+                    signalRaisedCounter++;
+                } else {
+                    wasSignaled = true;
+                }
+                // always call notify
+                notify();
+            }
+        }
+
+        void doWait() {
+            final Thread callerThread = Thread.currentThread();
+            if (!callerThread.equals(toSignalFor)) {
+                throw new IllegalStateException(
+                        "Thread [%s] is not the target of this signal carrier - only [%s] can wait on this object."
+                                .formatted(callerThread.getName(), toSignalFor.getName()));
+            } else {
+                synchronized (this) {
+                    // if a signal has been raised, decrement the counter and continue, no need to wait
+                    if (signalRaisedCounter > 0) {
+                        signalRaisedCounter--;
+                    } else { // else wait until a signal is raised
+                        // else wait
+                        isThreadWaiting = true;
+                        try {
+                            // while loop to guard against spurious wake-ups
+                            while (!wasSignaled) {
+                                wait();
+                            }
+                            wasSignaled = false;
+                        } catch (final InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                    // always set the isThreadWaiting to false
+                    isThreadWaiting = false;
+                }
+            }
+        }
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/LocalBlockArchiver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/LocalBlockArchiver.java
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.archive;
+
+// @todo(517) maybe we will not need this interface
+public interface LocalBlockArchiver extends BlockArchiver {}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/archive/NoOpArchiver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/archive/NoOpArchiver.java
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.archive;
+
+/**
+ * A no-op implementation of the archiver.
+ */
+public final class NoOpArchiver implements BlockArchiver {
+    /**
+     * Constructor.
+     */
+    private NoOpArchiver() {}
+
+    /**
+     * Factory method. Returns a new, fully initialized instance of
+     * {@link NoOpArchiver}.
+     *
+     * @return a new, fully initialized and valid instance of
+     * {@link NoOpArchiver}
+     */
+    public static NoOpArchiver newInstance() {
+        return new NoOpArchiver();
+    }
+
+    /**
+     * This method does nothing, it also has no precondition checks.
+     */
+    @Override
+    public void signalBlockWritten(final long currentBlockNumber) {
+        // do nothing
+    }
+
+    /**
+     * This method does nothing, it also has no precondition checks.
+     */
+    @Override
+    public void stop() throws InterruptedException {
+        // do nothing
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/Compression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/Compression.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,17 +28,18 @@ public interface Compression {
 
     /**
      * This method takes a valid, {@code non-null} {@link InputStream} instance
-     * and wraps it with the specific compression algorithm implementation. The
+     * and wraps it with the specified compression algorithm implementation. The
      * resulting {@link InputStream} is then returned.
      *
      * @param streamToWrap a valid {@code non-null} {@link InputStream} to wrap
+     * @param compressionType valid, {@code non-null} {@link CompressionType}
+     * that specifies the compression algorithm to use
      * @return a {@code non-null} {@link InputStream} that wraps the provided
-     * {@link InputStream} with the specific compression algorithm
-     * implementation
+     * {@link InputStream} with the specific compression algorithm implementation
      * @throws IOException if an I/O exception occurs
      */
     @NonNull
-    InputStream wrap(@NonNull final InputStream streamToWrap) throws IOException;
+    InputStream wrap(@NonNull final InputStream streamToWrap, final CompressionType compressionType) throws IOException;
 
     /**
      * This method aims to return a valid, {@code non-blank} {@link String} that

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/CompressionBase.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/CompressionBase.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.compression;
+
+import com.github.luben.zstd.ZstdInputStream;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/**
+ * Base for all compression implementations.
+ */
+public abstract class CompressionBase implements Compression {
+    /*
+     * Comment: no matter what the compression type configured is, we must
+     * always be able to wrap an {@link InputStream} with any supported
+     * compression type. Hence, this method should be final and should not be
+     * overridden by any implementing class. Also, the switch gives us safety
+     * because any changes to the {@link CompressionType} enum will be caught
+     * at compile time, and we will have to handle them.
+     */
+    @NonNull
+    @Override
+    public final InputStream wrap(
+            @NonNull final InputStream streamToWrap, @NonNull final CompressionType compressionType)
+            throws IOException {
+        return switch (Objects.requireNonNull(compressionType)) {
+            case ZSTD -> new ZstdInputStream(Objects.requireNonNull(streamToWrap));
+            case NONE -> Objects.requireNonNull(streamToWrap);
+        };
+    }
+}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/NoOpCompression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/NoOpCompression.java
@@ -3,8 +3,6 @@ package com.hedera.block.server.persistence.storage.compression;
 
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Objects;
 
@@ -13,7 +11,7 @@ import java.util.Objects;
  * does not use any algorithm, but simply generates a stream that writes the
  * data to it`s destination, as it is received.
  */
-public class NoOpCompression implements Compression {
+public final class NoOpCompression extends CompressionBase {
     /**
      * Constructor.
      */
@@ -39,18 +37,6 @@ public class NoOpCompression implements Compression {
     @NonNull
     @Override
     public OutputStream wrap(@NonNull final OutputStream streamToWrap) {
-        return Objects.requireNonNull(streamToWrap);
-    }
-
-    /**
-     * This implementation does not decompress the data. It uses no compression
-     * algorithm, but simply generates a stream that reads the data from it`s
-     * destination, as it has been written.
-     * @see Compression#wrap(OutputStream) for API contract
-     */
-    @NonNull
-    @Override
-    public InputStream wrap(@NonNull final InputStream streamToWrap) throws IOException {
         return Objects.requireNonNull(streamToWrap);
     }
 

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/compression/ZstdCompression.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/compression/ZstdCompression.java
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.persistence.storage.compression;
 
-import com.github.luben.zstd.ZstdInputStream;
 import com.github.luben.zstd.ZstdOutputStream;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Objects;
 
@@ -15,7 +13,7 @@ import java.util.Objects;
  * An implementation of {@link Compression} that compresses the data using the
  * Zstandard (Zstd) compression algorithm.
  */
-public class ZstdCompression implements Compression {
+public final class ZstdCompression extends CompressionBase {
     private final int compressionLevel;
 
     /**
@@ -46,12 +44,6 @@ public class ZstdCompression implements Compression {
     @Override
     public OutputStream wrap(@NonNull final OutputStream streamToWrap) throws IOException {
         return new ZstdOutputStream(Objects.requireNonNull(streamToWrap), compressionLevel);
-    }
-
-    @NonNull
-    @Override
-    public InputStream wrap(@NonNull final InputStream streamToWrap) throws IOException {
-        return new ZstdInputStream(Objects.requireNonNull(streamToWrap));
     }
 
     @NonNull

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/ArchiveBlockPath.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/ArchiveBlockPath.java
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.path;
+
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+
+/**
+ * TODO: add documentation
+ */
+public record ArchiveBlockPath(
+        long blockNumber,
+        @NonNull Path dirPath,
+        @NonNull String zipFileName,
+        @NonNull String zipEntryName,
+        @NonNull CompressionType compressionType) {}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockAsLocalDirPathResolver.java
@@ -3,6 +3,7 @@ package com.hedera.block.server.persistence.storage.path;
 
 import com.hedera.block.common.utils.Preconditions;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,13 +45,6 @@ public final class BlockAsLocalDirPathResolver implements BlockPathResolver {
         return liveRootPath.resolve(String.valueOf(blockNumber));
     }
 
-    @NonNull
-    @Override
-    public Path resolveArchiveRawPathToBlock(final long blockNumber) {
-        Preconditions.requireWhole(blockNumber);
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
     /**
      * The block-as-local-dir implementation does not support
      * compression/decompression. A block will only be found if it exists and is
@@ -62,13 +56,24 @@ public final class BlockAsLocalDirPathResolver implements BlockPathResolver {
      */
     @NonNull
     @Override
-    public Optional<Path> findBlock(final long blockNumber) {
+    public Optional<LiveBlockPath> findLiveBlock(final long blockNumber) {
         Preconditions.requireWhole(blockNumber);
         final Path liveRawRootPath = resolveLiveRawPathToBlock(blockNumber);
         if (Files.exists(liveRawRootPath)) {
-            return Optional.of(liveRawRootPath);
+            final LiveBlockPath found = new LiveBlockPath(
+                    blockNumber,
+                    liveRawRootPath.getParent(),
+                    liveRawRootPath.getFileName().toString(),
+                    CompressionType.NONE);
+            return Optional.of(found);
         } else {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public Optional<ArchiveBlockPath> findArchivedBlock(final long blockNumber) {
+        Preconditions.requireWhole(blockNumber);
+        throw new UnsupportedOperationException("Archiving is not supported by the block-as-dir implementation.");
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/BlockPathResolver.java
@@ -35,59 +35,7 @@ public interface BlockPathResolver {
     @NonNull
     Path resolveLiveRawPathToBlock(final long blockNumber);
 
-    /**
-     * This method resolves the fs {@link Path} to a Block by a given input
-     * number. This method does not guarantee that the returned {@link Path}
-     * exists! This method is guaranteed to return a {@code non-null}
-     * {@link Path}. The Block File extension
-     * {@link com.hedera.block.server.Constants#BLOCK_FILE_EXTENSION} is
-     * appended to the resolved Block path. No compression extension is appended
-     * to the file name. No other file extension is appended to the file name.
-     * The provided path is the raw resolved path to the Block inside the
-     * archive root storage.
-     * <br/>
-     * <br/>
-     * E.G. (illustrative example, actual path may vary):
-     * <pre>
-     *     If the blockNumber is 10, the resolved path will be:
-     *     <b>/path/to/archive/block/storage.zip/0000000000000000010.blk</b>
-     * </pre>
-     *
-     * @param blockNumber to be resolved the path for
-     * @return the resolved path to the given Block by a number
-     * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
-     */
-    @NonNull
-    Path resolveArchiveRawPathToBlock(final long blockNumber);
+    Optional<LiveBlockPath> findLiveBlock(final long blockNumber);
 
-    /**
-     * This method resolves the fs {@link Path} to a Block by a given input
-     * number. This method attempts to find the Block file, meaning it will try
-     * to resolve the Block file path based on multiple tries:
-     * <br/>
-     * <br/>
-     * <pre>
-     *     1. Try to resolve the Block file path by the given Block number with
-     *        the current compression extension appended to the file name in the
-     *        live root.
-     *     2. Try to resolve the Block file path by the given Block number with
-     *        the current compression extension appended to the file name in the
-     *        archive root.
-     *     3. Try to resolve the Block file path by the given Block number with
-     *        no compression extension appended to the file name in the live root.
-     *     4. Try to resolve the Block file path by the given Block number with
-     *        no compression extension appended to the file name in the archive root.
-     * </pre>
-     * We generally expect the Block files to always be compressed, but for best
-     * effort, we must also try to resolve the Block file without the
-     * compression extension if the Block file is not found with the compression
-     * extension. This method is guaranteed to return a {@code non-null}
-     * {@link Optional} value.
-     *
-     * @param blockNumber the block number to find the block file for
-     * @return optional value, the path to the Block file by the given Block number
-     * @throws IllegalArgumentException if the blockNumber IS NOT a whole number
-     */
-    @NonNull
-    Optional<Path> findBlock(final long blockNumber);
+    Optional<ArchiveBlockPath> findArchivedBlock(final long blockNumber);
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/LiveBlockPath.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/LiveBlockPath.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.block.server.persistence.storage.path;
+
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+
+/**
+ * TODO: add documentation
+ */
+public record LiveBlockPath(
+        long blockNumber,
+        @NonNull Path dirPath,
+        @NonNull String blockFileName,
+        @NonNull CompressionType compressionType) {}

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolver.java
@@ -37,22 +37,20 @@ public final class NoOpBlockPathResolver implements BlockPathResolver {
     }
 
     /**
-     * No-op resolver. Does nothing and always returns a path under '/tmp' that
-     * resolves to 'blockNumber.tmp.blk'. No preconditions check also.
+     * No-op resolver. Does nothing and always returns an empty optional.
+     * No preconditions check also.
      */
-    @NonNull
     @Override
-    public Path resolveArchiveRawPathToBlock(final long blockNumber) {
-        return resolveLiveRawPathToBlock(blockNumber);
+    public Optional<LiveBlockPath> findLiveBlock(final long blockNumber) {
+        return Optional.empty();
     }
 
     /**
      * No-op resolver. Does nothing and always returns an empty optional.
      * No preconditions check also.
      */
-    @NonNull
     @Override
-    public Optional<Path> findBlock(final long blockNumber) {
+    public Optional<ArchiveBlockPath> findArchivedBlock(final long blockNumber) {
         return Optional.empty();
     }
 }

--- a/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReader.java
@@ -2,17 +2,23 @@
 package com.hedera.block.server.persistence.storage.read;
 
 import com.hedera.block.common.utils.Preconditions;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import com.hedera.block.server.persistence.storage.compression.Compression;
+import com.hedera.block.server.persistence.storage.path.ArchiveBlockPath;
 import com.hedera.block.server.persistence.storage.path.BlockPathResolver;
+import com.hedera.block.server.persistence.storage.path.LiveBlockPath;
 import com.hedera.hapi.block.BlockUnparsed;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /**
  * A Block reader that reads block-as-file.
@@ -50,19 +56,36 @@ public final class BlockAsLocalFileReader implements LocalBlockReader<BlockUnpar
     @Override
     public Optional<BlockUnparsed> read(final long blockNumber) throws IOException, ParseException {
         Preconditions.requireWhole(blockNumber);
-        final Optional<Path> optBlockPath = pathResolver.findBlock(blockNumber);
+        final Optional<LiveBlockPath> optBlockPath = pathResolver.findLiveBlock(blockNumber);
         if (optBlockPath.isPresent()) {
-            return Optional.of(doRead(optBlockPath.get()));
+            final LiveBlockPath liveBlockPath = optBlockPath.get();
+            final Path actualPathToBlock = liveBlockPath.dirPath().resolve(liveBlockPath.blockFileName());
+            final BlockUnparsed value;
+            try (final InputStream in = Files.newInputStream(actualPathToBlock)) {
+                value = doRead(in, liveBlockPath.compressionType());
+            }
+            return Optional.of(value);
         } else {
+            final Optional<ArchiveBlockPath> optArchivedBlock = pathResolver.findArchivedBlock(blockNumber);
+            if (optArchivedBlock.isPresent()) {
+                final ArchiveBlockPath archiveBlockPath = optArchivedBlock.get();
+                final Path zipFilePath = archiveBlockPath.dirPath().resolve(archiveBlockPath.zipFileName());
+                final BlockUnparsed value;
+                try (final ZipFile zipFile = new ZipFile(zipFilePath.toFile())) {
+                    final ZipEntry entry = zipFile.getEntry(archiveBlockPath.zipEntryName());
+                    final InputStream in = zipFile.getInputStream(entry);
+                    value = doRead(in, archiveBlockPath.compressionType());
+                }
+                return Optional.of(value);
+            }
             return Optional.empty();
         }
     }
 
-    private BlockUnparsed doRead(final Path resolvedBlockPath) throws IOException, ParseException {
-        try (final ReadableStreamingData data =
-                new ReadableStreamingData(compression.wrap(Files.newInputStream(resolvedBlockPath)))) {
+    private BlockUnparsed doRead(final InputStream in, final CompressionType compressionType)
+            throws IOException, ParseException {
+        try (final ReadableStreamingData data = new ReadableStreamingData(compression.wrap(in, compressionType))) {
             return BlockUnparsed.PROTOBUF.parse(data);
-        } // todo this method must be extended to try to read uncompressed data if compressed data is not found
-        // need some mechanism that would be convenient to use not only here but also in other places
+        }
     }
 }

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module com.hedera.block.server {
     exports com.hedera.block.server.consumer;
     exports com.hedera.block.server.exception;
     exports com.hedera.block.server.persistence.storage;
+    exports com.hedera.block.server.persistence.storage.archive;
     exports com.hedera.block.server.persistence.storage.compression;
     exports com.hedera.block.server.persistence.storage.path;
     exports com.hedera.block.server.persistence.storage.write;

--- a/server/src/main/resources/app.properties
+++ b/server/src/main/resources/app.properties
@@ -15,3 +15,6 @@ prometheus.endpointPortNumber=9999
 # @todo(#372) - default persistence type should be BLOCK_AS_LOCAL_FILE
 persistence.storage.type=BLOCK_AS_LOCAL_DIRECTORY
 #persistence.storage.compression=NONE
+#persistence.storage.archiveEnabled=false
+# @todo(517) - enable default batch size
+persistence.storage.archiveBatchSize=10

--- a/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/ServerMappedConfigSourceInitializerTest.java
@@ -38,6 +38,8 @@ class ServerMappedConfigSourceInitializerTest {
 
     private static final Set<String> LOGGABLE_PACKAGES = Set.of("metrics", "prometheus");
     private static final ConfigMapping[] SUPPORTED_MAPPINGS = {
+        // Please add properties in alphabetical order
+
         // Consumer Config
         new ConfigMapping("consumer.timeoutThresholdMillis", "CONSUMER_TIMEOUT_THRESHOLD_MILLIS"),
 
@@ -54,9 +56,15 @@ class ServerMappedConfigSourceInitializerTest {
         new ConfigMapping("persistence.storage.compressionLevel", "PERSISTENCE_STORAGE_COMPRESSION_LEVEL"),
         new ConfigMapping("persistence.storage.liveRootPath", "PERSISTENCE_STORAGE_LIVE_ROOT_PATH"),
         new ConfigMapping("persistence.storage.type", "PERSISTENCE_STORAGE_TYPE"),
+        new ConfigMapping("persistence.storage.archiveEnabled", "PERSISTENCE_STORAGE_ARCHIVE_ENABLED"),
+        new ConfigMapping("persistence.storage.archiveBatchSize", "PERSISTENCE_STORAGE_ARCHIVE_BATCH_SIZE"),
 
         // Producer Config
         new ConfigMapping("producer.type", "PRODUCER_TYPE"),
+
+        // Prometheus Config (externally managed, but we need this mapping)
+        new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
+        new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER"),
 
         // Server Config
         new ConfigMapping("server.maxMessageSizeBytes", "SERVER_MAX_MESSAGE_SIZE_BYTES"),
@@ -65,13 +73,9 @@ class ServerMappedConfigSourceInitializerTest {
         // Service Config
         new ConfigMapping("service.shutdownDelayMillis", "SERVICE_SHUTDOWN_DELAY_MILLIS"),
 
-        // Prometheus Config (externally managed, but we need this mapping)
-        new ConfigMapping("prometheus.endpointEnabled", "PROMETHEUS_ENDPOINT_ENABLED"),
-        new ConfigMapping("prometheus.endpointPortNumber", "PROMETHEUS_ENDPOINT_PORT_NUMBER"),
-
         // Verification Config
-        new ConfigMapping("verification.sessionType", "VERIFICATION_SESSION_TYPE"),
         new ConfigMapping("verification.hashCombineBatchSize", "VERIFICATION_HASH_COMBINE_BATCH_SIZE"),
+        new ConfigMapping("verification.sessionType", "VERIFICATION_SESSION_TYPE"),
         new ConfigMapping("verification.type", "VERIFICATION_TYPE"),
     };
 

--- a/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/config/logging/ConfigurationLoggingImplTest.java
@@ -25,7 +25,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(27, config.size());
+        assertEquals(29, config.size());
 
         for (Map.Entry<String, Object> entry : config.entrySet()) {
             String value = entry.getValue().toString();
@@ -42,7 +42,7 @@ public class ConfigurationLoggingImplTest {
         final ConfigurationLoggingImpl configurationLogging = new ConfigurationLoggingImpl(configuration);
         final Map<String, Object> config = configurationLogging.collectConfig(configuration);
         assertNotNull(config);
-        assertEquals(29, config.size());
+        assertEquals(31, config.size());
 
         assertEquals("*****", config.get("test.secret").toString());
         assertEquals("", config.get("test.emptySecret").toString());

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerInjectionModuleTest.java
@@ -27,7 +27,9 @@ class AckHandlerInjectionModuleTest {
                 "",
                 PersistenceStorageConfig.StorageType.BLOCK_AS_LOCAL_FILE,
                 PersistenceStorageConfig.CompressionType.NONE,
-                0);
+                0,
+                false,
+                10);
         VerificationConfig verificationConfig = mock(VerificationConfig.class);
         when(verificationConfig.type()).thenReturn(VerificationConfig.VerificationServiceType.PRODUCTION);
 

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -240,6 +240,8 @@ class PersistenceInjectionModuleTest {
     @MethodSource("storageTypes")
     void testProvidesBlockPathResolver(final StorageType storageType) {
         lenient().when(persistenceStorageConfigMock.liveRootPath()).thenReturn(testLiveRootPath.toString());
+        lenient().when(persistenceStorageConfigMock.archiveRootPath()).thenReturn(testLiveRootPath.toString());
+        lenient().when(persistenceStorageConfigMock.archiveBatchSize()).thenReturn(10);
         when(persistenceStorageConfigMock.type()).thenReturn(storageType);
 
         final BlockPathResolver actual = PersistenceInjectionModule.providesPathResolver(persistenceStorageConfigMock);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/PersistenceStorageConfigTest.java
@@ -39,6 +39,9 @@ class PersistenceStorageConfigTest {
     private static final int LOWER_BOUNDARY_FOR_ZSTD_COMPRESSION = 0;
     private static final int DEFAULT_VALUE_FOR_ZSTD_COMPRESSION = DEFAULT_COMPRESSION_LEVEL;
     private static final int UPPER_BOUNDARY_FOR_ZSTD_COMPRESSION = 20;
+    // Archiving defaults
+    private static final boolean DEFAULT_ARCHIVE_ENABLED = true;
+    private static final int DEFAULT_ARCHIVE_BATCH_SIZE = 1000;
 
     @AfterEach
     void tearDown() {
@@ -67,8 +70,14 @@ class PersistenceStorageConfigTest {
     @ParameterizedTest
     @MethodSource("storageTypes")
     void testPersistenceStorageConfigStorageTypes(final StorageType storageType) {
-        final PersistenceStorageConfig actual =
-                new PersistenceStorageConfig("", "", storageType, CompressionType.NONE, DEFAULT_COMPRESSION_LEVEL);
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                "",
+                "",
+                storageType,
+                CompressionType.NONE,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_ENABLED,
+                DEFAULT_ARCHIVE_BATCH_SIZE);
         assertThat(actual).returns(storageType, from(PersistenceStorageConfig::type));
     }
 
@@ -94,7 +103,9 @@ class PersistenceStorageConfigTest {
                 archiveRootPathToTest,
                 StorageType.BLOCK_AS_LOCAL_FILE,
                 CompressionType.NONE,
-                DEFAULT_COMPRESSION_LEVEL);
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_ENABLED,
+                DEFAULT_ARCHIVE_BATCH_SIZE);
         assertThat(actual)
                 .returns(expectedLiveRootPathToTest, from(PersistenceStorageConfig::liveRootPath))
                 .returns(expectedArchiveRootPathToTest, from(PersistenceStorageConfig::archiveRootPath));
@@ -120,7 +131,9 @@ class PersistenceStorageConfigTest {
                         invalidArchiveRootPathToTest,
                         StorageType.BLOCK_AS_LOCAL_FILE,
                         CompressionType.NONE,
-                        DEFAULT_COMPRESSION_LEVEL));
+                        DEFAULT_COMPRESSION_LEVEL,
+                        DEFAULT_ARCHIVE_ENABLED,
+                        DEFAULT_ARCHIVE_BATCH_SIZE));
     }
 
     /**
@@ -134,7 +147,13 @@ class PersistenceStorageConfigTest {
     void testPersistenceStorageConfigValidCompressionLevel(
             final CompressionType compressionType, final int compressionLevel) {
         final PersistenceStorageConfig actual = new PersistenceStorageConfig(
-                "", "", StorageType.BLOCK_AS_LOCAL_FILE, compressionType, compressionLevel);
+                "",
+                "",
+                StorageType.BLOCK_AS_LOCAL_FILE,
+                compressionType,
+                compressionLevel,
+                DEFAULT_ARCHIVE_ENABLED,
+                DEFAULT_ARCHIVE_BATCH_SIZE);
         assertThat(actual).returns(compressionLevel, from(PersistenceStorageConfig::compressionLevel));
     }
 
@@ -151,7 +170,13 @@ class PersistenceStorageConfigTest {
             final CompressionType compressionType, final int compressionLevel) {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new PersistenceStorageConfig(
-                        "", "", StorageType.BLOCK_AS_LOCAL_FILE, compressionType, compressionLevel));
+                        "",
+                        "",
+                        StorageType.BLOCK_AS_LOCAL_FILE,
+                        compressionType,
+                        compressionLevel,
+                        DEFAULT_ARCHIVE_ENABLED,
+                        DEFAULT_ARCHIVE_BATCH_SIZE));
     }
 
     /**
@@ -163,8 +188,14 @@ class PersistenceStorageConfigTest {
     @ParameterizedTest
     @MethodSource("compressionTypes")
     void testPersistenceStorageConfigCompressionTypes(final CompressionType compressionType) {
-        final PersistenceStorageConfig actual =
-                new PersistenceStorageConfig("", "", StorageType.NO_OP, compressionType, DEFAULT_COMPRESSION_LEVEL);
+        final PersistenceStorageConfig actual = new PersistenceStorageConfig(
+                "",
+                "",
+                StorageType.NO_OP,
+                compressionType,
+                DEFAULT_COMPRESSION_LEVEL,
+                DEFAULT_ARCHIVE_ENABLED,
+                DEFAULT_ARCHIVE_BATCH_SIZE);
         assertThat(actual).returns(compressionType, from(PersistenceStorageConfig::compression));
     }
 

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/compression/NoOpCompressionTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/compression/NoOpCompressionTest.java
@@ -3,6 +3,7 @@ package com.hedera.block.server.persistence.storage.compression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -72,9 +73,9 @@ class NoOpCompressionTest {
 
     /**
      * This test aims to verify that the
-     * {@link NoOpCompression#wrap(InputStream)} correctly wraps a valid
-     * provided {@link InputStream} and reads the test data from it`s
-     * destination as it is provided, no decompression is done.
+     * {@link Compression#wrap(InputStream, com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType)}
+     * correctly wraps a valid provided {@link InputStream} and reads the test
+     * data from it`s destination as it is provided, no decompression is done.
      *
      * @param testData parameterized, test data
      * @throws IOException if an I/O exception occurs
@@ -95,7 +96,7 @@ class NoOpCompressionTest {
 
         // read data
         final byte[] actual;
-        try (final InputStream in = toTest.wrap(Files.newInputStream(toRead))) {
+        try (final InputStream in = toTest.wrap(Files.newInputStream(toRead), CompressionType.NONE)) {
             actual = in.readAllBytes();
         }
         assertThat(actual).isNotNull().isEqualTo(expected);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/compression/ZstdCompressionTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/compression/ZstdCompressionTest.java
@@ -8,6 +8,7 @@ import com.github.luben.zstd.ZstdOutputStream;
 import com.hedera.block.common.utils.FileUtilities;
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.persistence.storage.PersistenceStorageConfig;
+import com.hedera.block.server.persistence.storage.PersistenceStorageConfig.CompressionType;
 import com.hedera.block.server.util.TestConfigUtil;
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,9 +91,10 @@ class ZstdCompressionTest {
 
     /**
      * This test aims to verify that the
-     * {@link ZstdCompression#wrap(InputStream)} correctly wraps a valid
-     * provided {@link InputStream} and reads the test data from it`s
-     * destination but decompresses it using the Zstandard compression algorithm.
+     * {@link Compression#wrap(InputStream, PersistenceStorageConfig.CompressionType)}
+     * correctly wraps a valid provided {@link InputStream} and reads the test
+     * data from it`s destination but decompresses it using the Zstandard
+     * compression algorithm.
      *
      * @param testData parameterized, test data
      * @throws IOException if an I/O exception occurs
@@ -113,7 +115,7 @@ class ZstdCompressionTest {
 
         // read data
         final byte[] actual;
-        try (final InputStream in = toTest.wrap(Files.newInputStream(toRead))) {
+        try (final InputStream in = toTest.wrap(Files.newInputStream(toRead), CompressionType.ZSTD)) {
             actual = in.readAllBytes();
         }
         assertThat(actual).isNotNull().isEqualTo(expected);

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/path/NoOpBlockPathResolverTest.java
@@ -40,24 +40,7 @@ class NoOpBlockPathResolverTest {
 
     /**
      * This test aims to verify that the
-     * {@link NoOpBlockPathResolver#resolveArchiveRawPathToBlock(long)} correctly resolves
-     * the path to a block by a given number. The no-op resolver does nothing,
-     * always returns a path resolved under '/tmp' based on the blockNumber and
-     * has no preconditions check. E.g. for blockNumber 0, the resolved path is
-     * '/tmp/hashgraph/blocknode/data/0.tmp.blk'.
-     *
-     * @param toResolve parameterized, block number
-     */
-    @ParameterizedTest
-    @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
-    void testSuccessfulArchiveRawPathResolution(final long toResolve, final Path expected) {
-        final Path actual = toTest.resolveArchiveRawPathToBlock(toResolve);
-        assertThat(actual).isNotNull().isAbsolute().isEqualByComparingTo(expected);
-    }
-
-    /**
-     * This test aims to verify that the
-     * {@link NoOpBlockPathResolver#findBlock(long)} always returns an empty
+     * {@link NoOpBlockPathResolver#findLiveBlock(long)}  always returns an empty
      * optional.
      *
      * @param toResolve parameterized, block number
@@ -65,7 +48,7 @@ class NoOpBlockPathResolverTest {
     @ParameterizedTest
     @MethodSource({"validBlockNumbers", "invalidBlockNumbers"})
     void testSuccessfulFindBlock(final long toResolve) {
-        assertThat(toTest.findBlock(toResolve)).isNotNull().isEmpty();
+        assertThat(toTest.findLiveBlock(toResolve)).isNotNull().isEmpty();
     }
 
     /**

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/read/BlockAsLocalFileReaderTest.java
@@ -66,8 +66,8 @@ class BlockAsLocalFileReaderTest {
 
         final BlockAsLocalFilePathResolver blockAsLocalFileResolverMock =
                 spy(BlockAsLocalFilePathResolver.of(testConfig));
-        blockAsLocalFileWriterMock =
-                spy(BlockAsLocalFileWriter.of(blockNodeContext, blockAsLocalFileResolverMock, compressionMock));
+        blockAsLocalFileWriterMock = spy(
+                BlockAsLocalFileWriter.of(testConfig, blockNodeContext, blockAsLocalFileResolverMock, compressionMock));
         toTest = BlockAsLocalFileReader.of(compressionMock, blockAsLocalFileResolverMock);
     }
 

--- a/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriterTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/storage/write/BlockAsLocalFileWriterTest.java
@@ -67,7 +67,7 @@ class BlockAsLocalFileWriterTest {
 
         ackHandlerMock = mock(AckHandler.class);
 
-        toTest = BlockAsLocalFileWriter.of(blockNodeContext, pathResolverMock, compressionMock);
+        toTest = BlockAsLocalFileWriter.of(testConfig, blockNodeContext, pathResolverMock, compressionMock);
     }
 
     /**


### PR DESCRIPTION
**Description**:

- add block archiving support

**Related issue(s)**:

Fixes #339 #351

**Notes for reviewer**:

- see #339 for the description of the archiving algorithm
- this is v1 of archiving, it is made to wire the logic and explore setbacks and considerations which need to be taken into account
- while developing this, there are multiple considerations already captured, mainly we will switch to a task based implementation. In fact that was the initial idea, however there were way to many unknowns due to the complexity of the archiving algorithm in general and how to handle edge cases, like what would happen if we have task based implementation and some task fails, it will be stateless, so the archive will be missed, also what would happen if group size changes for a root that is already created and worked with x group size. Doing this simpler and somewhat naive implementation allows for the algorithm to be seen in action and to be able to recognize how it can be made task based and how the considerations that come up can be solved. In a way this v1 can be considered as a prototype (predecessor) to the actual archiving component, rather a real v1.
- all pending items are captured with `todo`s, the implementation will be immediately addressed in #517 
- there are not tests because implementation will change with #517 which would require to change tests also
