### PR TITLE
fix: issue with handling of `duplicate` and `future` blocks

### DIFF
--- a/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
+++ b/server/src/main/java/com/hedera/block/server/producer/ProducerBlockItemObserver.java
@@ -136,6 +136,7 @@ public class ProducerBlockItemObserver
                             long blockNumber = BlockHeader.PROTOBUF
                                     .parse(Objects.requireNonNull(blockItemUnparsed.blockHeader()))
                                     .number();
+                            serviceStatus.setLatestReceivedBlockNumber(blockNumber);
                             metricsService.get(CurrentBlockNumberInbound).set(blockNumber);
                         } catch (ParseException e) {
                             throw new RuntimeException(e);
@@ -265,6 +266,7 @@ public class ProducerBlockItemObserver
                     nextExpectedBlockNumber);
 
             notifyOfDuplicateBlock(nextBlockNumber);
+            return false;
         }
 
         // future non-immediate block
@@ -278,6 +280,7 @@ public class ProducerBlockItemObserver
                     nextExpectedBlockNumber);
 
             notifyOfFutureBlock(serviceStatus.getLatestAckedBlock().getBlockNumber());
+            return false;
         }
 
         // if block number is neither duplicate nor future (should be the same as expected)

--- a/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
+++ b/server/src/test/java/com/hedera/block/server/pbj/PbjBlockStreamServiceIntegrationTest.java
@@ -679,7 +679,7 @@ public class PbjBlockStreamServiceIntegrationTest {
     private static Bytes buildEndOfStreamResponse() {
         final EndOfStream endOfStream = EndOfStream.newBuilder()
                 .status(PublishStreamResponseCode.STREAM_ITEMS_INTERNAL_ERROR)
-                .blockNumber(0L)
+                .blockNumber(1L)
                 .build();
         return PublishStreamResponse.PROTOBUF.toBytes(
                 PublishStreamResponse.newBuilder().status(endOfStream).build());

--- a/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/producer/ProducerBlockItemObserverTest.java
@@ -192,6 +192,8 @@ public class ProducerBlockItemObserverTest {
 
         // verify helidonPublishPipeline.onNext() is called once with publishStreamResponse
         verify(helidonPublishPipeline, timeout(testTimeout).times(1)).onNext(publishStreamResponse);
+        // verify that the duplicate block is not published
+        verify(publisher, never()).publish(any());
     }
 
     @Test
@@ -222,5 +224,9 @@ public class ProducerBlockItemObserverTest {
 
         // verify helidonPublishPipeline.onNext() is called once with publishStreamResponse
         verify(helidonPublishPipeline, timeout(testTimeout).times(1)).onNext(publishStreamResponse);
+        // verify that .onNext() is called only once.
+        verify(helidonPublishPipeline, timeout(testTimeout).times(1)).onNext(any());
+        // verify that the future block is not published
+        verify(publisher, never()).publish(any());
     }
 }


### PR DESCRIPTION
**Description**:
Today during the demo it was found that there were some issues with the duplicate and future blocks. this was not evident during Unit Test, but when doing a `e2e` test it was found.

This PR fixes it.

**Related issue(s)**:

Fixes #573 

**Notes for reviewer**:
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/48287b0a-31e5-455b-a1bb-111aef4d236e" />

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
