### PR TITLE
fix: ackHandler order responses under edge cases

### DIFF
--- a/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
@@ -109,7 +109,7 @@ public class AckHandlerImpl implements AckHandler {
     private void attemptAcks() {
         // Temporarily if lastAcknowledgedBlockNumber is -1, we get the first block in the map
         if (lastAcknowledgedBlockNumber == -1) {
-            // todo(147): once we have a way to get the last acknowledged block from the store we should use that
+            // @todo(147): once we have a way to get the last acknowledged block from the store we should use that
             lastAcknowledgedBlockNumber = 0;
         }
 

--- a/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/ack/AckHandlerImpl.java
@@ -141,13 +141,12 @@ public class AckHandlerImpl implements AckHandler {
                 // Remove from map if desired (so we don't waste memory)
                 blockInfo.remove(nextBlock);
 
-                // Update metrics
+                // Update metrics and logging
                 metricsService.get(BlockNodeMetricTypes.Counter.AckedBlocked).increment();
+                LOGGER.log(System.Logger.Level.DEBUG, "ACKed block " + nextBlock);
 
                 // Update last acknowledged
                 lastAcknowledgedBlockNumber = nextBlock;
-
-                LOGGER.log(System.Logger.Level.DEBUG, "ACKed block " + nextBlock);
             } else {
                 // Someone else already ACKed this block.
                 // Stop, as we can't ACK the next block until this one is ACKed.

--- a/server/src/test/java/com/hedera/block/server/manager/AckHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/manager/AckHandlerImplTest.java
@@ -292,7 +292,7 @@ class AckHandlerImplTest {
             try {
                 startLatch.await();
                 for (int i = 1; i <= blockCount; i++) {
-                    ackHandler.blockPersisted(i);
+                    ackHandler.blockPersisted(new BlockPersistenceResult(i, BlockPersistenceStatus.SUCCESS));
                     if (maxPersistDelayNanos > 0) {
                         long delay = random.nextInt(maxPersistDelayNanos + 1);
                         TimeUnit.NANOSECONDS.sleep(delay);


### PR DESCRIPTION
## Reviewer Notes

This PR adds test that helped replicate edge cases when acks were sent out of order.
either due to the workaround to determine the first valid block (where to start sending acks) or
due to random delays occur in either `persistence` or `verification` threads.


Also this PR includes the fixes so those tests always pass instead of always failing or sometimes failing.

Fixes #638

**Before:**
![image](https://github.com/user-attachments/assets/7e3b0448-0bfd-443d-8ee5-cca48fefd1e7)

**After:** Under the same conditions, same result in multiple passes.
![image](https://github.com/user-attachments/assets/3b810f6d-5d3e-44e7-a761-8c39bd327515)

## Related Issue(s)
