### PR TITLE
fix: Cherry pick release notes fix

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -4,7 +4,7 @@ changelog:
     labels: ["wontfix", "question", "duplicate", "invalid"]
   categories:
     - title: "⭐ New Features"
-      labels: ["feature"]
+      labels: ["New Feature"]
     - title: "🚀 Enhancements"
       labels: ["Feature Enhancement"]
     - title: "🐛 Bug Fixes"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,50 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
 changelog:
   exclude:
-    labels: ['wontfix', 'question', 'duplicate', 'invalid']
+    labels: ["wontfix", "question", "duplicate", "invalid"]
   categories:
-    - title: '🚀 Enhancements'
-      labels: ['Feature Enhancement', 'New Feature']
-    - title: '🐛 Bug Fixes'
-      labels: ['Bug']
-    - title: '🔨 Tests'
-      labels: ['Tests']
-    - title: '📝 Documentation'
-      labels: ['Documentation', 'Design']
-    - title: '🔒 Security'
-      labels: ['Security']
-    - title: '🔧 Improvements'
-      labels: ['Improvement']
-    - title: '🔥 Breaking Changes'
-      labels: ['Breaking Change']
-    - title: '⬆️ Dependency Upgrades'
-      labels: ['dependencies']
-  sort: 'desc'
+    - title: "⭐ New Features"
+      labels: ["feature"]
+    - title: "🚀 Enhancements"
+      labels: ["Feature Enhancement"]
+    - title: "🐛 Bug Fixes"
+      labels: ["Bug"]
+    - title: "🔨 Tests"
+      labels: ["Tests"]
+    - title: "📝 Documentation"
+      labels: ["Documentation", "Design"]
+    - title: "🔒 Security"
+      labels: ["Security"]
+    - title: "🔧 Improvements"
+      labels: ["Improvement"]
+    - title: "🔥 Breaking Changes"
+      labels: ["Breaking Change"]
+    - title: "⬆️ Dependency Upgrades"
+      labels: ["dependencies"]
+  sort: "desc"
   transformers:
-    - pattern: '^feat: (.*)$'
-      target: 'Feature: $1'
-    - pattern: '^fix: (.*)$'
-      target: 'Fix: $1'
-    - pattern: '^docs: (.*)$'
-      target: 'Docs: $1'
-    - pattern: '^style: (.*)$'
-      target: 'Style: $1'
-    - pattern: '^refactor: (.*)$'
-      target: 'Refactor: $1'
-    - pattern: '^perf: (.*)$'
-      target: 'Performance: $1'
-    - pattern: '^test: (.*)$'
-      target: 'Test: $1'
-    - pattern: '^chore: (.*)$'
-      target: 'Chore: $1'
-    - pattern: '^revert: (.*)$'
-      target: 'Revert: $1'
-    - pattern: '^security: (.*)$'
-      target: 'Security: $1'
-    - pattern: '^build: (.*)$'
-      target: 'Build: $1'
-    - pattern: '^ci: (.*)$'
-      target: 'CI: $1'
+    - pattern: "^feat: (.*)$"
+      target: "Feature: $1"
+    - pattern: "^fix: (.*)$"
+      target: "Fix: $1"
+    - pattern: "^docs: (.*)$"
+      target: "Docs: $1"
+    - pattern: "^style: (.*)$"
+      target: "Style: $1"
+    - pattern: "^refactor: (.*)$"
+      target: "Refactor: $1"
+    - pattern: "^perf: (.*)$"
+      target: "Performance: $1"
+    - pattern: "^test: (.*)$"
+      target: "Test: $1"
+    - pattern: "^chore: (.*)$"
+      target: "Chore: $1"
+    - pattern: "^revert: (.*)$"
+      target: "Revert: $1"
+    - pattern: "^security: (.*)$"
+      target: "Security: $1"
+    - pattern: "^build: (.*)$"
+      target: "Build: $1"
+    - pattern: "^ci: (.*)$"
+      target: "CI: $1"
   template: |
     # $RELEASE_TITLE
 
@@ -54,7 +56,7 @@ changelog:
 
     $CHANGES
 
-    ## 👥 Contributors
+    ## ❤️ Contributors
 
     $CONTRIBUTORS
 

--- a/.github/workflows/release-automation.yaml
+++ b/.github/workflows/release-automation.yaml
@@ -115,17 +115,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
-      - name: Create Release Notes
-        if: ${{ steps.milestone.outputs.milestone_id != '' }}
-        uses: step-security/release-notes-generator-action@d7cdbb310d4aab8d98f273f4ae20fdd7cb055799 # v3.1.6
-        env:
-          FILENAME: ${{ env.RELEASE_NOTES_FILENAME }}
-          GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
-          MILESTONE_NUMBER: ${{ steps.milestone.outputs.milestone_id }}
-
-      - name: Spotless Apply (release_notes.md stylefix)
-        run: ./gradlew spotlessApply
-
       - name: Commit and Tag
         uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
         with:
@@ -139,9 +128,10 @@ jobs:
       - name: Create Github Release
         uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87 # v1.15.0
         with:
-          bodyFile: ${{ env.RELEASE_NOTES_FILENAME }}.md
+          allowUpdates: true
           commit: ${{ env.RELEASE_BRANCH }}
           draft: ${{ steps.version_parser.outputs.prerelease == '' }}
+          generateReleaseNotes: true
           name: ${{ env.RELEASE_TAG }}
           omitBody: ${{ steps.milestone.outputs.milestone_id == '' }}
           prerelease: ${{ steps.version_parser.outputs.prerelease != '' }}


### PR DESCRIPTION
**Description**:
Cherry-pick of #506 

removing the generate notes step, since it was creating a release_notes.md, that failed spotless check, but also not using the release.yaml template that the github repo is using to auto-generate notes. So the output was not the desired one.

Since task Create Github Release can also generateReleaseNotes, we are using that one, so we have a unified template and way for auto-generation of release notes.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
