### PR TITLE
refactor: Move Hasher to `common` sub-project

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.module.library") }
+plugins {
+    id("org.hiero.gradle.module.library")
+    id("application")
+}
 
 description = "Commons module with logic that could be abstracted and reused."
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins {
-    id("org.hiero.gradle.module.library")
-}
+plugins { id("org.hiero.gradle.module.library") }
 
 description = "Commons module with logic that could be abstracted and reused."
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.module.library")
-    id("application")
 }
 
 description = "Commons module with logic that could be abstracted and reused."

--- a/common/src/main/java/com/hedera/block/common/hasher/ConcurrentStreamingTreeHasher.java
+++ b/common/src/main/java/com/hedera/block/common/hasher/ConcurrentStreamingTreeHasher.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
-import static com.hedera.block.server.verification.hasher.HashingUtilities.noThrowSha384HashOf;
+import static com.hedera.block.common.hasher.HashingUtilities.noThrowSha384HashOf;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.block.common.utils.Preconditions;

--- a/common/src/main/java/com/hedera/block/common/hasher/Hashes.java
+++ b/common/src/main/java/com/hedera/block/common/hasher/Hashes.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.ByteBuffer;

--- a/common/src/main/java/com/hedera/block/common/hasher/HashingUtilities.java
+++ b/common/src/main/java/com/hedera/block/common/hasher/HashingUtilities.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.stream.BlockProof;

--- a/common/src/main/java/com/hedera/block/common/hasher/NaiveStreamingTreeHasher.java
+++ b/common/src/main/java/com/hedera/block/common/hasher/NaiveStreamingTreeHasher.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
-import static com.hedera.block.server.verification.hasher.HashingUtilities.noThrowSha384HashOf;
+import static com.hedera.block.common.hasher.HashingUtilities.noThrowSha384HashOf;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;

--- a/common/src/main/java/com/hedera/block/common/hasher/StreamingTreeHasher.java
+++ b/common/src/main/java/com/hedera/block/common/hasher/StreamingTreeHasher.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.crypto.DigestType;

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -2,6 +2,10 @@
 module com.hedera.block.common {
     exports com.hedera.block.common.constants;
     exports com.hedera.block.common.utils;
+    exports com.hedera.block.common.hasher;
 
+    requires com.hedera.block.stream;
+    requires com.hedera.pbj.runtime;
+    requires com.swirlds.common;
     requires static com.github.spotbugs.annotations;
 }

--- a/common/src/main/java/module-info.java
+++ b/common/src/main/java/module-info.java
@@ -4,8 +4,8 @@ module com.hedera.block.common {
     exports com.hedera.block.common.utils;
     exports com.hedera.block.common.hasher;
 
-    requires com.hedera.block.stream;
-    requires com.hedera.pbj.runtime;
+    requires transitive com.hedera.block.stream;
+    requires transitive com.hedera.pbj.runtime;
     requires com.swirlds.common;
     requires static com.github.spotbugs.annotations;
 }

--- a/common/src/test/java/com/hedera/block/common/hasher/ConcurrentStreamingTreeHasherTest.java
+++ b/common/src/test/java/com/hedera/block/common/hasher/ConcurrentStreamingTreeHasherTest.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.block.server.verification.hasher;
+package com.hedera.block.common.hasher;
 
-import static com.hedera.block.server.verification.hasher.ConcurrentStreamingTreeHasher.rootHashFrom;
-import static com.hedera.block.server.verification.hasher.StreamingTreeHasher.HASH_LENGTH;
+import static com.hedera.block.common.hasher.ConcurrentStreamingTreeHasher.rootHashFrom;
+import static com.hedera.block.common.hasher.StreamingTreeHasher.HASH_LENGTH;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,12 +12,9 @@ import java.nio.ByteBuffer;
 import java.util.SplittableRandom;
 import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class ConcurrentStreamingTreeHasherTest {
     private static final SplittableRandom RANDOM = new SplittableRandom();
 

--- a/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionAsync.java
+++ b/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionAsync.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.verification.session;
 
+import com.hedera.block.common.hasher.ConcurrentStreamingTreeHasher;
 import com.hedera.block.server.metrics.MetricsService;
-import com.hedera.block.server.verification.hasher.ConcurrentStreamingTreeHasher;
 import com.hedera.block.server.verification.signature.SignatureVerifier;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.stream.output.BlockHeader;

--- a/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionBase.java
+++ b/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionBase.java
@@ -3,13 +3,13 @@ package com.hedera.block.server.verification.session;
 
 import static java.lang.System.Logger.Level.INFO;
 
+import com.hedera.block.common.hasher.Hashes;
+import com.hedera.block.common.hasher.HashingUtilities;
+import com.hedera.block.common.hasher.StreamingTreeHasher;
 import com.hedera.block.server.metrics.BlockNodeMetricTypes;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.verification.BlockVerificationStatus;
 import com.hedera.block.server.verification.VerificationResult;
-import com.hedera.block.server.verification.hasher.Hashes;
-import com.hedera.block.server.verification.hasher.HashingUtilities;
-import com.hedera.block.server.verification.hasher.StreamingTreeHasher;
 import com.hedera.block.server.verification.signature.SignatureVerifier;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.stream.BlockProof;

--- a/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionSync.java
+++ b/server/src/main/java/com/hedera/block/server/verification/session/BlockVerificationSessionSync.java
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.verification.session;
 
-import static com.hedera.block.server.verification.hasher.HashingUtilities.getBlockItemHash;
+import static com.hedera.block.common.hasher.HashingUtilities.getBlockItemHash;
 
+import com.hedera.block.common.hasher.NaiveStreamingTreeHasher;
 import com.hedera.block.server.metrics.MetricsService;
-import com.hedera.block.server.verification.hasher.NaiveStreamingTreeHasher;
 import com.hedera.block.server.verification.signature.SignatureVerifier;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.stream.BlockProof;

--- a/server/src/main/java/com/hedera/block/server/verification/signature/SignatureVerifierDummy.java
+++ b/server/src/main/java/com/hedera/block/server/verification/signature/SignatureVerifierDummy.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.verification.signature;
 
-import com.hedera.block.server.verification.hasher.HashingUtilities;
+import com.hedera.block.common.hasher.HashingUtilities;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -25,7 +25,6 @@ module com.hedera.block.server {
     exports com.hedera.block.server.pbj;
     exports com.hedera.block.server.producer;
     exports com.hedera.block.server.verification;
-    exports com.hedera.block.server.verification.hasher;
     exports com.hedera.block.server.verification.session;
     exports com.hedera.block.server.verification.signature;
     exports com.hedera.block.server.verification.service;

--- a/server/src/test/java/com/hedera/block/server/verification/signature/SignatureVerifierDummyTest.java
+++ b/server/src/test/java/com/hedera/block/server/verification/signature/SignatureVerifierDummyTest.java
@@ -3,7 +3,7 @@ package com.hedera.block.server.verification.signature;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.hedera.block.server.verification.hasher.HashingUtilities;
+import com.hedera.block.common.hasher.HashingUtilities;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
**Description**:
This PR only moves the `hasher` subpackage of the `:server` subproject to the `:commons` subproject.

This so on a follow-up PR, we can implement the Generation Mode of the simulator with `valid` block_proof and hashes.

**Related issue(s)**:

Fixes #569

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
