### PR TITLE
refactor: changed to batches of block items unparsed

### DIFF
--- a/server/src/main/java/com/hedera/block/server/consumer/AsyncConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/AsyncConsumerStreamResponseObserver.java
@@ -56,11 +56,6 @@ class AsyncConsumerStreamResponseObserver implements BlockNodeEventHandler<Objec
     @Override
     public void onEvent(@NonNull final ObjectEvent<List<BlockItemUnparsed>> event, final long l, final boolean b) {
 
-        if (event.get() == null) {
-            LOGGER.log(ERROR, "BlockItems list is null.");
-            return;
-        }
-
         try {
             completionService.submit(new ProcessOutboundEvent(event, l, b, nextBlockNodeEventHandler));
 

--- a/server/src/main/java/com/hedera/block/server/consumer/AsyncConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/AsyncConsumerStreamResponseObserver.java
@@ -8,10 +8,11 @@ import com.hedera.block.server.consumer.Functions.ProcessOutboundEvent;
 import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.mediator.SubscriptionHandler;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.UncheckedIOException;
 import java.lang.System.Logger;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -22,14 +23,13 @@ import java.util.concurrent.Future;
  * RingBuffer worker threads from the consumer processing required to send each
  * response to a downstream consumer.
  */
-class AsyncConsumerStreamResponseObserver
-        implements BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> {
+class AsyncConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> {
 
     private static final Logger LOGGER = System.getLogger(ProcessOutboundEvent.class.getName());
 
-    private final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler;
+    private final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler;
     private final CompletionService<Void> completionService;
-    private final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> nextBlockNodeEventHandler;
+    private final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> nextBlockNodeEventHandler;
 
     /**
      * Constructor for the AsyncConsumerStreamResponseObserver class.
@@ -40,8 +40,8 @@ class AsyncConsumerStreamResponseObserver
     // spotless:off
     public AsyncConsumerStreamResponseObserver(
             @NonNull final CompletionService<Void> completionService,
-            @NonNull final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler,
-            @NonNull final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>>
+            @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
+            @NonNull final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>>
                             nextBlockNodeEventHandler) {
 
         this.completionService = Objects.requireNonNull(completionService);
@@ -54,8 +54,12 @@ class AsyncConsumerStreamResponseObserver
      * {@inheritDoc}
      */
     @Override
-    public void onEvent(
-            @NonNull final ObjectEvent<SubscribeStreamResponseUnparsed> event, final long l, final boolean b) {
+    public void onEvent(@NonNull final ObjectEvent<List<BlockItemUnparsed>> event, final long l, final boolean b) {
+
+        if (event.get() == null) {
+            LOGGER.log(ERROR, "BlockItems list is null.");
+            return;
+        }
 
         try {
             completionService.submit(new ProcessOutboundEvent(event, l, b, nextBlockNodeEventHandler));

--- a/server/src/main/java/com/hedera/block/server/consumer/ClosedRangeHistoricStreamEventHandlerBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ClosedRangeHistoricStreamEventHandlerBuilder.java
@@ -35,14 +35,7 @@ public final class ClosedRangeHistoricStreamEventHandlerBuilder {
             @NonNull final MetricsService metricsService,
             @NonNull final Configuration configuration) {
 
-        final var consumerStreamResponseObserver =
-                new ConsumerStreamResponseObserver(helidonConsumerObserver, metricsService);
         return new HistoricBlockStreamSupplier(
-                startBlockNumber,
-                endBlockNumber,
-                blockReader,
-                consumerStreamResponseObserver,
-                metricsService,
-                configuration);
+                startBlockNumber, endBlockNumber, blockReader, helidonConsumerObserver, metricsService, configuration);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -88,11 +88,6 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
     public void onEvent(@NonNull final ObjectEvent<List<BlockItemUnparsed>> event, final long l, final boolean b)
             throws ParseException {
 
-        if (event.get() == null) {
-            LOGGER.log(ERROR, "BlockItems list is null.");
-            return;
-        }
-
         // Only send the response if the consumer has not cancelled
         // or closed the stream.
         if (isResponsePermitted.get()) {

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -141,8 +141,7 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
             throw new IllegalArgumentException(message);
         }
 
-        final List<BlockItemUnparsed> blockItems =
-                Objects.requireNonNull(subscribeStreamResponse.blockItems()).blockItems();
+        final List<BlockItemUnparsed> blockItems = subscribeStreamResponse.blockItems().blockItems();
 
         // Only start sending BlockItems after we've reached
         // the beginning of a block.
@@ -154,7 +153,7 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
         if (streamStarted) {
             if (firstBlockItem.hasBlockHeader()) {
                 long blockNumber = BlockHeader.PROTOBUF
-                        .parse(Objects.requireNonNull(firstBlockItem.blockHeader()))
+                        .parse(firstBlockItem.blockHeader())
                         .number();
                 if (LOGGER.isLoggable(DEBUG)) {
                     LOGGER.log(DEBUG, "{0} sending block: {1}", Thread.currentThread(), blockNumber);

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -141,7 +141,8 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
             throw new IllegalArgumentException(message);
         }
 
-        final List<BlockItemUnparsed> blockItems = subscribeStreamResponse.blockItems().blockItems();
+        final List<BlockItemUnparsed> blockItems =
+                subscribeStreamResponse.blockItems().blockItems();
 
         // Only start sending BlockItems after we've reached
         // the beginning of a block.
@@ -152,9 +153,8 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
 
         if (streamStarted) {
             if (firstBlockItem.hasBlockHeader()) {
-                long blockNumber = BlockHeader.PROTOBUF
-                        .parse(firstBlockItem.blockHeader())
-                        .number();
+                long blockNumber =
+                        BlockHeader.PROTOBUF.parse(firstBlockItem.blockHeader()).number();
                 if (LOGGER.isLoggable(DEBUG)) {
                     LOGGER.log(DEBUG, "{0} sending block: {1}", Thread.currentThread(), blockNumber);
                 }

--- a/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserver.java
@@ -11,10 +11,10 @@ import com.hedera.block.server.events.LivenessCalculator;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.metrics.BlockNodeMetricTypes;
 import com.hedera.block.server.metrics.MetricsService;
+import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.hapi.block.stream.output.BlockHeader;
-import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.swirlds.config.api.Configuration;
@@ -30,22 +30,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * by Helidon). The ConsumerBlockItemObserver implements the BlockNodeEventHandler interface so the
  * Disruptor can invoke the onEvent() method when a new SubscribeStreamResponse is available.
  */
-class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> {
+class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> {
 
     private final Logger LOGGER = System.getLogger(getClass().getName());
 
     private final MetricsService metricsService;
     private final Pipeline<? super SubscribeStreamResponseUnparsed> helidonConsumerObserver;
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> prevSubscriptionHandler;
+    private BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> prevSubscriptionHandler;
 
     private final AtomicBoolean isResponsePermitted = new AtomicBoolean(true);
-    private final ResponseSender statusResponseSender = new StatusResponseSender();
-    private final ResponseSender blockItemsResponseSender = new BlockItemsResponseSender();
 
     private static final String PROTOCOL_VIOLATION_MESSAGE =
             "Protocol Violation. %s is OneOf type %s but %s is null.\n%s";
 
     private final LivenessCalculator livenessCalculator;
+
+    private boolean streamStarted = false;
 
     /**
      * Constructor for the ConsumerStreamResponseObserver class. It is responsible for observing the
@@ -74,24 +74,6 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
     }
 
     /**
-     * Constructor for the ConsumerStreamResponseObserver class. It is responsible for observing the
-     * SubscribeStreamResponse events from the Disruptor and passing them to the downstream consumer
-     * via the subscribeStreamResponseObserver. Use this constructor when the producer liveness is not
-     * required.
-     *
-     * @param helidonConsumerObserver the observer to use to send responses to the consumer
-     * @param metricsService - the service responsible for handling metrics
-     */
-    public ConsumerStreamResponseObserver(
-            @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> helidonConsumerObserver,
-            @NonNull final MetricsService metricsService) {
-
-        this.livenessCalculator = null;
-        this.metricsService = Objects.requireNonNull(metricsService);
-        this.helidonConsumerObserver = Objects.requireNonNull(helidonConsumerObserver);
-    }
-
-    /**
      * The onEvent method is invoked by the Disruptor when a new SubscribeStreamResponse is
      * available. Before sending the response to the downstream consumer, the method checks the
      * producer liveness and unsubscribes the observer if the producer activity is outside the
@@ -103,9 +85,13 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
      * @param b true if the event is the last in the sequence
      */
     @Override
-    public void onEvent(
-            @NonNull final ObjectEvent<SubscribeStreamResponseUnparsed> event, final long l, final boolean b)
+    public void onEvent(@NonNull final ObjectEvent<List<BlockItemUnparsed>> event, final long l, final boolean b)
             throws ParseException {
+
+        if (event.get() == null) {
+            LOGGER.log(ERROR, "BlockItems list is null.");
+            return;
+        }
 
         // Only send the response if the consumer has not cancelled
         // or closed the stream.
@@ -121,9 +107,14 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
                 // Refresh the producer liveness and pass the BlockItem to the downstream observer.
                 refreshLiveness();
 
-                final SubscribeStreamResponseUnparsed subscribeStreamResponse = event.get();
-                final ResponseSender responseSender = getResponseSender(subscribeStreamResponse);
-                responseSender.send(subscribeStreamResponse);
+                final SubscribeStreamResponseUnparsed subscribeStreamResponse =
+                        SubscribeStreamResponseUnparsed.newBuilder()
+                                .blockItems(BlockItemSetUnparsed.newBuilder()
+                                        .blockItems(event.get())
+                                        .build())
+                                .build();
+
+                send(subscribeStreamResponse);
             }
         }
     }
@@ -146,81 +137,42 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
         }
     }
 
-    @NonNull
-    private ResponseSender getResponseSender(@NonNull final SubscribeStreamResponseUnparsed subscribeStreamResponse) {
+    public void send(@NonNull final SubscribeStreamResponseUnparsed subscribeStreamResponse) throws ParseException {
 
-        final OneOf<SubscribeStreamResponseUnparsed.ResponseOneOfType> responseType =
-                subscribeStreamResponse.response();
-        return switch (responseType.kind()) {
-            case STATUS -> {
-                // Per the spec, status messages signal
-                // the end of processing. Unsubscribe this
-                // observer and send a message back to the
-                // client
-                unsubscribe();
-                yield statusResponseSender;
-            }
-            case BLOCK_ITEMS -> blockItemsResponseSender;
-                // An unknown response type here is a protocol violation
-                // and should shut down the server.
-            default -> throw new IllegalArgumentException("Unknown response type: " + responseType.kind());
-        };
-    }
-
-    private interface ResponseSender {
-        void send(@NonNull final SubscribeStreamResponseUnparsed subscribeStreamResponse) throws ParseException;
-    }
-
-    private final class BlockItemsResponseSender implements ResponseSender {
-        private boolean streamStarted = false;
-
-        public void send(@NonNull final SubscribeStreamResponseUnparsed subscribeStreamResponse) throws ParseException {
-
-            if (subscribeStreamResponse.blockItems() == null) {
-                final String message = PROTOCOL_VIOLATION_MESSAGE.formatted(
-                        "SubscribeStreamResponse", "BLOCK_ITEMS", "block_items", subscribeStreamResponse);
-                LOGGER.log(ERROR, message);
-                throw new IllegalArgumentException(message);
-            }
-
-            final List<BlockItemUnparsed> blockItems =
-                    Objects.requireNonNull(subscribeStreamResponse.blockItems()).blockItems();
-
-            // Only start sending BlockItems after we've reached
-            // the beginning of a block.
-            final BlockItemUnparsed firstBlockItem = blockItems.getFirst();
-            if (!streamStarted && firstBlockItem.hasBlockHeader()) {
-                streamStarted = true;
-            }
-
-            if (streamStarted) {
-                if (firstBlockItem.hasBlockHeader()) {
-                    long blockNumber = BlockHeader.PROTOBUF
-                            .parse(Objects.requireNonNull(firstBlockItem.blockHeader()))
-                            .number();
-                    if (LOGGER.isLoggable(DEBUG)) {
-                        LOGGER.log(DEBUG, "{0} sending block: {1}", Thread.currentThread(), blockNumber);
-                    }
-                    metricsService.get(CurrentBlockNumberOutbound).set(blockNumber);
-                }
-
-                metricsService
-                        .get(BlockNodeMetricTypes.Counter.LiveBlockItemsConsumed)
-                        .add(blockItems.size());
-
-                // Send the response down through Helidon
-                helidonConsumerObserver.onNext(subscribeStreamResponse);
-            }
+        if (subscribeStreamResponse.blockItems() == null) {
+            final String message = PROTOCOL_VIOLATION_MESSAGE.formatted(
+                    "SubscribeStreamResponse", "BLOCK_ITEMS", "block_items", subscribeStreamResponse);
+            LOGGER.log(ERROR, message);
+            throw new IllegalArgumentException(message);
         }
-    }
 
-    // TODO: Implement another StatusResponseSender that will unsubscribe the observer once the
-    // status code is fixed.
-    private final class StatusResponseSender implements ResponseSender {
-        public void send(@NonNull final SubscribeStreamResponseUnparsed subscribeStreamResponse) {
-            LOGGER.log(DEBUG, "Sending SubscribeStreamResponse downstream: " + subscribeStreamResponse);
+        final List<BlockItemUnparsed> blockItems =
+                Objects.requireNonNull(subscribeStreamResponse.blockItems()).blockItems();
+
+        // Only start sending BlockItems after we've reached
+        // the beginning of a block.
+        final BlockItemUnparsed firstBlockItem = blockItems.getFirst();
+        if (!streamStarted && firstBlockItem.hasBlockHeader()) {
+            streamStarted = true;
+        }
+
+        if (streamStarted) {
+            if (firstBlockItem.hasBlockHeader()) {
+                long blockNumber = BlockHeader.PROTOBUF
+                        .parse(Objects.requireNonNull(firstBlockItem.blockHeader()))
+                        .number();
+                if (LOGGER.isLoggable(DEBUG)) {
+                    LOGGER.log(DEBUG, "{0} sending block: {1}", Thread.currentThread(), blockNumber);
+                }
+                metricsService.get(CurrentBlockNumberOutbound).set(blockNumber);
+            }
+
+            metricsService
+                    .get(BlockNodeMetricTypes.Counter.LiveBlockItemsConsumed)
+                    .add(blockItems.size());
+
+            // Send the response down through Helidon
             helidonConsumerObserver.onNext(subscribeStreamResponse);
-            helidonConsumerObserver.onComplete();
         }
     }
 
@@ -235,8 +187,7 @@ class ConsumerStreamResponseObserver implements BlockNodeEventHandler<ObjectEven
     }
 
     public void setPrevSubscriptionHandler(
-            @NonNull
-                    final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> prevSubscriptionHandler) {
+            @NonNull final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> prevSubscriptionHandler) {
         this.prevSubscriptionHandler = Objects.requireNonNull(prevSubscriptionHandler);
     }
 }

--- a/server/src/main/java/com/hedera/block/server/consumer/Functions.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/Functions.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
-import static java.lang.System.Logger.Level.ERROR;
-
 import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.hapi.block.BlockItemUnparsed;
@@ -22,8 +20,6 @@ final class Functions {
      * a consumer.
      */
     static final class ProcessOutboundEvent implements Callable<Void> {
-
-        private static final System.Logger LOGGER = System.getLogger(ProcessOutboundEvent.class.getName());
 
         private final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> nextBlockNodeEventHandler;
         private final ObjectEvent<List<BlockItemUnparsed>> event;
@@ -48,12 +44,7 @@ final class Functions {
          */
         @Override
         public Void call() throws Exception {
-            if (event.get() == null) {
-                LOGGER.log(ERROR, "BlockItems list is null.");
-            } else {
-                nextBlockNodeEventHandler.onEvent(event, l, b);
-            }
-
+            nextBlockNodeEventHandler.onEvent(event, l, b);
             return null;
         }
     }

--- a/server/src/main/java/com/hedera/block/server/consumer/HistoricBlockStreamSupplier.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/HistoricBlockStreamSupplier.java
@@ -7,14 +7,13 @@ import static com.hedera.block.server.pbj.PbjBlockStreamServiceProxy.READ_STREAM
 import static java.lang.System.Logger.Level.ERROR;
 
 import com.hedera.block.common.utils.ChunkUtils;
-import com.hedera.block.server.events.BlockNodeEventHandler;
-import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
 import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
+import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -32,7 +31,7 @@ class HistoricBlockStreamSupplier implements Runnable {
     private final long endBlockNumber;
     private final BlockReader<BlockUnparsed> blockReader;
     private final int maxBlockItemBatchSize;
-    private final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> consumerStreamResponseObserver;
+    private final Pipeline<? super SubscribeStreamResponseUnparsed> helidonConsumerObserver;
     private final MetricsService metricsService;
 
     /**
@@ -41,7 +40,7 @@ class HistoricBlockStreamSupplier implements Runnable {
      * @param startBlockNumber - the start of the requested range of blocks
      * @param endBlockNumber - the end of the requested range of blocks
      * @param blockReader - the block reader to query for blocks
-     * @param consumerStreamResponseObserver - the consumer stream response observer to send the blocks
+     * @param helidonConsumerObserver - the consumer stream response observer to send the blocks
      * @param metricsService - the service responsible for handling metrics
      * @param configuration - the configuration settings for the block node
      */
@@ -49,9 +48,7 @@ class HistoricBlockStreamSupplier implements Runnable {
             long startBlockNumber,
             long endBlockNumber,
             @NonNull final BlockReader<BlockUnparsed> blockReader,
-            @NonNull
-                    final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>>
-                            consumerStreamResponseObserver,
+            @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> helidonConsumerObserver,
             @NonNull final MetricsService metricsService,
             @NonNull final Configuration configuration) {
         this.startBlockNumber = startBlockNumber;
@@ -62,7 +59,7 @@ class HistoricBlockStreamSupplier implements Runnable {
         final ConsumerConfig consumerConfig =
                 Objects.requireNonNull(configuration).getConfigData(ConsumerConfig.class);
         this.maxBlockItemBatchSize = Objects.requireNonNull(consumerConfig).maxBlockItemBatchSize();
-        this.consumerStreamResponseObserver = Objects.requireNonNull(consumerStreamResponseObserver);
+        this.helidonConsumerObserver = Objects.requireNonNull(helidonConsumerObserver);
     }
 
     /**
@@ -105,7 +102,6 @@ class HistoricBlockStreamSupplier implements Runnable {
     }
 
     void sendInBatches(final List<List<BlockItemUnparsed>> blockItems) throws Exception {
-
         for (List<BlockItemUnparsed> blockItemsBatch : blockItems) {
             // Prepare the response
             final var subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
@@ -114,18 +110,13 @@ class HistoricBlockStreamSupplier implements Runnable {
                             .build())
                     .build();
 
-            final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-            event.set(subscribeStreamResponse);
-            consumerStreamResponseObserver.onEvent(event, 0L, false);
+            helidonConsumerObserver.onNext(subscribeStreamResponse);
         }
     }
 
     private void sendReadStreamNotAvailable() {
-        // End of stream failure
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(READ_STREAM_NOT_AVAILABLE);
         try {
-            consumerStreamResponseObserver.onEvent(event, 0L, true);
+            helidonConsumerObserver.onNext(READ_STREAM_NOT_AVAILABLE);
         } catch (Exception e) {
             LOGGER.log(
                     ERROR,
@@ -135,11 +126,9 @@ class HistoricBlockStreamSupplier implements Runnable {
     }
 
     private void sendSuccessResponse() {
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(READ_STREAM_SUCCESS_RESPONSE);
         try {
             // End of stream success
-            consumerStreamResponseObserver.onEvent(event, 0L, true);
+            helidonConsumerObserver.onNext(READ_STREAM_SUCCESS_RESPONSE);
         } catch (Exception e) {
             LOGGER.log(
                     ERROR,

--- a/server/src/main/java/com/hedera/block/server/consumer/LiveStreamEventHandlerBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/consumer/LiveStreamEventHandlerBuilder.java
@@ -5,11 +5,13 @@ import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.mediator.SubscriptionHandler;
 import com.hedera.block.server.metrics.MetricsService;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.InstantSource;
+import java.util.List;
 import java.util.concurrent.CompletionService;
 
 /**
@@ -17,10 +19,10 @@ import java.util.concurrent.CompletionService;
  * streaming block items.
  */
 public final class LiveStreamEventHandlerBuilder {
-    public static BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> build(
+    public static BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> build(
             @NonNull final CompletionService<Void> completionService,
             @NonNull final InstantSource producerLivenessClock,
-            @NonNull final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler,
+            @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
             @NonNull final Pipeline<? super SubscribeStreamResponseUnparsed> observer,
             @NonNull final MetricsService metricsService,
             @NonNull final Configuration configuration) {

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediator.java
@@ -3,7 +3,6 @@ package com.hedera.block.server.mediator;
 
 import com.hedera.block.server.notifier.Notifiable;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import java.util.List;
 
 /**
@@ -11,4 +10,4 @@ import java.util.List;
  * Hedera network with the contract to be notified of critical system events.
  */
 public interface LiveStreamMediator
-        extends StreamMediator<List<BlockItemUnparsed>, SubscribeStreamResponseUnparsed>, Notifiable {}
+        extends StreamMediator<List<BlockItemUnparsed>, List<BlockItemUnparsed>>, Notifiable {}

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorBuilder.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorBuilder.java
@@ -5,9 +5,10 @@ import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.service.ServiceStatus;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import com.lmax.disruptor.BatchEventProcessor;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -25,8 +26,8 @@ public class LiveStreamMediatorBuilder {
     private final ServiceStatus serviceStatus;
 
     private Map<
-                    BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>>,
-                    BatchEventProcessor<ObjectEvent<SubscribeStreamResponseUnparsed>>>
+                    BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>>,
+                    BatchEventProcessor<ObjectEvent<List<BlockItemUnparsed>>>>
             subscribers;
 
     /** The initial capacity of the subscriber map. */
@@ -67,8 +68,8 @@ public class LiveStreamMediatorBuilder {
     public LiveStreamMediatorBuilder subscribers(
             @NonNull
                     final Map<
-                                    BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>>,
-                                    BatchEventProcessor<ObjectEvent<SubscribeStreamResponseUnparsed>>>
+                                    BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>>,
+                                    BatchEventProcessor<ObjectEvent<List<BlockItemUnparsed>>>>
                             subscribers) {
         this.subscribers = subscribers;
         return this;

--- a/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/LiveStreamMediatorImpl.java
@@ -106,9 +106,7 @@ class LiveStreamMediatorImpl extends SubscriptionHandlerBase<List<BlockItemUnpar
 
         LOGGER.log(ERROR, "Sending an error response to end the stream for all consumers.");
 
-        // @todo: Change how we broadcast an end of stream response in the event of an unrecoverable error.
+        // @todo(662): Change how we broadcast an end of stream response in the event of an unrecoverable error.
         // Publish an end of stream response to all downstream consumers
-        //        final SubscribeStreamResponseUnparsed endStreamResponse = buildEndStreamResponse();
-        //        ringBuffer.publishEvent((event, sequence) -> event.set(endStreamResponse));
     }
 }

--- a/server/src/main/java/com/hedera/block/server/mediator/MediatorInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/MediatorInjectionModule.java
@@ -6,11 +6,12 @@ import static com.hedera.block.server.mediator.MediatorConfig.MediatorType.NO_OP
 import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.notifier.Notifiable;
 import com.hedera.block.server.service.ServiceStatus;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import javax.inject.Singleton;
 
 /** A Dagger module for providing dependencies for Mediator Module.` */
@@ -48,7 +49,7 @@ public interface MediatorInjectionModule {
      */
     @Binds
     @Singleton
-    SubscriptionHandler<SubscribeStreamResponseUnparsed> bindSubscriptionHandler(
+    SubscriptionHandler<List<BlockItemUnparsed>> bindSubscriptionHandler(
             @NonNull final LiveStreamMediator liveStreamMediator);
 
     /**

--- a/server/src/main/java/com/hedera/block/server/mediator/NoOpLiveStreamMediator.java
+++ b/server/src/main/java/com/hedera/block/server/mediator/NoOpLiveStreamMediator.java
@@ -9,7 +9,6 @@ import com.hedera.block.server.events.BlockNodeEventHandler;
 import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 
@@ -44,19 +43,19 @@ public class NoOpLiveStreamMediator implements LiveStreamMediator {
      * {@inheritDoc}
      */
     @Override
-    public void subscribe(@NonNull BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> handler) {}
+    public void subscribe(@NonNull BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> handler) {}
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public void unsubscribe(@NonNull BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> handler) {}
+    public void unsubscribe(@NonNull BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> handler) {}
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public boolean isSubscribed(@NonNull BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> handler) {
+    public boolean isSubscribed(@NonNull BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> handler) {
         return false;
     }
 

--- a/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamServiceProxy.java
+++ b/server/src/main/java/com/hedera/block/server/pbj/PbjBlockStreamServiceProxy.java
@@ -92,7 +92,7 @@ public class PbjBlockStreamServiceProxy implements PbjBlockStreamService {
     public PbjBlockStreamServiceProxy(
             @NonNull final LiveStreamMediator streamMediator,
             @NonNull final ServiceStatus serviceStatus,
-            @NonNull final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> streamPersistenceHandler,
+            @NonNull final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamPersistenceHandler,
             @NonNull final StreamVerificationHandlerImpl streamVerificationHandler,
             @NonNull final BlockReader<BlockUnparsed> blockReader,
             @NonNull final Notifier notifier,

--- a/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/PersistenceInjectionModule.java
@@ -26,11 +26,12 @@ import com.hedera.block.server.persistence.storage.write.AsyncBlockAsLocalFileWr
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.persistence.storage.write.AsyncNoOpWriterFactory;
 import com.hedera.block.server.service.ServiceStatus;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import dagger.Module;
 import dagger.Provides;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executors;
 import javax.inject.Singleton;
@@ -153,8 +154,8 @@ public interface PersistenceInjectionModule {
      */
     @Provides
     @Singleton
-    static BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> providesBlockNodeEventHandler(
-            @NonNull final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler,
+    static BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> providesBlockNodeEventHandler(
+            @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
             @NonNull final Notifier notifier,
             @NonNull final BlockNodeContext blockNodeContext,
             @NonNull final ServiceStatus serviceStatus,

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -93,14 +93,9 @@ public class StreamPersistenceHandlerImpl implements BlockNodeEventHandler<Objec
     @Override
     public void onEvent(final ObjectEvent<List<BlockItemUnparsed>> event, long l, boolean b) {
 
-        final List<BlockItemUnparsed> blockItems = event.get();
-        if (blockItems == null) {
-            LOGGER.log(ERROR, "BlockItems list is null.");
-            return;
-        }
-
         try {
             if (serviceStatus.isRunning()) {
+                final List<BlockItemUnparsed> blockItems = event.get();
                 if (blockItems.isEmpty()) {
                     final String message = "BlockItems list is empty.";
                     throw new BlockStreamProtocolException(message);

--- a/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImpl.java
@@ -18,11 +18,8 @@ import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory
 import com.hedera.block.server.persistence.storage.write.BlockPersistenceResult;
 import com.hedera.block.server.persistence.storage.write.BlockPersistenceResult.BlockPersistenceStatus;
 import com.hedera.block.server.service.ServiceStatus;
-import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.hapi.block.stream.output.BlockHeader;
-import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -45,12 +42,9 @@ import javax.inject.Singleton;
  * invoke the onEvent() method when a new SubscribeStreamResponse is available.
  */
 @Singleton
-public class StreamPersistenceHandlerImpl
-        implements BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> {
+public class StreamPersistenceHandlerImpl implements BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> {
     private static final System.Logger LOGGER = System.getLogger(StreamPersistenceHandlerImpl.class.getName());
-    private static final String PROTOCOL_VIOLATION_MESSAGE =
-            "Protocol Violation. %s is OneOf type %s but %s is null.\n%s";
-    private final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler;
+    private final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler;
     private final Notifier notifier;
     private final MetricsService metricsService;
     private final ServiceStatus serviceStatus;
@@ -72,7 +66,7 @@ public class StreamPersistenceHandlerImpl
      */
     @Inject
     public StreamPersistenceHandlerImpl(
-            @NonNull final SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler,
+            @NonNull final SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler,
             @NonNull final Notifier notifier,
             @NonNull final BlockNodeContext blockNodeContext,
             @NonNull final ServiceStatus serviceStatus,
@@ -97,38 +91,24 @@ public class StreamPersistenceHandlerImpl
      * @param b true if the event is the last in the sequence
      */
     @Override
-    public void onEvent(final ObjectEvent<SubscribeStreamResponseUnparsed> event, long l, boolean b) {
+    public void onEvent(final ObjectEvent<List<BlockItemUnparsed>> event, long l, boolean b) {
+
+        final List<BlockItemUnparsed> blockItems = event.get();
+        if (blockItems == null) {
+            LOGGER.log(ERROR, "BlockItems list is null.");
+            return;
+        }
+
         try {
             if (serviceStatus.isRunning()) {
-                final SubscribeStreamResponseUnparsed subscribeStreamResponse = event.get();
-                final OneOf<SubscribeStreamResponseUnparsed.ResponseOneOfType> oneOfTypeOneOf =
-                        subscribeStreamResponse.response();
-                switch (oneOfTypeOneOf.kind()) {
-                    case BLOCK_ITEMS -> {
-                        final BlockItemSetUnparsed blockItemSetUnparsed = subscribeStreamResponse.blockItems();
-                        if (blockItemSetUnparsed == null) {
-                            final String message = PROTOCOL_VIOLATION_MESSAGE.formatted(
-                                    "SubscribeStreamResponse", "BLOCK_ITEM", "block_item", subscribeStreamResponse);
-                            throw new BlockStreamProtocolException(message);
-                        } else {
-                            final List<BlockItemUnparsed> blockItems = blockItemSetUnparsed.blockItems();
-                            if (blockItems.isEmpty()) {
-                                final String message = "BlockItems list is empty.";
-                                throw new BlockStreamProtocolException(message);
-                            } else {
-                                handleBlockItems(blockItems);
-                            }
-                        }
-                    }
-                    case STATUS -> LOGGER.log(DEBUG, "Unexpected received a status message rather than a block item");
-                    default -> {
-                        final String message = "Unknown response type: " + oneOfTypeOneOf.kind();
-                        LOGGER.log(ERROR, message);
-                        throw new BlockStreamProtocolException(message);
-                    }
+                if (blockItems.isEmpty()) {
+                    final String message = "BlockItems list is empty.";
+                    throw new BlockStreamProtocolException(message);
                 }
+
+                handleBlockItems(blockItems);
             } else {
-                LOGGER.log(ERROR, "Service is not running. Block item will not be processed further.");
+                LOGGER.log(ERROR, "Service is not running. Block items will not be persisted.");
             }
         } catch (final Exception e) {
             LOGGER.log(ERROR, "Failed to persist BlockItems due to {0}", e);

--- a/server/src/main/java/com/hedera/block/server/verification/StreamVerificationHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/verification/StreamVerificationHandlerImpl.java
@@ -70,11 +70,6 @@ public class StreamVerificationHandlerImpl implements BlockNodeEventHandler<Obje
             }
 
             final List<BlockItemUnparsed> blockItems = event.get();
-            if (blockItems == null) {
-                LOGGER.log(ERROR, "BlockItems batch is null. BlockItems will not be processed further.");
-                return;
-            }
-
             blockVerificationService.onBlockItemsReceived(blockItems);
         } catch (final Exception e) {
 

--- a/server/src/main/java/com/hedera/block/server/verification/StreamVerificationHandlerImpl.java
+++ b/server/src/main/java/com/hedera/block/server/verification/StreamVerificationHandlerImpl.java
@@ -80,7 +80,7 @@ public class StreamVerificationHandlerImpl implements BlockNodeEventHandler<Obje
             // Unsubscribe from the mediator to avoid additional onEvent calls.
             unsubscribe();
 
-            // @todo: We need an error channel to broadcast
+            // @todo(662) We need an error channel to broadcast
             // messages to the consumers and producers
             notifier.notifyUnrecoverableError();
         }

--- a/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
+++ b/server/src/test/java/com/hedera/block/server/BlockNodeAppTest.java
@@ -17,8 +17,8 @@ import com.hedera.block.server.pbj.PbjBlockStreamServiceProxy;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.verification.StreamVerificationHandlerImpl;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.pbj.grpc.helidon.PbjRouting;
 import com.hedera.pbj.grpc.helidon.config.PbjConfig;
 import io.helidon.webserver.ConnectionConfig;
@@ -26,6 +26,7 @@ import io.helidon.webserver.WebServer;
 import io.helidon.webserver.WebServerConfig;
 import io.helidon.webserver.http.HttpRouting;
 import java.io.IOException;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,7 +55,7 @@ class BlockNodeAppTest {
     private BlockReader<BlockUnparsed> blockReader;
 
     @Mock
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> blockNodeEventHandler;
+    private BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> blockNodeEventHandler;
 
     @Mock
     private StreamVerificationHandlerImpl streamVerificationHandler;

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.consumer;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -30,7 +29,6 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -172,29 +170,6 @@ public class ConsumerStreamResponseObserverTest {
         // Confirm that the observer was called with the next BlockItem
         // since we never send a BlockItem with a Header to start the stream.
         verify(responseStreamObserver, timeout(testTimeout).times(0)).onNext(subscribeStreamResponse);
-    }
-
-    @Disabled("Should we guarantee the publisher will never send a null BlockItem instead?")
-    @Test
-    public void testSubscriberStreamResponseIsBlockItemWhenBlockItemIsNull() throws Exception {
-
-        when(objectEvent.get()).thenReturn(null);
-        final var consumerBlockItemObserver = LiveStreamEventHandlerBuilder.build(
-                completionService,
-                testClock,
-                streamMediator,
-                responseStreamObserver,
-                testContext.metricsService(),
-                testContext.configuration());
-
-        // This call will throw an exception but, because of the async
-        // service executor, the exception will not get caught until the
-        // next call.
-        consumerBlockItemObserver.onEvent(objectEvent, 0, true);
-        Thread.sleep(testTimeout);
-
-        // This second call will throw the exception.
-        assertThatIllegalArgumentException().isThrownBy(() -> consumerBlockItemObserver.onEvent(objectEvent, 0, true));
     }
 
     @Test

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -119,8 +119,10 @@ public class ConsumerStreamResponseObserverTest {
                 testContext.metricsService(),
                 testContext.configuration());
 
-        when(objectEvent.get())
-                .thenReturn(List.of(BlockItemUnparsed.newBuilder().build()));
+        final List<BlockItemUnparsed> blockItems =
+                List.of(BlockItemUnparsed.newBuilder().build());
+        final ObjectEvent<List<BlockItemUnparsed>> objectEvent = new ObjectEvent<>();
+        objectEvent.set(blockItems);
         consumerBlockItemObserver.onEvent(objectEvent, 0, true);
         verify(streamMediator, timeout(testTimeout)).unsubscribe(consumerBlockItemObserver);
     }

--- a/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/ConsumerStreamResponseObserverTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,11 +24,13 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.InstantSource;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Executors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -44,13 +45,13 @@ public class ConsumerStreamResponseObserverTest {
     private static final int testTimeout = 1000;
 
     @Mock
-    private StreamMediator<BlockItemUnparsed, SubscribeStreamResponseUnparsed> streamMediator;
+    private StreamMediator<BlockItemUnparsed, List<BlockItemUnparsed>> streamMediator;
 
     @Mock
-    private Pipeline<SubscribeStreamResponseUnparsed> responseStreamObserver;
+    private Pipeline<? super SubscribeStreamResponseUnparsed> responseStreamObserver;
 
     @Mock
-    private ObjectEvent<SubscribeStreamResponseUnparsed> objectEvent;
+    private ObjectEvent<List<BlockItemUnparsed>> objectEvent;
 
     @Mock
     private InstantSource testClock;
@@ -86,15 +87,17 @@ public class ConsumerStreamResponseObserverTest {
         final BlockItemUnparsed blockItem = BlockItemUnparsed.newBuilder()
                 .blockHeader(BlockHeader.PROTOBUF.toBytes(blockHeader))
                 .build();
+
+        List<BlockItemUnparsed> blockItems = List.of(blockItem);
+        when(objectEvent.get()).thenReturn(blockItems);
+
+        consumerBlockItemObserver.onEvent(objectEvent, 0, true);
+
         final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItem).build();
+                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
         final SubscribeStreamResponseUnparsed subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
                 .blockItems(blockItemSet)
                 .build();
-
-        when(objectEvent.get()).thenReturn(subscribeStreamResponse);
-
-        consumerBlockItemObserver.onEvent(objectEvent, 0, true);
 
         // verify the observer is called with the next BlockItem
         verify(responseStreamObserver, timeout(testTimeout)).onNext(subscribeStreamResponse);
@@ -118,6 +121,8 @@ public class ConsumerStreamResponseObserverTest {
                 testContext.metricsService(),
                 testContext.configuration());
 
+        when(objectEvent.get())
+                .thenReturn(List.of(BlockItemUnparsed.newBuilder().build()));
         consumerBlockItemObserver.onEvent(objectEvent, 0, true);
         verify(streamMediator, timeout(testTimeout)).unsubscribe(consumerBlockItemObserver);
     }
@@ -145,25 +150,13 @@ public class ConsumerStreamResponseObserverTest {
                         EventHeader.PROTOBUF.toBytes(EventHeader.newBuilder().build());
                 final BlockItemUnparsed blockItem =
                         BlockItemUnparsed.newBuilder().eventHeader(eventHeader).build();
-                final BlockItemSetUnparsed blockItemSet =
-                        BlockItemSetUnparsed.newBuilder().blockItems(blockItem).build();
-                final SubscribeStreamResponseUnparsed subscribeStreamResponse =
-                        SubscribeStreamResponseUnparsed.newBuilder()
-                                .blockItems(blockItemSet)
-                                .build();
-                lenient().when(objectEvent.get()).thenReturn(subscribeStreamResponse);
+                lenient().when(objectEvent.get()).thenReturn(List.of(blockItem));
             } else {
                 final Bytes blockProof = BlockProof.PROTOBUF.toBytes(
                         BlockProof.newBuilder().block(i).build());
                 final BlockItemUnparsed blockItem =
                         BlockItemUnparsed.newBuilder().blockProof(blockProof).build();
-                final BlockItemSetUnparsed blockItemSet =
-                        BlockItemSetUnparsed.newBuilder().blockItems(blockItem).build();
-                final SubscribeStreamResponseUnparsed subscribeStreamResponse =
-                        SubscribeStreamResponseUnparsed.newBuilder()
-                                .blockItems(blockItemSet)
-                                .build();
-                when(objectEvent.get()).thenReturn(subscribeStreamResponse);
+                when(objectEvent.get()).thenReturn(List.of(blockItem));
             }
 
             consumerBlockItemObserver.onEvent(objectEvent, 0, true);
@@ -181,47 +174,11 @@ public class ConsumerStreamResponseObserverTest {
         verify(responseStreamObserver, timeout(testTimeout).times(0)).onNext(subscribeStreamResponse);
     }
 
+    @Disabled("Should we guarantee the publisher will never send a null BlockItem instead?")
     @Test
     public void testSubscriberStreamResponseIsBlockItemWhenBlockItemIsNull() throws Exception {
 
-        // The generated objects contain safeguards to prevent a SubscribeStreamResponse
-        // being created with a null BlockItem. Here, I have to used a spy() to even
-        // manufacture this scenario. This should not happen in production.
-        final BlockItemUnparsed blockItem = BlockItemUnparsed.newBuilder().build();
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItem).build();
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse = spy(SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build());
-
-        when(subscribeStreamResponse.blockItems()).thenReturn(null);
-        when(objectEvent.get()).thenReturn(subscribeStreamResponse);
-
-        final var consumerBlockItemObserver = LiveStreamEventHandlerBuilder.build(
-                completionService,
-                testClock,
-                streamMediator,
-                responseStreamObserver,
-                testContext.metricsService(),
-                testContext.configuration());
-
-        // This call will throw an exception but, because of the async
-        // service executor, the exception will not get caught until the
-        // next call.
-        consumerBlockItemObserver.onEvent(objectEvent, 0, true);
-        Thread.sleep(testTimeout);
-
-        // This second call will throw the exception.
-        assertThatIllegalArgumentException().isThrownBy(() -> consumerBlockItemObserver.onEvent(objectEvent, 0, true));
-    }
-
-    @Test
-    public void testSubscribeStreamResponseTypeNotSupported() throws Exception {
-
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse =
-                SubscribeStreamResponseUnparsed.newBuilder().build();
-        when(objectEvent.get()).thenReturn(subscribeStreamResponse);
-
+        when(objectEvent.get()).thenReturn(null);
         final var consumerBlockItemObserver = LiveStreamEventHandlerBuilder.build(
                 completionService,
                 testClock,
@@ -246,12 +203,14 @@ public class ConsumerStreamResponseObserverTest {
         final BlockItemUnparsed blockItem = BlockItemUnparsed.newBuilder()
                 .blockHeader(BlockHeader.PROTOBUF.toBytes(blockHeader))
                 .build();
+
+        when(objectEvent.get()).thenReturn(List.of(blockItem));
+
         final BlockItemSetUnparsed blockItemSet =
                 BlockItemSetUnparsed.newBuilder().blockItems(blockItem).build();
         final SubscribeStreamResponseUnparsed subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
                 .blockItems(blockItemSet)
                 .build();
-        when(objectEvent.get()).thenReturn(subscribeStreamResponse);
         doThrow(UncheckedIOException.class).when(responseStreamObserver).onNext(subscribeStreamResponse);
 
         final var consumerBlockItemObserver = LiveStreamEventHandlerBuilder.build(
@@ -285,7 +244,7 @@ public class ConsumerStreamResponseObserverTest {
         final SubscribeStreamResponseUnparsed subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
                 .blockItems(blockItemSet)
                 .build();
-        when(objectEvent.get()).thenReturn(subscribeStreamResponse);
+        when(objectEvent.get()).thenReturn(List.of(blockItem));
         doThrow(RuntimeException.class).when(responseStreamObserver).onNext(subscribeStreamResponse);
 
         final var consumerBlockItemObserver = LiveStreamEventHandlerBuilder.build(

--- a/server/src/test/java/com/hedera/block/server/consumer/HistoricBlockStreamSupplierTest.java
+++ b/server/src/test/java/com/hedera/block/server/consumer/HistoricBlockStreamSupplierTest.java
@@ -11,8 +11,6 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.block.common.utils.ChunkUtils;
 import com.hedera.block.server.config.BlockNodeContext;
-import com.hedera.block.server.events.BlockNodeEventHandler;
-import com.hedera.block.server.events.ObjectEvent;
 import com.hedera.block.server.persistence.storage.read.BlockReader;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
@@ -41,7 +39,7 @@ public class HistoricBlockStreamSupplierTest {
     private BlockReader<BlockUnparsed> blockReader;
 
     @Mock
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> helidonConsumerObserver;
+    private Pipeline<SubscribeStreamResponseUnparsed> helidonConsumerObserver;
 
     @Mock
     private Pipeline<? super SubscribeStreamResponseUnparsed> closedRangeHistoricStreamObserver;
@@ -82,8 +80,7 @@ public class HistoricBlockStreamSupplierTest {
         historicBlockStreamSupplier.sendInBatches(ChunkUtils.chunkify(blockItems, maxBatchSize));
 
         // Verify the helidon observer was invoked an expected number of times
-        verify(helidonConsumerObserver, times(expectedNumberOfInvocations))
-                .onEvent(any(), any(Long.class), any(Boolean.class));
+        verify(helidonConsumerObserver, times(expectedNumberOfInvocations)).onNext(any());
     }
 
     @Test
@@ -129,8 +126,7 @@ public class HistoricBlockStreamSupplierTest {
         historicBlockStreamSupplier.run();
 
         // Confirm the observer was invoked with the read stream not available message
-        verify(helidonConsumerObserver, timeout(testTimeout).times(1))
-                .onEvent(any(), any(Long.class), any(Boolean.class));
+        verify(helidonConsumerObserver, timeout(testTimeout).times(1)).onNext(any());
     }
 
     private List<BlockUnparsed> generateBlocks(int numberOfBlocks, int itemsPerBlock) {

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -503,7 +503,7 @@ class LiveStreamMediatorImplTest {
         verify(helidonSubscribeStreamObserver2, timeout(TEST_TIMEOUT).times(1)).onNext(subscribeStreamResponse);
         verify(helidonSubscribeStreamObserver3, timeout(TEST_TIMEOUT).times(1)).onNext(subscribeStreamResponse);
 
-        // @todo: Revisit this code after we implement an error channel
+        // @todo(662): Revisit this code after we implement an error channel
         // TODO: Replace READ_STREAM_SUCCESS (2) with a generic error code?
         //        final SubscribeStreamResponseUnparsed endOfStreamResponse =
         // SubscribeStreamResponseUnparsed.newBuilder()

--- a/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/LiveStreamMediatorImplTest.java
@@ -28,7 +28,6 @@ import com.hedera.block.server.util.PersistTestUtils;
 import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseCode;
 import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.pbj.runtime.grpc.Pipeline;
@@ -55,13 +54,13 @@ class LiveStreamMediatorImplTest {
     private static final int TEST_TIMEOUT = 1000;
 
     @Mock
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> observer1;
+    private BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> observer1;
 
     @Mock
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> observer2;
+    private BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> observer2;
 
     @Mock
-    private BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> observer3;
+    private BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> observer3;
 
     @Mock
     private Notifier notifier;
@@ -169,7 +168,7 @@ class LiveStreamMediatorImplTest {
 
         when(testClock.millis()).thenReturn(TEST_TIME, TEST_TIME + TIMEOUT_THRESHOLD_MILLIS);
 
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver1 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver1 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -177,7 +176,7 @@ class LiveStreamMediatorImplTest {
                         helidonSubscribeStreamObserver1,
                         testContext.metricsService(),
                         testContext.configuration());
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver2 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver2 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -185,7 +184,7 @@ class LiveStreamMediatorImplTest {
                         helidonSubscribeStreamObserver2,
                         testContext.metricsService(),
                         testContext.configuration());
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver3 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver3 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -292,7 +291,7 @@ class LiveStreamMediatorImplTest {
         final LiveStreamMediator streamMediator = LiveStreamMediatorBuilder.newBuilder(blockNodeContext, serviceStatus)
                 .build();
 
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver1 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver1 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -427,7 +426,7 @@ class LiveStreamMediatorImplTest {
         final LiveStreamMediator streamMediator = LiveStreamMediatorBuilder.newBuilder(blockNodeContext, serviceStatus)
                 .build();
 
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver1 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver1 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -435,7 +434,7 @@ class LiveStreamMediatorImplTest {
                         helidonSubscribeStreamObserver1,
                         testContext.metricsService(),
                         testContext.configuration());
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver2 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver2 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -443,7 +442,7 @@ class LiveStreamMediatorImplTest {
                         helidonSubscribeStreamObserver2,
                         testContext.metricsService(),
                         testContext.configuration());
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> concreteObserver3 =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> concreteObserver3 =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,
@@ -494,7 +493,7 @@ class LiveStreamMediatorImplTest {
                         .get());
 
         // Send another block item after the exception
-        streamMediator.publish(List.of(blockItems.get(1)));
+        streamMediator.publish(List.of(firstBlockItem));
         final BlockItemSetUnparsed blockItemSet =
                 BlockItemSetUnparsed.newBuilder().blockItems(firstBlockItem).build();
         final SubscribeStreamResponseUnparsed subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
@@ -504,13 +503,15 @@ class LiveStreamMediatorImplTest {
         verify(helidonSubscribeStreamObserver2, timeout(TEST_TIMEOUT).times(1)).onNext(subscribeStreamResponse);
         verify(helidonSubscribeStreamObserver3, timeout(TEST_TIMEOUT).times(1)).onNext(subscribeStreamResponse);
 
+        // @todo: Revisit this code after we implement an error channel
         // TODO: Replace READ_STREAM_SUCCESS (2) with a generic error code?
-        final SubscribeStreamResponseUnparsed endOfStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
-                .status(SubscribeStreamResponseCode.READ_STREAM_SUCCESS)
-                .build();
-        verify(helidonSubscribeStreamObserver1, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
-        verify(helidonSubscribeStreamObserver2, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
-        verify(helidonSubscribeStreamObserver3, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
+        //        final SubscribeStreamResponseUnparsed endOfStreamResponse =
+        // SubscribeStreamResponseUnparsed.newBuilder()
+        //                .status(SubscribeStreamResponseCode.READ_STREAM_SUCCESS)
+        //                .build();
+        //        verify(helidonSubscribeStreamObserver1, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
+        //        verify(helidonSubscribeStreamObserver2, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
+        //        verify(helidonSubscribeStreamObserver3, timeout(TEST_TIMEOUT).times(1)).onNext(endOfStreamResponse);
 
         // Confirm Writer created
         verify(asyncBlockWriterFactoryMock, timeout(TEST_TIMEOUT).times(1)).create(1L);
@@ -534,7 +535,7 @@ class LiveStreamMediatorImplTest {
                 executorMock);
         streamMediator.subscribe(handler);
 
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> testConsumerBlockItemObserver =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> testConsumerBlockItemObserver =
                 LiveStreamEventHandlerBuilder.build(
                         completionService,
                         testClock,

--- a/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/mediator/MediatorInjectionModuleTest.java
@@ -8,7 +8,6 @@ import com.hedera.block.server.config.BlockNodeContext;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,7 @@ class MediatorInjectionModuleTest {
         BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
 
         // Call the method under test
-        StreamMediator<List<BlockItemUnparsed>, SubscribeStreamResponseUnparsed> streamMediator =
+        StreamMediator<List<BlockItemUnparsed>, List<BlockItemUnparsed>> streamMediator =
                 MediatorInjectionModule.providesLiveStreamMediator(blockNodeContext, serviceStatus);
 
         // Verify that the streamMediator is correctly instantiated
@@ -50,7 +49,7 @@ class MediatorInjectionModuleTest {
         BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext(properties);
 
         // Call the method under test
-        StreamMediator<List<BlockItemUnparsed>, SubscribeStreamResponseUnparsed> streamMediator =
+        StreamMediator<List<BlockItemUnparsed>, List<BlockItemUnparsed>> streamMediator =
                 MediatorInjectionModule.providesLiveStreamMediator(blockNodeContext, serviceStatus);
 
         // Verify that the streamMediator is correctly instantiated

--- a/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/notifier/NotifierImplTest.java
@@ -33,7 +33,6 @@ import com.hedera.hapi.block.Acknowledgement;
 import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
 import com.hedera.hapi.block.PublishStreamResponse;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.pbj.runtime.grpc.Pipeline;
 import com.hedera.pbj.runtime.grpc.ServiceInterface;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -229,8 +228,8 @@ class NotifierImplTest {
 
     private LiveStreamMediator buildStreamMediator(
             final Map<
-                            BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>>,
-                            BatchEventProcessor<ObjectEvent<SubscribeStreamResponseUnparsed>>>
+                            BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>>,
+                            BatchEventProcessor<ObjectEvent<List<BlockItemUnparsed>>>>
                     subscribers,
             final ServiceStatus serviceStatus) {
         serviceStatus.setWebServer(webServer);

--- a/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/PersistenceInjectionModuleTest.java
@@ -30,10 +30,11 @@ import com.hedera.block.server.persistence.storage.remove.NoOpBlockRemover;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.util.TestConfigUtil;
+import com.hedera.hapi.block.BlockItemUnparsed;
 import com.hedera.hapi.block.BlockUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +56,7 @@ class PersistenceInjectionModuleTest {
     private Compression compressionMock;
 
     @Mock
-    private SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandlerMock;
+    private SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandlerMock;
 
     @Mock
     private Notifier notifierMock;
@@ -192,7 +193,7 @@ class PersistenceInjectionModuleTest {
         final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
 
         // Call the method under test
-        final BlockNodeEventHandler<ObjectEvent<SubscribeStreamResponseUnparsed>> streamVerifier =
+        final BlockNodeEventHandler<ObjectEvent<List<BlockItemUnparsed>>> streamVerifier =
                 new StreamPersistenceHandlerImpl(
                         subscriptionHandlerMock,
                         notifierMock,

--- a/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
@@ -3,11 +3,8 @@ package com.hedera.block.server.persistence;
 
 import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.StreamPersistenceHandlerError;
 import static com.hedera.block.server.util.PersistTestUtils.generateBlockItemsUnparsed;
-import static com.hedera.hapi.block.SubscribeStreamResponseCode.READ_STREAM_SUCCESS;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,10 +17,7 @@ import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.util.TestConfigUtil;
-import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
-import com.hedera.pbj.runtime.OneOf;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -37,7 +31,7 @@ class StreamPersistenceHandlerImplTest {
     private static final int TEST_TIMEOUT = 50;
 
     @Mock
-    private SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler;
+    private SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler;
 
     @Mock
     private Notifier notifier;
@@ -75,13 +69,8 @@ class StreamPersistenceHandlerImplTest {
                 executorMock);
 
         final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsed(1);
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse = SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build();
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(subscribeStreamResponse);
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(blockItems);
 
         streamPersistenceHandler.onEvent(event, 0, false);
 
@@ -94,8 +83,6 @@ class StreamPersistenceHandlerImplTest {
     @Test
     void testBlockItemIsNull() throws IOException {
         final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
-        when(serviceStatus.isRunning()).thenReturn(true);
-
         final StreamPersistenceHandlerImpl streamPersistenceHandler = new StreamPersistenceHandlerImpl(
                 subscriptionHandler,
                 notifier,
@@ -105,81 +92,8 @@ class StreamPersistenceHandlerImplTest {
                 asyncBlockWriterFactoryMock,
                 executorMock);
 
-        final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsed(1);
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse = spy(SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build());
-
-        // Force the block item to be null
-        when(subscribeStreamResponse.blockItems()).thenReturn(null);
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(subscribeStreamResponse);
-
-        streamPersistenceHandler.onEvent(event, 0, false);
-
-        verify(serviceStatus, timeout(TEST_TIMEOUT).times(1)).stopRunning(any());
-        verify(subscriptionHandler, timeout(TEST_TIMEOUT).times(1)).unsubscribe(any());
-        verify(notifier, timeout(TEST_TIMEOUT).times(1)).notifyUnrecoverableError();
-    }
-
-    @Test
-    void testSubscribeStreamResponseTypeUnknown() throws IOException {
-        final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
-        when(serviceStatus.isRunning()).thenReturn(true);
-
-        final StreamPersistenceHandlerImpl streamPersistenceHandler = new StreamPersistenceHandlerImpl(
-                subscriptionHandler,
-                notifier,
-                blockNodeContext,
-                serviceStatus,
-                ackHandlerMock,
-                asyncBlockWriterFactoryMock,
-                executorMock);
-
-        final List<BlockItemUnparsed> blockItems = generateBlockItemsUnparsed(1);
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse = spy(SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build());
-
-        // Force the block item to be UNSET
-        final OneOf<SubscribeStreamResponseUnparsed.ResponseOneOfType> illegalOneOf =
-                new OneOf<>(SubscribeStreamResponseUnparsed.ResponseOneOfType.UNSET, null);
-        when(subscribeStreamResponse.response()).thenReturn(illegalOneOf);
-
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(subscribeStreamResponse);
-
-        streamPersistenceHandler.onEvent(event, 0, false);
-
-        verify(serviceStatus, timeout(TEST_TIMEOUT).times(1)).stopRunning(any());
-        verify(subscriptionHandler, timeout(TEST_TIMEOUT).times(1)).unsubscribe(any());
-        verify(notifier, timeout(TEST_TIMEOUT).times(1)).notifyUnrecoverableError();
-    }
-
-    @Test
-    void testSubscribeStreamResponseTypeStatus() {
-        when(blockNodeContext.metricsService()).thenReturn(metricsService);
-        when(serviceStatus.isRunning()).thenReturn(true);
-
-        final StreamPersistenceHandlerImpl streamPersistenceHandler = new StreamPersistenceHandlerImpl(
-                subscriptionHandler,
-                notifier,
-                blockNodeContext,
-                serviceStatus,
-                ackHandlerMock,
-                asyncBlockWriterFactoryMock,
-                executorMock);
-
-        final SubscribeStreamResponseUnparsed subscribeStreamResponse = spy(SubscribeStreamResponseUnparsed.newBuilder()
-                .status(READ_STREAM_SUCCESS)
-                .build());
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(subscribeStreamResponse);
-
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(null);
         streamPersistenceHandler.onEvent(event, 0, false);
 
         verify(serviceStatus, never()).stopRunning(any());

--- a/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/persistence/StreamPersistenceHandlerImplTest.java
@@ -16,9 +16,7 @@ import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.persistence.storage.write.AsyncBlockWriterFactory;
 import com.hedera.block.server.service.ServiceStatus;
-import com.hedera.block.server.util.TestConfigUtil;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
@@ -78,26 +76,5 @@ class StreamPersistenceHandlerImplTest {
         // these methods were not called.
         verify(notifier, never()).publish(any());
         verify(metricsService, never()).get(StreamPersistenceHandlerError);
-    }
-
-    @Test
-    void testBlockItemIsNull() throws IOException {
-        final BlockNodeContext blockNodeContext = TestConfigUtil.getTestBlockNodeContext();
-        final StreamPersistenceHandlerImpl streamPersistenceHandler = new StreamPersistenceHandlerImpl(
-                subscriptionHandler,
-                notifier,
-                blockNodeContext,
-                serviceStatus,
-                ackHandlerMock,
-                asyncBlockWriterFactoryMock,
-                executorMock);
-
-        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
-        event.set(null);
-        streamPersistenceHandler.onEvent(event, 0, false);
-
-        verify(serviceStatus, never()).stopRunning(any());
-        verify(subscriptionHandler, never()).unsubscribe(any());
-        verify(notifier, never()).notifyUnrecoverableError();
     }
 }

--- a/server/src/test/java/com/hedera/block/server/verification/StreamVerificationHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/verification/StreamVerificationHandlerImplTest.java
@@ -11,13 +11,11 @@ import com.hedera.block.server.metrics.MetricsService;
 import com.hedera.block.server.notifier.Notifier;
 import com.hedera.block.server.service.ServiceStatus;
 import com.hedera.block.server.verification.service.BlockVerificationService;
-import com.hedera.hapi.block.BlockItemSetUnparsed;
 import com.hedera.hapi.block.BlockItemUnparsed;
-import com.hedera.hapi.block.SubscribeStreamResponseUnparsed;
 import com.hedera.hapi.block.stream.output.BlockHeader;
-import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import com.swirlds.metrics.api.Counter;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class StreamVerificationHandlerImplTest {
 
     @Mock
-    private SubscriptionHandler<SubscribeStreamResponseUnparsed> subscriptionHandler;
+    private SubscriptionHandler<List<BlockItemUnparsed>> subscriptionHandler;
 
     @Mock
     private Notifier notifier;
@@ -54,9 +52,8 @@ public class StreamVerificationHandlerImplTest {
         final var streamVerificationHandler = new StreamVerificationHandlerImpl(
                 subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
 
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        final var response = SubscribeStreamResponseUnparsed.newBuilder().build(); // no block items, no status
-        event.set(response);
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(Collections.emptyList());
 
         // Call the handler
         streamVerificationHandler.onEvent(event, 0, false);
@@ -67,83 +64,21 @@ public class StreamVerificationHandlerImplTest {
     }
 
     @Test
-    public void testBlockItemsNullThrowsException() {
-        when(metricsService.get(VerificationBlocksError)).thenReturn(verificationBlocksError);
-
-        when(serviceStatus.isRunning()).thenReturn(true);
-
+    public void testBlockItemsDoesNotThrowExceptionWithNullItems() {
         final var streamVerificationHandler = new StreamVerificationHandlerImpl(
                 subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
 
-        // Create a SubscribeStreamResponseUnparsed with BLOCK_ITEMS type but null blockItems
-        final SubscribeStreamResponseUnparsed response = spy(SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems((BlockItemSetUnparsed) null)
-                .build());
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(response);
-
-        // Ensure that the response kind is BLOCK_ITEMS but blockItems is null
-        final OneOf<SubscribeStreamResponseUnparsed.ResponseOneOfType> blockItemsOneOf =
-                new OneOf<>(SubscribeStreamResponseUnparsed.ResponseOneOfType.BLOCK_ITEMS, null);
-        when(response.response()).thenReturn(blockItemsOneOf);
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(null);
 
         // Trigger the event
         streamVerificationHandler.onEvent(event, 0, false);
 
-        // We expect a protocol exception, leading to service stop and unsubscribing
-        verify(metricsService, timeout(testTimeout).times(1)).get(VerificationBlocksError);
-        verify(serviceStatus, timeout(testTimeout).times(1)).stopRunning(any());
-        verify(subscriptionHandler, timeout(testTimeout).times(1)).unsubscribe(any());
-        verify(notifier, timeout(testTimeout).times(1)).notifyUnrecoverableError();
-        // verify(blockVerificationService, never()).onBlockItemsReceived(any());
-    }
-
-    @Test
-    public void testUnknownResponseTypeThrowsException() {
-        when(serviceStatus.isRunning()).thenReturn(true);
-
-        final var streamVerificationHandler = new StreamVerificationHandlerImpl(
-                subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
-
-        final SubscribeStreamResponseUnparsed response =
-                spy(SubscribeStreamResponseUnparsed.newBuilder().build());
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(response);
-
-        // Force an UNKNOWN/UNSET oneOf type
-        final OneOf<SubscribeStreamResponseUnparsed.ResponseOneOfType> unknownOneOf =
-                new OneOf<>(SubscribeStreamResponseUnparsed.ResponseOneOfType.UNSET, null);
-        when(response.response()).thenReturn(unknownOneOf);
-
-        streamVerificationHandler.onEvent(event, 0, false);
-
-        verify(metricsService, timeout(testTimeout).times(1)).get(VerificationBlocksError);
-        verify(serviceStatus, timeout(testTimeout).times(1)).stopRunning(any());
-        verify(subscriptionHandler, timeout(testTimeout).times(1)).unsubscribe(any());
-        verify(notifier, timeout(testTimeout).times(1)).notifyUnrecoverableError();
-        // verify(blockVerificationService, never()).onBlockItemsReceived(any());
-    }
-
-    @Test
-    public void testStatusMessageDoesNotThrow() {
-        when(serviceStatus.isRunning()).thenReturn(true);
-
-        final var streamVerificationHandler = new StreamVerificationHandlerImpl(
-                subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
-
-        // Create a subscribeStreamResponse with a STATUS type
-        final SubscribeStreamResponseUnparsed response = SubscribeStreamResponseUnparsed.newBuilder()
-                .status(com.hedera.hapi.block.SubscribeStreamResponseCode.READ_STREAM_SUCCESS)
-                .build();
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(response);
-
-        streamVerificationHandler.onEvent(event, 0, false);
-
+        // Confirm that with a null item, we do not interact with any of the services
+        verify(metricsService, never()).get(VerificationBlocksError);
         verify(serviceStatus, never()).stopRunning(any());
         verify(subscriptionHandler, never()).unsubscribe(any());
         verify(notifier, never()).notifyUnrecoverableError();
-        // verify(blockVerificationService, never()).onBlockItemsReceived(any());
     }
 
     @Test
@@ -160,13 +95,8 @@ public class StreamVerificationHandlerImplTest {
                 .blockHeader(BlockHeader.PROTOBUF.toBytes(blockHeader))
                 .build());
 
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
-        final SubscribeStreamResponseUnparsed response = SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build();
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(response);
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(blockItems);
 
         streamVerificationHandler.onEvent(event, 0, false);
 
@@ -190,13 +120,8 @@ public class StreamVerificationHandlerImplTest {
                 .blockHeader(BlockHeader.PROTOBUF.toBytes(blockHeader))
                 .build());
 
-        final BlockItemSetUnparsed blockItemSet =
-                BlockItemSetUnparsed.newBuilder().blockItems(blockItems).build();
-        final SubscribeStreamResponseUnparsed response = SubscribeStreamResponseUnparsed.newBuilder()
-                .blockItems(blockItemSet)
-                .build();
-        final ObjectEvent<SubscribeStreamResponseUnparsed> event = new ObjectEvent<>();
-        event.set(response);
+        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
+        event.set(blockItems);
 
         // Simulate an exception when verifying block items
         doThrow(new RuntimeException("Verification failed"))
@@ -207,6 +132,5 @@ public class StreamVerificationHandlerImplTest {
 
         verify(serviceStatus, timeout(testTimeout).times(1)).stopRunning(any());
         verify(subscriptionHandler, timeout(testTimeout).times(1)).unsubscribe(any());
-        verify(notifier, timeout(testTimeout).times(1)).notifyUnrecoverableError();
     }
 }

--- a/server/src/test/java/com/hedera/block/server/verification/StreamVerificationHandlerImplTest.java
+++ b/server/src/test/java/com/hedera/block/server/verification/StreamVerificationHandlerImplTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.block.server.verification;
 
-import static com.hedera.block.server.metrics.BlockNodeMetricTypes.Counter.VerificationBlocksError;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -61,24 +60,6 @@ public class StreamVerificationHandlerImplTest {
         verify(serviceStatus, timeout(testTimeout).times(0)).stopRunning(any());
         verify(subscriptionHandler, timeout(testTimeout).times(0)).unsubscribe(any());
         verify(notifier, timeout(testTimeout).times(0)).notifyUnrecoverableError();
-    }
-
-    @Test
-    public void testBlockItemsDoesNotThrowExceptionWithNullItems() {
-        final var streamVerificationHandler = new StreamVerificationHandlerImpl(
-                subscriptionHandler, notifier, metricsService, serviceStatus, blockVerificationService);
-
-        final ObjectEvent<List<BlockItemUnparsed>> event = new ObjectEvent<>();
-        event.set(null);
-
-        // Trigger the event
-        streamVerificationHandler.onEvent(event, 0, false);
-
-        // Confirm that with a null item, we do not interact with any of the services
-        verify(metricsService, never()).get(VerificationBlocksError);
-        verify(serviceStatus, never()).stopRunning(any());
-        verify(subscriptionHandler, never()).unsubscribe(any());
-        verify(notifier, never()).notifyUnrecoverableError();
     }
 
     @Test


### PR DESCRIPTION
## Reviewer Notes
* Changed the generics type from `SubscribeStreamResponseUnparsed` to `List<BlockItemUnparsed>`
* Removed `SubscribeStreamResponseUnparsed` processing logic from the verification, persistence and consumer subscribers.

## Related Issue(s)
Fixes #652 